### PR TITLE
AGR-624 Reformat source card to avoid IDs going outside of box

### DIFF
--- a/src/components/externalLink.js
+++ b/src/components/externalLink.js
@@ -1,23 +1,20 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
+import style from './style.css';
+
 class ExternalLink extends Component {
   render() {
     return (
-      <span style={{whiteSpace: 'nowrap'}}>
+      <span>
         <a
+          className={this.props.href ? style.externalLink : ''}
           href={this.props.href}
           rel="noopener noreferrer"
           target="_blank"
           title={this.props.title}
         >
           {this.props.children || this.props.href}
-          {this.props.href && (
-            <i
-              className="fa fa-external-link"
-              style={{margin: '0 3px', fontSize: '85%'}}
-            />
-          )}
         </a>
       </span>
     );

--- a/src/components/style.css
+++ b/src/components/style.css
@@ -1,3 +1,10 @@
+.externalLink:after {
+  font-family: FontAwesome;
+  content: "\f08e";
+  padding-left: 3px;
+  font-size: 85%;
+}
+
 .loadingText {
   width: 100%;
   height: 1rem;

--- a/src/containers/genePage/dataSourceCard.js
+++ b/src/containers/genePage/dataSourceCard.js
@@ -2,32 +2,36 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
 import DataSourceLink from '../../components/dataSourceLink';
-import PrimaryAttributesList from '../../components/primaryAttributesList';
+import {
+  AttributeList,
+  AttributeLabel,
+  AttributeValue,
+} from '../../components/attribute';
 import SpeciesIcon from '../../components/speciesIcon';
 
 import style from './style.css';
 
 class DataSourceCard extends Component {
   render() {
-    const attrs = [
-      {
-        field: 'species',
-        format: s => <i>{s}</i>,
-      },
-      {
-        field: 'reference',
-        format: r => <DataSourceLink reference={r} />,
-        name: 'Primary Source',
-      }
-    ];
-
+    const { species, reference } = this.props;
+    const listClass = 'col-xs-12';
+    const labelClass = 'col-md-3';
+    const valueClass = 'col-md-9';
     return (
       <div className='card'>
         <div className={style.iconContainer}>
-          <SpeciesIcon species={this.props.species} />
+          <SpeciesIcon species={species} />
         </div>
         <div className='card-block'>
-          <PrimaryAttributesList attributes={attrs} data={this.props} termWidth='5' />
+          <AttributeList bsClassName={listClass}>
+            <AttributeLabel bsClassName={labelClass}>Species</AttributeLabel>
+            <AttributeValue bsClassName={valueClass}><i>{species}</i></AttributeValue>
+
+            <AttributeLabel bsClassName={labelClass}>Source</AttributeLabel>
+            <AttributeValue bsClassName={valueClass}>
+              <DataSourceLink reference={reference} />
+            </AttributeValue>
+          </AttributeList>
         </div>
       </div>
     );


### PR DESCRIPTION
Also applies the icon using CSS instead of as a separate element to avoid possibly having a line break between the link text and the icon.