### PR TITLE
Pretest linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "env": {
     "browser": true,
     "es6": true,
-    "node": true
+    "node": true,
+    "mocha": true,
   },
   "extends": "eslint:recommended",
   "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "build": "cross-env NODE_ENV=production webpack -p --optimize-minimize",
     "clean": "rimraf dist",
     "copy": "cp -r src/public/. dist",
+    "lint": "eslint src --max-warnings 0",
+    "pretest": "npm run lint",
     "test": "NODE_ENV=test mocha-webpack --webpack-config webpack.config-test.js \"src/**/*test.js\"",
     "test:watch": "NODE_ENV=test mocha-webpack --webpack-config webpack.config-test.js --watch \"src/**/*test.js\""
   }

--- a/src/containers/layout/test.js
+++ b/src/containers/layout/test.js
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import React from 'react';
-import { renderToString } from 'react-dom/server';
 
 import Component from './index';
 

--- a/src/containers/search/tests/test.js
+++ b/src/containers/search/tests/test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { createMemoryHistory } from 'react-router';
-import { Provider } from 'react-redux'
+import { Provider } from 'react-redux';
 
 import configureStore from '../../../lib/configureStore';
 import SearchContainer from '../search';
@@ -24,7 +24,7 @@ describe('Search', () => {
 
   it('should be able to render after getting a response', () => {
     let store = configureStore(historyObj);
-    store.dispatch(receiveResponse(fixtureResponse, { q: 'kinase' }))
+    store.dispatch(receiveResponse(fixtureResponse, { q: 'kinase' }));
     let htmlString = renderToString(<Provider store={store}><SearchContainer /></Provider>);
     assert.equal(typeof htmlString, 'string');
   });
@@ -43,7 +43,7 @@ describe('SearchControls', () => {
     let htmlString = renderToString(
       <SearchControlsComponent
         currentPage={1}
-        isTable={true}
+        isTable
         queryParams={{}}
         totalPages={5}
       />

--- a/src/containers/wordpress/wordpressFeeds/test.js
+++ b/src/containers/wordpress/wordpressFeeds/test.js
@@ -5,10 +5,7 @@ import { Provider } from 'react-redux';
 import { createMemoryHistory } from 'react-router';
 
 import configureStore from '../../../lib/configureStore';
-import{ WP_POST_BASE_URL,WP_POST_URL } from '../../../constants';
-
-
-
+import{ WP_POST_BASE_URL } from '../../../constants';
 
 import WordpressFeeds from './index';
 

--- a/src/reducers/tests/diseaseReducer.test.js
+++ b/src/reducers/tests/diseaseReducer.test.js
@@ -29,7 +29,7 @@ describe('Disease reducer', () => {
   });
 
   it('fetchAssociationsFailure', () => {
-    const errorMsg = "Request failed";
+    const errorMsg = 'Request failed';
     const action = {
       type: actionsAndTypes.FETCH_ASSOCIATIONS_FAILURE,
       payload: errorMsg
@@ -52,4 +52,3 @@ describe('Disease reducer', () => {
     assert.deepEqual(returnedState.get('perPageSize'), perPageSize);
   });
 });
-

--- a/src/selectors/tests/searchSelectors.test.js
+++ b/src/selectors/tests/searchSelectors.test.js
@@ -1,110 +1,137 @@
 import assert from 'assert';
-import { fromJS } from 'immutable';
+import {
+  fromJS
+} from 'immutable';
 
 import {
-    selectSearchDomain,
-    selectSearch,
-    selectErrorMessage,
-    selectIsError,
-    selectResults,
-    selectTotal,
-    selectPageSize,
-    selectTotalPages,
-    selectActiveCategory,
-    selectAggregations,
+  selectSearchDomain,
+  selectSearch,
+  selectErrorMessage,
+  selectIsError,
+  selectResults,
+  selectTotal,
+  selectPageSize,
+  selectTotalPages,
+  selectActiveCategory,
+  selectAggregations,
 } from '../searchSelectors';
 
 describe('SearchSelectors', () => {
-    it('selectSearchDomain', () => {
-        const searchState = fromJS({
-            isError: true,
-            results: [],
-        });
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.equal(selectSearchDomain(mockedState),searchState);
+  it('selectSearchDomain', () => {
+    const searchState = fromJS({
+      isError: true,
+      results: [],
     });
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.equal(selectSearchDomain(mockedState), searchState);
+  });
 
-    it('selectSearch', () => {
-        const searchState = {
-            isError: true,
-            results: [],
-        };
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.deepEqual(selectSearch(mockedState),searchState);
-    });
+  it('selectSearch', () => {
+    const searchState = {
+      isError: true,
+      results: [],
+    };
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.deepEqual(selectSearch(mockedState), searchState);
+  });
 
-    it('selectResults', () => {
-        const searchState = { results: [1,2,3,4] };
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.deepEqual(selectResults(mockedState),searchState.results);
-    });
+  it('selectResults', () => {
+    const searchState = {
+      results: [1, 2, 3, 4]
+    };
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.deepEqual(selectResults(mockedState), searchState.results);
+  });
 
-    it('selectErrorMessage', () => {
-        const searchState = { errorMessage: 'This is an error' };
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.deepEqual(selectErrorMessage(mockedState),searchState.errorMessage);
-    });
-    
-    it('selectIsError', () => {
-        const searchState = { isError: true };
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.equal(selectIsError(mockedState),searchState.isError);
-    });
+  it('selectErrorMessage', () => {
+    const searchState = {
+      errorMessage: 'This is an error'
+    };
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.deepEqual(selectErrorMessage(mockedState), searchState.errorMessage);
+  });
 
-    it('selectTotal', () => {
-        const searchState = { total: 10 };
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.equal(selectTotal(mockedState),searchState.total);
-    });
+  it('selectIsError', () => {
+    const searchState = {
+      isError: true
+    };
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.equal(selectIsError(mockedState), searchState.isError);
+  });
 
-    it('selectPageSize', () => {
-        const searchState = { pageSize: 33 };
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.equal(selectPageSize(mockedState),searchState.pageSize);
-    });
+  it('selectTotal', () => {
+    const searchState = {
+      total: 10
+    };
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.equal(selectTotal(mockedState), searchState.total);
+  });
 
-    it('selectTotalPages', () => {
-        let searchState = { total: 10, pageSize: 50 };
-        let mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.equal(selectTotalPages(mockedState),1);
+  it('selectPageSize', () => {
+    const searchState = {
+      pageSize: 33
+    };
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.equal(selectPageSize(mockedState), searchState.pageSize);
+  });
 
-        searchState = { total: 101, pageSize: 50 };
-        mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.equal(selectTotalPages(mockedState),3);
-    });
+  it('selectTotalPages', () => {
+    let searchState = {
+      total: 10,
+      pageSize: 50
+    };
+    let mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.equal(selectTotalPages(mockedState), 1);
 
-    it('selectActiveCategory', () => {
-        const searchState = { activeCategory: 'my category' };
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.equal(selectActiveCategory(mockedState),searchState.activeCategory);
-    });
+    searchState = {
+      total: 101,
+      pageSize: 50
+    };
+    mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.equal(selectTotalPages(mockedState), 3);
+  });
 
-    it('selectAggregations', () => {
-        const searchState = { aggregations: [{name:'myagg1', displayName:'My agg1'},{name:'myagg2', displayName:'My agg2'}]};
-        const mockedState = {
-            search: fromJS(searchState),
-        };
-        assert.deepEqual(selectAggregations(mockedState),searchState.aggregations);
-        });
+  it('selectActiveCategory', () => {
+    const searchState = {
+      activeCategory: 'my category'
+    };
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.equal(selectActiveCategory(mockedState), searchState.activeCategory);
+  });
+
+  it('selectAggregations', () => {
+    const searchState = {
+      aggregations: [{
+        name: 'myagg1',
+        displayName: 'My agg1'
+      }, {
+        name: 'myagg2',
+        displayName: 'My agg2'
+      }]
+    };
+    const mockedState = {
+      search: fromJS(searchState),
+    };
+    assert.deepEqual(selectAggregations(mockedState), searchState.aggregations);
+  });
 });
-


### PR DESCRIPTION
This change will make `eslint` run before `npm test` (or on-demand via `npm run lint`). Therefore, `eslint` will run in TravisCI so that we get feedback on that automatically as part of pull requests. These changes also clean up existing linter errors. 