### PR TITLE
Wordpress path: Changed main navigation  links from router Links to external links

### DIFF
--- a/src/containers/layout/navLinksContainer.js
+++ b/src/containers/layout/navLinksContainer.js
@@ -18,10 +18,7 @@ class NavLinksContainer extends Component {
       if (page_url === HOME_ROUTE) page_url = '/';
       let page_label=WP_PAGES[page].label;
       let link_token=[];
-      if(page==='news'){
-        link_token.push(<a className={`nav-link ${style.navLink}`} href={page_url} key={index}>{page_label}</a>);
-      }
-      else{link_token.push(<NavLink key={index} label={page_label} url={page_url} />);}
+      link_token.push(<a className={`nav-link ${style.navLink}`} href={page_url} key={index}>{page_label}</a>);
       container.push(<div className={style.navContainer} key={index}>
           {link_token}
           <SubMenu key={index} path={page} />


### PR DESCRIPTION
This takes care of the navigation issue detected when trying to access wordpress pages from the News pages by clicking on either the main menu or the sitemap menu.

Tested as followed: Assuming docker is installed 
1) Clone the agr_ui repos 
2) cd to agr_ui and checkout this branch (AGR-642)
3) Clean docker:  all exited, dangling docker containers 
    List of all exited containers - cmd: docker ps -aq -f status=exited
    Remove stopped containers - cmd: docker ps -aq --no-trunc | xargs docker rm
    Remove dangling  images - cmd: docker images -q --filter dangling=true | xargs docker rmi 

4) Run : make docker-build-nginx
5) Run : make docker-run
6) Test that you can access Wordpress pages after you browse the news pages

