### PR TITLE
AGR-591 - Removed deprecated React.PropTypes usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "gene-ontology-ribbon": "0.1.5",
     "immutable": "^3.8.1",
+    "prop-types": "^15.5.10",
     "react": "^15.3.2",
     "react-autosuggest": "^6.1.0",
     "react-bootstrap": "^0.31.2",

--- a/src/components/attribute/attributeLabel.js
+++ b/src/components/attribute/attributeLabel.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class AttributeLabel extends Component {
 

--- a/src/components/attribute/attributeList.js
+++ b/src/components/attribute/attributeList.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class AttributeList extends Component {
 
@@ -26,7 +27,7 @@ AttributeList.defaultProps = {
 AttributeList.propTypes = {
   bsClassName: PropTypes.string,
   children: PropTypes.oneOfType([
-    PropTypes.arrayOf(React.PropTypes.node),
+    PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]),
 };

--- a/src/components/attribute/attributeValue.js
+++ b/src/components/attribute/attributeValue.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class AttributeValue extends Component {
 
@@ -22,7 +23,7 @@ AttributeValue.defaultProps = {
 
 AttributeValue.propTypes = {
   bsClassName: PropTypes.string,
-  children: PropTypes.element,  
+  children: PropTypes.element,
   style: PropTypes.object,
 };
 

--- a/src/components/collapsibleList.js
+++ b/src/components/collapsibleList.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-set-state */
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 import style from './style.css';
 
@@ -46,8 +47,8 @@ class CollapsibleList extends Component {
 }
 
 CollapsibleList.propTypes = {
-  collapsedSize: React.PropTypes.number,
-  items: React.PropTypes.array,
+  collapsedSize: PropTypes.number,
+  items: PropTypes.array,
 };
 
 CollapsibleList.defaultProps = {

--- a/src/components/collapsiblePanel.js
+++ b/src/components/collapsiblePanel.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-set-state */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Collapse } from 'react-bootstrap';
 
 class CollapsiblePanel extends Component {

--- a/src/components/externalLink.js
+++ b/src/components/externalLink.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class ExternalLink extends Component {
   render() {

--- a/src/components/orthology/orthologyBasicInfo.js
+++ b/src/components/orthology/orthologyBasicInfo.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   AttributeList,
   AttributeLabel,

--- a/src/components/orthology/pantherCrossRef.js
+++ b/src/components/orthology/pantherCrossRef.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ExternalLink from '../externalLink';
 
 class PantherCrossRef extends Component {

--- a/src/components/primaryAttributesList.js
+++ b/src/components/primaryAttributesList.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import style from './style.css';
 
@@ -34,9 +35,9 @@ PrimaryAttributesList.defaultProps = {
 };
 
 PrimaryAttributesList.propTypes = {
-  attributes: React.PropTypes.array,
-  data: React.PropTypes.object,
-  termWidth: React.PropTypes.number,
+  attributes: PropTypes.array,
+  data: PropTypes.object,
+  termWidth: PropTypes.number,
 };
 
 export default PrimaryAttributesList;

--- a/src/containers/diseasePage/basicDiseaseInfo.js
+++ b/src/containers/diseasePage/basicDiseaseInfo.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import { Link } from 'react-router';
+import PropTypes from 'prop-types';
 
 import CollapsibleList from '../../components/collapsibleList';
 import PrimaryAttributesList from '../../components/primaryAttributesList';
@@ -71,7 +72,7 @@ class BasicDiseaseInfo extends Component {
 }
 
 BasicDiseaseInfo.propTypes = {
-  disease: React.PropTypes.object,
+  disease: PropTypes.object,
 };
 
 export default BasicDiseaseInfo;

--- a/src/containers/layout/navLink.js
+++ b/src/containers/layout/navLink.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
+import PropTypes from 'prop-types';
 
 import style from './style.css';
 
@@ -11,7 +12,7 @@ class NavLink extends Component {
   }
 }
 NavLink.propTypes={
-  label: React.PropTypes.string,
-  url: React.PropTypes.string
+  label: PropTypes.string,
+  url: PropTypes.string
 };
 export default NavLink;

--- a/src/containers/layout/navLinksContainer.js
+++ b/src/containers/layout/navLinksContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import style from './style.css';
 import SubMenu from './subMenu';
@@ -32,6 +33,6 @@ class NavLinksContainer extends Component {
   }
 }
 NavLinksContainer.propTypes={
-  type: React.PropTypes.string,
+  type: PropTypes.string,
 };
 export default NavLinksContainer;

--- a/src/containers/search/filterSelector/singleFilterSelector.js
+++ b/src/containers/search/filterSelector/singleFilterSelector.js
@@ -153,7 +153,7 @@ class SingleFilterSelector extends Component {
 SingleFilterSelector.propTypes = {
   dispatch: PropTypes.func,
   displayName: PropTypes.string,
-  isShowMore: PropTypes.boolean,
+  isShowMore: PropTypes.bool,
   name: PropTypes.string,
   queryParams: PropTypes.object,
   values: PropTypes.array

--- a/src/containers/search/search.js
+++ b/src/containers/search/search.js
@@ -102,7 +102,7 @@ class SearchComponent extends Component {
 
   render() {
     if (!this.props.isReady) return <LoadingPage />;
-    let title = this.props.queryParams.q;
+    let title = 'Search ' + (this.props.queryParams.q || '');
     return (
       <div className='container'>
         {this.renderErrorNode()}


### PR DESCRIPTION
I removed all uses of the deprecated React.PropTypes and also fixed a typo in one of the Class.propTypes definitions.  This should address the source of some of the warnings that @oblodgett  found during the UI build process.