### PR TITLE
lazy loading of polyfill based browser features

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 
@@ -7,4 +6,20 @@ import './public/public.css'; // ./public/public.css uses a special loader, refe
 
 import ReactApp from './reactApplication';
 
-render(<ReactApp />, document.getElementById('app'));
+function main() {
+  render(<ReactApp />, document.getElementById('app'));
+}
+
+function browserSupportsAllFeatures() {
+  return window.Promise && window.fetch && window.Symbol;
+}
+
+if (browserSupportsAllFeatures()) {
+  // Browsers that support all features run `main()` immediately.
+  main();
+} else {
+  // All other browsers loads polyfills and then run `main()`.
+  require(['babel-polyfill'], () => {
+    main();
+  });
+}


### PR DESCRIPTION
A separate chunk containing the polyfill is created (maybe something like dist/1.22909c9eb4b6a7a401b5.js, about ~88K) and is loaded iff the browser is missing certain features that we care about