### PR TITLE
Use latest LTS Node.js release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "8"
+  - "lts/*"
 
 cache:
   directories:


### PR DESCRIPTION
future-proof travis config file to use the latest, active LTS.

