### PR TITLE
Fix google structured data identifier

### DIFF
--- a/src/components/headMetaTags.js
+++ b/src/components/headMetaTags.js
@@ -17,6 +17,7 @@ class HeadMetaTags extends Component {
         innerHTML: JSON.stringify({
           '@context': 'http://schema.org',
           '@type': 'Dataset',
+          '@id': data.primaryId,
           name: data.symbol,
           description: data.automatedGeneSynopsis + ' ' + (data.geneSynopsis || data.geneSynopsisUrl || ''),
           url: 'http://www.alliancegenome.org/gene/' + data.primaryId,
@@ -28,10 +29,6 @@ class HeadMetaTags extends Component {
           },
           version: '2.0',
           license: 'CC BY 4.0',
-          identifier: {
-            '@type': 'Text',
-            value:  data.primaryId
-          },
         }),
       };
     }

--- a/src/components/headMetaTags.js
+++ b/src/components/headMetaTags.js
@@ -28,7 +28,10 @@ class HeadMetaTags extends Component {
           },
           version: '2.0',
           license: 'CC BY 4.0',
-          identifier: data.primaryId,
+          identifier: {
+            '@type': 'Text',
+            value:  data.primaryId
+          },
         }),
       };
     }


### PR DESCRIPTION
From:  https://www.w3.org/TR/2014/REC-json-ld-20140116/#node-identifiers

Should have been using `@id`, seems to work now:

![screen shot 2018-09-11 at 7 42 06 pm](https://user-images.githubusercontent.com/751274/45398892-d1234080-b5fa-11e8-89a1-d3ea75876ada.png)
