### PR TITLE
attempt unknown routes on WordPress prior to display page not found

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,7 +9,7 @@ export const WP_POST_BASE_URL = WP_REST_API_BASE+'/posts';
 export const WP_POST_URL = WP_POST_BASE_URL+'?slug=';
 /* Maximum number of posts to display on the News and Events page */
 export const WP_POST_MAX_COUNT = 10;
-export const WP_PATH= '/wordpress';
+export const WP_PATH= '';
 export const WP_POST_PATH = '/posts';
 
 export const CATEGORIES = [

--- a/src/containers/layout/navLinksContainer.js
+++ b/src/containers/layout/navLinksContainer.js
@@ -6,7 +6,7 @@ import SubMenu from './subMenu';
 import NavLink from './navLink';
 import { MENU, WP_PAGES ,WP_PATH ,WP_POST_PATH } from '../../constants';
 
-const HOME_ROUTE = '/wordpress/home';
+const HOME_ROUTE = '/home';
 
 class NavLinksContainer extends Component {
   render() {

--- a/src/containers/layout/subMenu.js
+++ b/src/containers/layout/subMenu.js
@@ -15,7 +15,7 @@ class SubMenu extends Component {
       let page=SUB_MENU[page_key][index];
       container.push(
         <li className={style.subMenuListItem} key={index}>
-          <Link className={`${style.sub_nav_link}`} key={index} to={`/wordpress/${WP_PAGES[page].path}`}>
+          <Link className={`${style.sub_nav_link}`} key={index} to={`/${WP_PAGES[page].path}`}>
             {WP_PAGES[page].label}
           </Link>
         </li>

--- a/src/containers/wordpress/index.js
+++ b/src/containers/wordpress/index.js
@@ -7,6 +7,7 @@ import fetchData from '../../lib/fetchData';
 import { fetchWp, fetchWpSuccess, fetchWpFailure } from '../../actions/wp';
 import { selectWp } from '../../selectors/wpSelectors';
 import LoadingPage from '../../components/loadingPage';
+import NotFound from '../../components/notFound';
 
 import WordpressPage from './wordpressPage';
 
@@ -36,7 +37,14 @@ class Wordpress extends Component {
     let page_slug=(currentRoute in WP_PAGES)?WP_PAGES[currentRoute].slug:currentRoute;
     let homeUrl=WP_PAGE_BASE_URL+page_slug;
     fetchData(homeUrl)
-      .then(data => this.props.dispatch(fetchWpSuccess(data)))
+      .then(data => {
+        if (data && data[0]) {
+          this.props.dispatch(fetchWpSuccess(data));
+        } else {
+          // throw our own error, since WP API doesn't return 404 when page is not found
+          throw new Error('Page not found');
+        }
+      })
       .catch(error => this.props.dispatch(fetchWpFailure(error)));
   }
   render() {
@@ -45,7 +53,7 @@ class Wordpress extends Component {
     }
 
     if (this.props.error) {
-      return <div className='alert alert-danger'>{this.props.error}</div>;
+      return <NotFound />;
     }
 
     if (!this.props.data) {

--- a/src/containers/wordpress/secondaryNav.js
+++ b/src/containers/wordpress/secondaryNav.js
@@ -14,7 +14,7 @@ class SecondaryNav extends Component {
     case 'contact':return style.contactMenuContainer;
     case 'projects':return style.projectsMenuContainer;
     case 'post':return style.postMenuContainer;
-    } 
+    }
   }
   render() {
     let container=[];
@@ -25,7 +25,7 @@ class SecondaryNav extends Component {
     let menu_cat=(this.props.type==='post')?'post':MENU_IDS[this.props.parent];
     let menu_container=this.getStyle(menu_cat);
 
-    container.push(<a href='/wordpress/home'>Home </a>);
+    container.push(<a href='/home'>Home </a>);
     if(this.props.type==='post'){
       container.push(<a href='/posts/news'> /News</a>);
     }
@@ -33,11 +33,11 @@ class SecondaryNav extends Component {
       if(menu_cat==='home'){return (<div />);}
       let parent=MENU_IDS[parent_id];
       let parent_label=WP_PAGES[parent].label;
-      container.push(<a href={`/wordpress/${parent}`}> /{parent_label}/</a>);
+      container.push(<a href={`/${parent}`}> /{parent_label}/</a>);
       if(parent_id!=page_id){
         container.push(<a dangerouslySetInnerHTML={{ __html: page_title}} />);
       }
-     
+
     }
     return (
        <div className={menu_container}>

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, IndexRedirect, IndexRoute } from 'react-router';
+import { Route, IndexRedirect, Redirect } from 'react-router';
 
 import Wordpress from './containers/wordpress';
 import WordpressFeeds from './containers/wordpress/wordpressFeeds';
@@ -10,17 +10,17 @@ import DiseasePage from './containers/diseasePage';
 
 export default (
   <Route component={Layout} path='/'>
-    <IndexRoute component={Wordpress} />
-    <Route component={Wordpress} path='wordpress' >
-      <IndexRedirect to="home" />
-      <Route component={Wordpress} path=':pageId' />
-    </Route>
+    <IndexRedirect to="/home" />
+    <Route component={Search} path='search' />
+    <Route component={GenePage} path='gene/:geneId' />
+    <Route component={DiseasePage} path='disease/:diseaseId' />
     <Route component={WordpressFeeds} path='posts' >
       <IndexRedirect to="/posts/news" />
       <Route component={WordpressFeeds} path=':postId' />
     </Route>
-    <Route component={Search} path='search' />
-    <Route component={GenePage} path='gene/:geneId' />
-    <Route component={DiseasePage} path='disease/:diseaseId' />
+    <Redirect from='/wordpress/:id' to='/:id' /> {/* before links within user edited WordPress content is fixed, this path rewrite is necessary */}
+    <Route component={Wordpress} path='/'>
+      <Route component={Wordpress} path=':pageId' />
+    </Route>
   </Route>
 );


### PR DESCRIPTION
Hi there, 

The PR is created to enable endpoints created via WordPress available at the root path `/`, such as `/project`, `about-us` etc. @oblodgett requested this change for SEO reasons.

**Significant change is made to how routing is done with any route unknown to the javascript. If you have any concern, please let me know.** Thanks!

Technical detail:
- At the bottom of the Route definition in `routes.js`, any unmatched routes is handled by the WordPress component
- WordPress component attempts to retrieve the content from WordPress API, and upon failure or getting empty results displays `<NotFound>`

