### PR TITLE
AGR-983 Downgrade to ES5 version of query-string, fix Link to params

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "numeral": "^2.0.6",
     "popper.js": "1.14.3",
     "prop-types": "^15.5.10",
-    "query-string": "^6.1.0",
+    "query-string": "^5.1.1",
     "react": "^15.3.2",
     "react-autosuggest": "^6.1.0",
     "react-bootstrap-table": "https://github.com/FlyBase/react-bootstrap-table/releases/download/v4.0.3/react-bootstrap-table-4.0.3.tgz",

--- a/src/containers/layout/searchBar/index.js
+++ b/src/containers/layout/searchBar/index.js
@@ -84,7 +84,7 @@ class SearchBarComponent extends Component {
         let newQp = { q: query };
         if (query === '') newQp = {};
         if (newCat !== 'all') newQp.category = newCat;
-        this.props.history.push({ pathname: '/search', query: newQp });
+        this.props.history.push({ pathname: '/search', search: stringifyQuery(newQp) });
       }
     }
   }

--- a/src/containers/search/filterSelector/filterSelector.js
+++ b/src/containers/search/filterSelector/filterSelector.js
@@ -7,6 +7,7 @@ import style from './style.scss';
 import SingleFilterSelector from './singleFilterSelector';
 import { getQueryParamWithValueChanged } from '../../../lib/searchHelpers';
 import CategoryLabel from '../categoryLabel';
+import { stringify } from 'query-string';
 
 import {
   selectActiveCategory,
@@ -42,7 +43,7 @@ class FilterSelectorComponent extends Component {
       return null;
     }
     let newQp = getQueryParamWithValueChanged('category', [], this.props.queryParams, true);
-    let newHref = { pathname: '/search', query: newQp };
+    let newHref = { pathname: '/search', search: stringify(newQp) };
     return (
       <div>
         <p><CategoryLabel category={this.props.activeCategory} /></p>

--- a/src/containers/search/filterSelector/singleFilterSelector.js
+++ b/src/containers/search/filterSelector/singleFilterSelector.js
@@ -35,7 +35,7 @@ class SingleFilterSelector extends Component {
   handleSelectChange(newValues) {
     let simpleValues = newValues.map( d => d.name );
     let newQp = getQueryParamWithoutPage(this.props.name, simpleValues, this.props.queryParams);
-    let newPath = { pathname: SEARCH_PATH, query: newQp };
+    let newPath = { pathname: SEARCH_PATH, search: stringifyQuery(newQp) };
     this.props.history.push(newPath);
   }
 

--- a/src/containers/search/multiTable.js
+++ b/src/containers/search/multiTable.js
@@ -111,7 +111,7 @@ class MultiTableComponent extends Component {
 
   renderCategory(category, key) {
     let categoryQp = getQueryParamWithValueChanged('category', category, this.props.queryParams);
-    let categoryHref = { pathname: SEARCH_PATH, query: categoryQp };
+    let categoryHref = { pathname: SEARCH_PATH, search: stringifyQuery(categoryQp) };
 
     if (this.getTotalForCategory(category) === '0') { return null; }
 

--- a/src/containers/search/searchBreadcrumbs.js
+++ b/src/containers/search/searchBreadcrumbs.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import style from './style.scss';
 import { getQueryParamWithoutPage, makeFieldDisplayName, makeTitleCaseFieldDisplayName } from '../../lib/searchHelpers';
 import { selectIsPending, selectTotal } from '../../selectors/searchSelectors.js';
+import { stringify } from 'query-string';
 
 import CategoryLabel from './categoryLabel.js';
 
@@ -16,7 +17,7 @@ class SearchBreadcrumbsComponent extends Component {
   renderCrumbValues(key, values) {
     return values.map( (d, i) => {
       let newQp = getQueryParamWithoutPage(key,d,this.props.queryParams);
-      let newPath = { pathname: '/search', query: newQp };
+      let newPath = { pathname: '/search', search: stringify(newQp) };
       let label = makeFieldDisplayName(d);
       let labelNode = (key === 'q') ? `"${label}"` : label;
       let fieldLabel = makeTitleCaseFieldDisplayName(key) + ':';

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -68,6 +68,7 @@ const searchReducer = function (state = DEFAULT_STATE, action) {
       .set('isPending', false)
       .set(totalTarget, action.payload.total)
       .set('aggregations', newAggs)
+      .set('activeCategory', action.queryParams.category || 'none')
       .set('isReady', true)
       // parse results
       .set(resultsTarget, fromJS(parseResults(action.payload.results)));


### PR DESCRIPTION
@sibyl229 there was a problem building the production JS bundle with query-string@6. I think to use that version we'd have to have babel compile dependencies, too? I'm not sure if we want to do that or not, so in the meantime I'm just going back to their recommended ES5 version. I also found a few more `to` params that needed to be updated.