### PR TITLE
Add loading overlay to remote tables

### DIFF
--- a/src/components/dataTable/loadingOverlay.js
+++ b/src/components/dataTable/loadingOverlay.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import style from './style.scss';
+
+const LoadingOverlay = ({loading}) => {
+  return (
+    <div className={`${style.loadingOverlay} ${loading ? style.loading : ''}`}>
+      {loading && <i className='fa fa-spinner fa-spin' />}
+    </div>
+  );
+};
+
+LoadingOverlay.propTypes = {
+  loading: PropTypes.bool,
+};
+
+export default LoadingOverlay;

--- a/src/components/dataTable/remoteDataTable.js
+++ b/src/components/dataTable/remoteDataTable.js
@@ -9,6 +9,7 @@ import DownloadButton from './downloadButton';
 import Utils from './utils';
 import PaginationPanel from './paginationPanel';
 import NoData from '../noData';
+import LoadingOverlay from './loadingOverlay';
 
 class RemoteDataTable extends Component {
   constructor(props) {
@@ -80,7 +81,8 @@ class RemoteDataTable extends Component {
     };
 
     return (
-      <div>
+      <div style={{position: 'relative'}}>
+        <LoadingOverlay loading={loading} />
         <BootstrapTable
           bordered={false}
           data={data}

--- a/src/components/dataTable/style.scss
+++ b/src/components/dataTable/style.scss
@@ -1,0 +1,22 @@
+.loadingOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  background-color: white;
+  opacity: 0;
+  transition: opacity 0ms;
+  pointer-events: none;
+  font-size: 2em;
+  color: #808080;
+
+  &.loading {
+    opacity: 0.7;
+    transition: opacity 300ms ease-in;
+  }
+}


### PR DESCRIPTION
Some of the expression data might be slow enough to load to warrant indicating to the user that the table is loading. It seemed to make sense to add it to all the remote data tables, so I'm making this separate PR for it. I tried to set it up so it's not really noticeable when the loading happens quickly enough.