### PR TITLE
Don't store API-translated field name when sorting

### DIFF
--- a/src/actions/disease.js
+++ b/src/actions/disease.js
@@ -42,6 +42,22 @@ export const fetchDiseaseFailure = function (error) {
 };
 
 export const fetchAssociations = function (id, page = 1, limit = 10, sortName = 'default', sortOrder = 'asc') {
+  // TODO: this is a hack because the API JSON field names don't line up with
+  // the URL query param names. So we rectify them here. It might be better to
+  // do it as part of the table column definition.
+  switch(sortName) {
+  case 'diseaseName':
+    sortName = 'disease';
+    break;
+
+  case 'disease_species':
+    sortName = 'species';
+    break;
+
+  case 'geneDocument':
+    sortName = 'gene';
+    break;
+  }
   return (dispatch) => {
     dispatch(fetchAssociationsRequest());
     return fetchData(`/api/disease/${id}/associations?page=${page}&limit=${limit}&sortBy=${sortName}&asc=${sortOrder === 'asc'}`)

--- a/src/containers/diseasePage/diseasePageAssociationsTable.js
+++ b/src/containers/diseasePage/diseasePageAssociationsTable.js
@@ -24,25 +24,6 @@ import ExternalLink from '../../components/externalLink';
 import { RemoteDataTable } from '../../components/dataTable';
 import { ReferenceCell } from '../../components/disease';
 
-// TODO: this is a hack because the API JSON field names don't line up with
-// the URL query param names. So we rectify them here. It might be better to
-// do it as part of the column definition.
-const getSortName = (fieldName) => {
-  switch(fieldName) {
-  case 'diseaseName':
-    return 'disease';
-
-  case 'disease_species':
-    return 'species';
-
-  case 'geneDocument':
-    return 'gene';
-
-  default:
-    return 'default';
-  }
-};
-
 class DiseasePageAssociationsTable extends Component {
   constructor(props) {
     super(props);
@@ -87,9 +68,8 @@ class DiseasePageAssociationsTable extends Component {
 
   handleSortChange(fieldName, sortOrder) {
     const { currentPage, dispatch, id, perPageSize } = this.props;
-    const sortName = getSortName(fieldName);
-    dispatch(setSort(sortName, sortOrder));
-    dispatch(fetchAssociations(id, currentPage, perPageSize, sortName, sortOrder));
+    dispatch(setSort(fieldName, sortOrder));
+    dispatch(fetchAssociations(id, currentPage, perPageSize, fieldName, sortOrder));
   }
 
   renderDiseaseName(name, row) {


### PR DESCRIPTION
This fixes some bugs I found while doing more testing of the recent disease components refactor on dev. The gist is that the redux store should always hold the sorting field name that the react-bootstrap-table is expecting. We should only translate that to the name that the API is expecting at the very last minute (i.e. before we fire off the fetch request) and that doesn't go in the redux store.