### PR TITLE
Fixes AGR-546

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -33,7 +33,8 @@ let config = {
     proxy: {
       '/api': {
         target: API_URL,
-        secure: false
+        secure: false,
+        changeOrigin: true
       }
     }
   },


### PR DESCRIPTION
This basically sends the hostname of the api server to the api server for the request rather then localhost.