### PR TITLE
Agr 415 add focus gene

### DIFF
--- a/src/components/orthology/index.js
+++ b/src/components/orthology/index.js
@@ -2,8 +2,10 @@ import OrthologyTable from './orthologyTable';
 import OrthologyFilteredTable from './orthologyFilteredTable';
 import OrthologyUserGuide from './orthologyUserGuide';
 import PantherCrossRef from './pantherCrossRef';
+import OrthologyBasicInfo from './orthologyBasicInfo';
 
 export {
+  OrthologyBasicInfo,
   OrthologyTable,
   OrthologyFilteredTable,
   OrthologyUserGuide,

--- a/src/components/orthology/orthologyBasicInfo.js
+++ b/src/components/orthology/orthologyBasicInfo.js
@@ -1,0 +1,32 @@
+import React, { Component, PropTypes } from 'react';
+import {
+  AttributeList,
+  AttributeLabel,
+  AttributeValue,
+} from '../attribute';
+import PantherCrossRef from './pantherCrossRef';
+
+class OrthologyBasicInfo extends Component {
+
+  render() {
+
+    return (
+      <AttributeList>
+
+        <AttributeLabel>Panther</AttributeLabel>
+        <AttributeValue>
+          <PantherCrossRef crossReferences={this.props.crossReferences} />
+        </AttributeValue>
+
+      </AttributeList>
+
+    );
+  }
+}
+
+OrthologyBasicInfo.propTypes = {
+  crossReferences: PropTypes.any,
+  symbol: PropTypes.string,
+};
+
+export default OrthologyBasicInfo;

--- a/src/components/orthology/orthologyBasicInfo.js
+++ b/src/components/orthology/orthologyBasicInfo.js
@@ -13,6 +13,11 @@ class OrthologyBasicInfo extends Component {
     return (
       <AttributeList>
 
+        <AttributeLabel>Focus gene</AttributeLabel>
+        <AttributeValue>
+          {this.props.focusGeneSymbol}
+        </AttributeValue>
+
         <AttributeLabel>Panther</AttributeLabel>
         <AttributeValue>
           <PantherCrossRef crossReferences={this.props.crossReferences} />
@@ -26,7 +31,7 @@ class OrthologyBasicInfo extends Component {
 
 OrthologyBasicInfo.propTypes = {
   crossReferences: PropTypes.any,
-  symbol: PropTypes.string,
+  focusGeneSymbol: PropTypes.string,
 };
 
 export default OrthologyBasicInfo;

--- a/src/components/orthology/pantherCrossRef.js
+++ b/src/components/orthology/pantherCrossRef.js
@@ -1,9 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import {
-  AttributeList,
-  AttributeLabel,
-  AttributeValue,
-} from '../attribute';
 import ExternalLink from '../externalLink';
 
 class PantherCrossRef extends Component {
@@ -13,18 +8,10 @@ class PantherCrossRef extends Component {
       (dat) => dat.crossrefCompleteUrl.match(/http:\/\/pantherdb.org.*/i)
     )[0];
     return (
-      <AttributeList>
-        <AttributeLabel>Panther</AttributeLabel>
-        <AttributeValue>
-          {
-            pantherCrossRef ?
-              <ExternalLink href={pantherCrossRef.crossrefCompleteUrl}>
-                {pantherCrossRef.localId}
-              </ExternalLink> : null
-          }
-        </AttributeValue>
-      </AttributeList>
-
+      pantherCrossRef ?
+        <ExternalLink href={pantherCrossRef.crossrefCompleteUrl}>
+          {pantherCrossRef.localId}
+        </ExternalLink> : null
     );
   }
 }

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -88,7 +88,10 @@ class GenePage extends Component {
         </Subsection>
 
         <Subsection title='Orthology'>
-          <OrthologyBasicInfo crossReferences={this.props.data.crossReferences} />
+          <OrthologyBasicInfo
+            crossReferences={this.props.data.crossReferences}
+            focusGeneSymbol={this.props.data.symbol}
+          />
           <OrthologyUserGuide />
           <Subsection hasData={(this.props.data.orthology || []).length > 0}>
             <OrthologyFilteredTable data={this.props.data.orthology} />

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -7,7 +7,7 @@ import { selectGene } from '../../selectors/geneSelectors';
 
 import BasicGeneInfo from './basicGeneInfo';
 import GenePageHeader from './genePageHeader';
-import { OrthologyFilteredTable, OrthologyUserGuide, PantherCrossRef } from '../../components/orthology';
+import { OrthologyFilteredTable, OrthologyUserGuide, OrthologyBasicInfo } from '../../components/orthology';
 import { GenePageDiseaseTable } from '../../components/disease';
 import GeneOntologyRibbon from '../../components/geneOntologyRibbon';
 import Subsection from '../../components/subsection';
@@ -88,7 +88,7 @@ class GenePage extends Component {
         </Subsection>
 
         <Subsection title='Orthology'>
-          <PantherCrossRef crossReferences={this.props.data.crossReferences} />
+          <OrthologyBasicInfo crossReferences={this.props.data.crossReferences} />
           <OrthologyUserGuide />
           <Subsection hasData={(this.props.data.orthology || []).length > 0}>
             <OrthologyFilteredTable data={this.props.data.orthology} />


### PR DESCRIPTION
Hi there,

This PR adds the focus gene symbol to the orthology section.

`<OrthologyBasicInfo>` now replaces `<PantherCrossRef>` in the `genePage/index.js`. It creates an attribute list that includes both focus gene and panther link.

Thanks,

Sibyl 