### PR TITLE
AGR-800 fixed go synonym column

### DIFF
--- a/src/reducers/searchParsers.js
+++ b/src/reducers/searchParsers.js
@@ -171,7 +171,7 @@ function parseGoResult(_d) {
     highlight: d.highlights,
     href: d.href,
     name: d.name,
-    synonyms: d.go_synonyms,
+    synonyms: d.synonyms,
     missing: d.missingTerms,
     explanation: d.explanation,
     score: d.score


### PR DESCRIPTION
tiny change, down in the index go_synonyms was changed to synonyms a while ago.