### PR TITLE
Agr 415 orthology user guide

### DIFF
--- a/src/components/collapsiblePanel.js
+++ b/src/components/collapsiblePanel.js
@@ -1,0 +1,59 @@
+import React, { Component, PropTypes } from 'react';
+import { Collapse } from 'react-bootstrap';
+
+class CollapsiblePanel extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      expended: props.initiallyExpended
+    };
+  }
+
+  handleToggle() {
+    this.setState((prevState) => {
+      return {
+        expended: !prevState.expended
+      };
+    });
+  }
+
+
+  render() {
+    return (
+      <div className="card">
+        <div
+          className={`card-header alert-${this.props.backgroundVariants}`}
+          onClick={() => this.handleToggle()} role="tab">
+          <i
+            aria-hidden="true"
+            className={`fa fa-chevron-${this.state.expended ? 'up' : 'down'}`}
+            style={{marginRight: "1em"}}
+          />
+          <span>{this.props.title}</span>
+        </div>
+
+        <Collapse in={this.state.expended}>
+          <div role="tabpanel">
+            <div className="card-block">
+              {this.props.children}
+            </div>
+          </div>
+        </Collapse>
+      </div>
+    );
+  }
+}
+
+CollapsiblePanel.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.element.isRequired,
+  initiallyExpended: PropTypes.bool,
+  backgroundVariants: PropTypes.string,
+};
+
+CollapsiblePanel.defaultProps = {
+  backgroundVariants: 'info',
+  initiallyExpended: false
+};
+
+export default CollapsiblePanel;

--- a/src/components/collapsiblePanel.js
+++ b/src/components/collapsiblePanel.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-set-state */
+
 import React, { Component, PropTypes } from 'react';
 import { Collapse } from 'react-bootstrap';
 
