### PR TITLE
Remove top margin from orthology table

### DIFF
--- a/src/components/orthology/orthologyFilteredTable.js
+++ b/src/components/orthology/orthologyFilteredTable.js
@@ -279,7 +279,7 @@ class OrthologyFilteredTable extends Component {
           </div>
         </div>
 
-        <div style={{marginTop: -40, marginBottom: '1rem'}}>
+        <div style={{marginBottom: '1rem'}}>
           {
             filteredData.length > 0 ?
             <HorizontalScroll width={800}>


### PR DESCRIPTION
Negative margin was causing the 'Method' label and the message when all orthologs were filtered to be hidden by the filter controls box.