### PR TITLE
Fix unavailable gene tree link

### DIFF
--- a/src/components/orthology/orthologyBasicInfo.js
+++ b/src/components/orthology/orthologyBasicInfo.js
@@ -15,11 +15,6 @@ class OrthologyBasicInfo extends Component {
     return (
       <AttributeList>
 
-        <AttributeLabel>Focus gene</AttributeLabel>
-        <AttributeValue>
-          {this.props.focusGeneSymbol} - (Species: {this.props.species})
-        </AttributeValue>
-
         <AttributeLabel>Gene tree</AttributeLabel>
         <AttributeValue>
           {pantherCrossReference && <DataSourceLink reference={pantherCrossReference} />}
@@ -32,9 +27,7 @@ class OrthologyBasicInfo extends Component {
 }
 
 OrthologyBasicInfo.propTypes = {
-  focusGeneSymbol: PropTypes.string,
   pantherCrossReference: PropTypes.object,
-  species: PropTypes.string,
 };
 
 export default OrthologyBasicInfo;

--- a/src/components/orthology/orthologyBasicInfo.js
+++ b/src/components/orthology/orthologyBasicInfo.js
@@ -10,6 +10,7 @@ import DataSourceLink from '../../components/dataSourceLink';
 class OrthologyBasicInfo extends Component {
 
   render() {
+    const { pantherCrossReference } = this.props;
 
     return (
       <AttributeList>
@@ -21,7 +22,7 @@ class OrthologyBasicInfo extends Component {
 
         <AttributeLabel>Gene tree</AttributeLabel>
         <AttributeValue>
-          <DataSourceLink reference={this.props.pantherCrossReference} />
+          {pantherCrossReference && <DataSourceLink reference={pantherCrossReference} />}
         </AttributeValue>
 
       </AttributeList>

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -167,11 +167,7 @@ class GenePage extends Component {
           </Subsection>
 
           <Subsection title={ORTHOLOGY}>
-            <OrthologyBasicInfo
-              focusGeneSymbol={data.symbol}
-              pantherCrossReference={data.crossReferences.panther}
-              species={data.species.name}
-            />
+            <OrthologyBasicInfo pantherCrossReference={data.crossReferences.panther} />
             <Subsection hasData={(data.orthology || []).length > 0}>
               <OrthologyFilteredTable data={data.orthology} />
               <OrthologyUserGuide />


### PR DESCRIPTION
With the API refactoring changes, this component was throwing an error when there was no Panther cross reference, which is (I think) expected for rat and human genes.

Slightly unrelated, I'm taking this opportunity to take out the "Focus gene" attribute. I think that was just a relic from when the sticky navigation panel wasn't there, and it's not a pattern that's used by other sections that utilize orthology. So I think it's safe to remove it. 