@@ -23,11 +25,12 @@ class CollapsiblePanel extends Component {
       <div className="card">
         <div
           className={`card-header alert-${this.props.backgroundVariants}`}
-          onClick={() => this.handleToggle()} role="tab">
+          onClick={() => this.handleToggle()} role="tab"
+        >
           <i
             aria-hidden="true"
             className={`fa fa-chevron-${this.state.expended ? 'up' : 'down'}`}
-            style={{marginRight: "1em"}}
+            style={{marginRight: '1em'}}
           />
           <span>{this.props.title}</span>
         </div>
@@ -45,10 +48,10 @@ class CollapsiblePanel extends Component {
 }
 
 CollapsiblePanel.propTypes = {
-  title: PropTypes.string.isRequired,
+  backgroundVariants: PropTypes.string,
   children: PropTypes.element.isRequired,
   initiallyExpended: PropTypes.bool,
-  backgroundVariants: PropTypes.string,
+  title: PropTypes.string.isRequired,
 };
 
 CollapsiblePanel.defaultProps = {

--- a/src/components/externalLink.js
+++ b/src/components/externalLink.js
@@ -1,0 +1,28 @@
+import React, { Component, PropTypes } from 'react';
+
+class ExternalLink extends Component {
+  render() {
+    return (
+      <span>
+        <a
+          href={this.props.href}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {this.props.children || this.props.href}
+        </a>
+        <i
+          className="fa fa-external-link"
+          style={{margin: '0 3px'}}
+        />
+      </span>
+    );
+  }
+}
+
+ExternalLink.propTypes = {
+  href: PropTypes.string.isRequired,
+  children: PropTypes.element
+};
+
+export default ExternalLink;

--- a/src/components/orthology/index.js
+++ b/src/components/orthology/index.js
@@ -1,7 +1,9 @@
 import OrthologyTable from './orthologyTable';
 import OrthologyFilteredTable from './orthologyFilteredTable';
+import OrthologyUserGuide from './orthologyUserGuide';
 
 export {
   OrthologyTable,
-  OrthologyFilteredTable
+  OrthologyFilteredTable,
+  OrthologyUserGuide,
 };

--- a/src/components/orthology/orthologyUserGuide.js
+++ b/src/components/orthology/orthologyUserGuide.js
@@ -1,0 +1,22 @@
+import React, { Component, PropTypes } from 'react';
+import { Collapse } from 'react-bootstrap';
+import CollapsiblePanel from '../collapsiblePanel';
+
+class OrthologyUserGuide extends Component {
+
+  render() {
+    return (
+      <CollapsiblePanel
+        backgroundVariants="info"
+        title="Learn about how orthologs are identified"
+      >
+        <p>Many aspects of data integration across organisms require a common set of orthology relationships among genes for the organisms represented in the AGR. This common set is needed to facilitate comparison of biological annotations and other data across the diverse organisms represented in AGR: human, mouse, rat, zebrafish, fly, worm, and yeast.</p>
+        <p>The AGR methodology for the identification of orthologs among human and AGR organisms is currently built on the DRSC Integrative Ortholog Prediction Tool (DIOPT) (
+          <a href="http://www.flyrnai.org/diopt">http://www.flyrnai.org/diopt</a>
+        ). DIOPT integrates a number of existing approaches: Compara, eggnog, HGNC, Homologene, Inparanoid, Isobase, OMA, OrthoDB, orthoMCL, Panther, Phylome, RoundUp, TreeFam, ZFIN, and assigns a score/count based on these different methods.</p>
+      </CollapsiblePanel>
+    );
+  }
+}
+
+export default OrthologyUserGuide;

--- a/src/components/orthology/orthologyUserGuide.js
+++ b/src/components/orthology/orthologyUserGuide.js
@@ -1,5 +1,4 @@
-import React, { Component, PropTypes } from 'react';
-import { Collapse } from 'react-bootstrap';
+import React, { Component } from 'react';
 import CollapsiblePanel from '../collapsiblePanel';
 
 class OrthologyUserGuide extends Component {

--- a/src/components/orthology/orthologyUserGuide.js
+++ b/src/components/orthology/orthologyUserGuide.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import CollapsiblePanel from '../collapsiblePanel';
+import ExternalLink from '../externalLink';
 
 class OrthologyUserGuide extends Component {
 
@@ -11,7 +12,7 @@ class OrthologyUserGuide extends Component {
       >
         <p>Many aspects of data integration across organisms require a common set of orthology relationships among genes for the organisms represented in the AGR. This common set is needed to facilitate comparison of biological annotations and other data across the diverse organisms represented in AGR: human, mouse, rat, zebrafish, fly, worm, and yeast.</p>
         <p>The AGR methodology for the identification of orthologs among human and AGR organisms is currently built on the DRSC Integrative Ortholog Prediction Tool (DIOPT) (
-          <a href="http://www.flyrnai.org/diopt">http://www.flyrnai.org/diopt</a>
+          <ExternalLink href="http://www.flyrnai.org/diopt" />
         ). DIOPT integrates a number of existing approaches: Compara, eggnog, HGNC, Homologene, Inparanoid, Isobase, OMA, OrthoDB, orthoMCL, Panther, Phylome, RoundUp, TreeFam, ZFIN, and assigns a score/count based on these different methods.</p>
       </CollapsiblePanel>
     );

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -7,7 +7,7 @@ import { selectGene } from '../../selectors/geneSelectors';
 
 import BasicGeneInfo from './basicGeneInfo';
 import GenePageHeader from './genePageHeader';
-import { OrthologyFilteredTable } from '../../components/orthology';
+import { OrthologyFilteredTable, OrthologyUserGuide } from '../../components/orthology';
 import { GenePageDiseaseTable } from '../../components/disease';
 import GeneOntologyRibbon from '../../components/geneOntologyRibbon';
 import Subsection from '../../components/subsection';
@@ -87,8 +87,11 @@ class GenePage extends Component {
           <GeneOntologyRibbon id={this.props.data.primaryId} />
         </Subsection>
 
-        <Subsection hasData={(this.props.data.orthology || []).length > 0} title='Orthology'>
-          <OrthologyFilteredTable data={this.props.data.orthology} />
+        <Subsection title='Orthology'>
+          <OrthologyUserGuide />
+          <Subsection hasData={(this.props.data.orthology || []).length > 0}>
+            <OrthologyFilteredTable data={this.props.data.orthology} />
+          </Subsection>
         </Subsection>
 
         <Subsection hasData={(this.props.data.diseases || []) .length > 0} title='Disease Associations'>


### PR DESCRIPTION
Hi there,

The pull requests adds a collapsible user guide in the orthology section above the orthology table. (AGR-415 https://agr-jira.atlassian.net/browse/AGR-415)

By default it looks like:
![screen shot 2017-09-11 at 6 00 17 pm](https://user-images.githubusercontent.com/1753893/30298926-5b2b1708-971b-11e7-9fae-08fd4b8fc7e4.png)

Toggling the header to expand and collapse the user guide section as needed:
![screen shot 2017-09-11 at 6 00 28 pm](https://user-images.githubusercontent.com/1753893/30298968-7f7cbcba-971b-11e7-9d49-1d830113507f.png)

Two components are added to the `./src/components`: 
- CollapsiblePanel replicates the basic feature react-bootstrap Panel, but is compatible with Bootstrap 4 css.
- ExternalLink for formatting non-AGR links

Thanks!