### PR TITLE
Fix display of evidence codes on gene page

### DIFF
--- a/src/components/disease/evidenceCodesCell.js
+++ b/src/components/disease/evidenceCodesCell.js
@@ -1,0 +1,13 @@
+import uniq from 'lodash.uniq';
+
+const EvidenceCodesCell = (publications) => {
+  if (!publications || !publications.length) {
+    return '';
+  }
+  const codes = publications
+    .map(publication => publication.evidenceCodes)
+    .reduce((a, b) => a.concat(b));
+  return uniq(codes).sort().join(', ');
+};
+
+export default EvidenceCodesCell;

--- a/src/components/disease/genePageDiseaseTable.js
+++ b/src/components/disease/genePageDiseaseTable.js
@@ -5,6 +5,7 @@ import ReferenceCell from './referenceCell';
 import { LocalDataTable } from '../../components/dataTable';
 import ExternalLink from '../../components/externalLink';
 import { uniq } from 'lodash.uniq';
+import EvidenceCodesCell from './evidenceCodesCell';
 
 class GenePageDiseaseTable extends Component {
 
@@ -105,6 +106,8 @@ class GenePageDiseaseTable extends Component {
       {
         field: 'publications',
         label: 'Evidence Code',
+        format: EvidenceCodesCell,
+        asText: EvidenceCodesCell,
         sortable: true,
         filterable: true,
       },

--- a/src/containers/diseasePage/diseasePageAssociationsTable.js
+++ b/src/containers/diseasePage/diseasePageAssociationsTable.js
@@ -3,8 +3,6 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 
-import uniq from 'lodash.uniq';
-
 import {
   fetchAssociations,
   setCurrentPage,
@@ -25,6 +23,7 @@ import {
 import ExternalLink from '../../components/externalLink';
 import { RemoteDataTable } from '../../components/dataTable';
 import { ReferenceCell } from '../../components/disease';
+import EvidenceCodesCell from '../../components/disease/evidenceCodesCell';
 
 class DiseasePageAssociationsTable extends Component {
   constructor(props) {
@@ -100,22 +99,6 @@ class DiseasePageAssociationsTable extends Component {
     return '';
   }
 
-  renderEvidenceCodes(publications){
-    if(publications){
-      let returnValue = publications && uniq(publications.map((publication) => {
-        return (
-          publication.evidenceCodes
-        );
-      }).reduce((a, b) => a.concat(b)))
-      .filter((x, i, a) => a.indexOf(x) == i)
-      .sort();
-
-      return returnValue.join(', ');
-    }
-
-    return '';
-  }
-
   render() {
 
     const columns = [
@@ -161,7 +144,7 @@ class DiseasePageAssociationsTable extends Component {
       {
         field: 'publications',
         label: 'Evidence Code',
-        format: this.renderEvidenceCodes,
+        format: EvidenceCodesCell,
       },
       {
         field: 'source',


### PR DESCRIPTION
This connects the evidence code column to a formatter. Also creates a shared component to display evidence codes in both disease tables.