### PR TITLE
Fix funky acronym spacing

### DIFF
--- a/src/lib/searchHelpers.js
+++ b/src/lib/searchHelpers.js
@@ -7,6 +7,21 @@ import ExternalLink from '../components/externalLink';
 const SINGLE_VAL_FIELDS = ['mode', 'page'];
 const CLEARING_FIELDS = ['category'];
 
+export function makeValueDisplayName(unformattedName) {
+  unformattedName = unformattedName || '';
+
+  switch(unformattedName) {
+  case 'biological_process':
+    return 'biological process';
+  case 'molecular_function':
+    return 'molecular function';
+  case 'cellular_component':
+    return 'cellular component';
+  default:
+    return unformattedName;
+  }
+}
+
 export function makeFieldDisplayName(unformattedName) {
   unformattedName = unformattedName || '';
 

--- a/src/reducers/searchParsers.js
+++ b/src/reducers/searchParsers.js
@@ -1,7 +1,7 @@
 const JOIN_HIGHLIGHT_BY = '...';
 const FILTER_ORDER = ['biotype', 'species'];
 
-import { makeFieldDisplayName } from '../lib/searchHelpers';
+import { makeFieldDisplayName, makeValueDisplayName } from '../lib/searchHelpers';
 import { NON_HIGHLIGHTED_FIELDS } from '../constants';
 
 function flattenWithPrettyFieldNames(highlights) {
@@ -96,7 +96,7 @@ export function parseAggs(rawAggs, queryObject) {
       }
       return {
         name: _d.key,
-        displayName: makeFieldDisplayName(_d.key),
+        displayName: makeValueDisplayName(_d.key),
         key: _d.key,
         total: _d.total,
         isActive: _isActive
@@ -104,7 +104,7 @@ export function parseAggs(rawAggs, queryObject) {
     });
     return {
       name: d.key,
-      displayName: makeFieldDisplayName(d.key),
+      displayName: makeValueDisplayName(d.key),
       key: d.key,
       values: _values
     };
@@ -184,7 +184,7 @@ function parseGoResult(_d) {
   return {
     category: d.category,
     display_name: d.name,
-    go_branch: makeFieldDisplayName(d.go_type),
+    go_branch: makeValueDisplayName(d.go_type),
     id: d.id,
     highlight: d.highlights,
     href: d.href,


### PR DESCRIPTION
Facet values no longer use the same 'pretty' naming function as fields, fixing odd spaces in acronyms
