### PR TITLE
Use react-scrollspy instead of vanilla bootstrap scrollspy

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-hash-link": "^1.2.0",
     "react-router-scroll-4": "^1.0.0-beta.1",
+    "react-scrollspy": "^3.3.5",
     "react-select": "^1.0.0-rc.2",
     "react-twitter-widgets": "^1.3.0",
     "reactstrap": "^6.0.0",

--- a/src/components/dataPage/pageNav.js
+++ b/src/components/dataPage/pageNav.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { HashLink } from 'react-router-hash-link';
 import $ from 'jquery';
+import Scrollspy from 'react-scrollspy';
 
 import { makeId } from '../../lib/utils';
 
@@ -25,18 +26,24 @@ const PageNav = ({entityName, extra, icon, link, sections}) => {
           </button>
         </div>
 
-        <div className='navbar-collapse collapse list-group list-group-flush' id='data-page-nav'>
-          {
-            sections && sections.map(section => (
-              <HashLink className='list-group-item list-group-item-action'
-                        key={section}
-                        onClick={() => $('#data-page-nav').collapse('hide')}
-                        to={'#' + makeId(section)}
-              >
-                {section}
-              </HashLink>
-            ))
-          }
+        <div className='navbar-collapse collapse' id='data-page-nav'>
+          <Scrollspy className={`list-group list-group-flush ${style.scrollSpy}`}
+                     componentTag='div'
+                     currentClassName='active'
+                     items={sections.map(makeId)}
+          >
+            {
+              sections.map(section => (
+                <HashLink className='list-group-item list-group-item-action'
+                          key={section}
+                          onClick={() => $('#data-page-nav').collapse('hide')}
+                          to={'#' + makeId(section)}
+                >
+                  {section}
+                </HashLink>
+              ))
+            }
+          </Scrollspy>
         </div>
       </div>
     </div>

--- a/src/components/dataPage/style.scss
+++ b/src/components/dataPage/style.scss
@@ -22,6 +22,7 @@
   z-index: 101;
   padding: 0;
   box-shadow: 0 6px 10px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
 
   @include media-breakpoint-up(md) {
     height: 100%;
@@ -52,6 +53,10 @@
     h4 {
       color: #495057;
     }
+  }
+
+  .scrollSpy {
+    flex-grow: 1;
   }
 }
 

--- a/src/components/style.scss
+++ b/src/components/style.scss
@@ -24,9 +24,9 @@
 }
 
 .subsection {
-  margin-top: 1rem;
   margin-bottom: 4rem;
   clear: left;
+  position: relative;
 
   h3 {
     border-bottom: 1px solid #ddd;
@@ -36,13 +36,16 @@
   .target {
     display: block;
     visibility: hidden;
-    position: relative;
+    position: absolute;
     top: -1rem;
+    bottom: 0;
+    width: 100%;
   }
 
   @media (max-width: 768px) {
     .target {
       top: -125px;
+      bottom: 125px;
     }
   }
 }

--- a/src/components/subsection.js
+++ b/src/components/subsection.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import $ from 'jquery';
 
 import style from './style.scss';
 import { makeId } from '../lib/utils';
@@ -8,10 +7,6 @@ import { makeId } from '../lib/utils';
 import NoData from './noData';
 
 class Subsection extends Component {
-  componentDidMount() {
-    $(document.body).scrollspy('refresh');
-  }
-
   render() {
     const id = this.props.title && makeId(this.props.title);
     return (

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
 </head>
 
-<body data-spy="scroll" data-target="#data-page-nav" data-offset="1">
+<body>
     <div id="app"></div>
     <!-- html-webpack-plugin will append assets here -->
 </body>


### PR DESCRIPTION
More testing indicated that using the vanilla bootstrap scrollspy implementation wasn't always reliable. I think it might have been due to a timing issue around when the bootstrap scrollspy was initialized vs when the subsection components were mounted. Regardless, I'm finding that using this react-specific package is more reliable.