### PR TITLE
AGR-1132 refactor orthology and expression for index refactoring

### DIFF
--- a/src/actions/genes.js
+++ b/src/actions/genes.js
@@ -2,6 +2,7 @@ import { buildTableQueryString } from '../lib/utils';
 import { createFetchAction } from '../lib/createActions';
 
 export const FETCH_GENE = 'FETCH_GENE';
+export const FETCH_ORTHOLOGS = 'FETCH_ORTHOLOGS';
 export const FETCH_ALLELES = 'FETCH_ALLELES';
 export const FETCH_PHENOTYPES = 'FETCH_PHENOTYPES';
 export const FETCH_DISEASE_VIA_EMPIRICAL = 'FETCH_DISEASE_VIA_EMPIRICAL';
@@ -9,6 +10,7 @@ export const FETCH_DISEASE_VIA_ORTHOLOGY = 'FETCH_DISEASE_VIA_ORTHOLOGY';
 export const FETCH_INTERACTIONS = 'FETCH_INTERACTIONS';
 
 export const fetchGene = createFetchAction(FETCH_GENE, id => `/api/gene/${id}`);
+export const fetchOrthologs =createFetchAction(FETCH_ORTHOLOGS, id => `/api/gene/${id}/homologs?stringencyFilter=all`);
 export const fetchAlleles = createFetchAction(FETCH_ALLELES, id => `/api/gene/${id}/alleles`);
 export const fetchPhenotypes = createFetchAction(FETCH_PHENOTYPES, (id, opts) => `/api/gene/${id}/phenotypes?${buildTableQueryString(opts)}`);
 export const fetchDiseaseViaEmpirical = createFetchAction(

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -8,7 +8,7 @@ import { Button } from 'reactstrap';
 import ControlsContainer from '../controlsContainer';
 import { StringencySelector } from '../orthology';
 import { STRINGENCY_HIGH } from '../orthology/constants';
-import { selectOrthology } from '../../selectors/geneSelectors';
+import { selectOrthologs } from '../../selectors/geneSelectors';
 import {
   compareAlphabeticalCaseInsensitive,
   compareByFixedOrder,
@@ -164,7 +164,7 @@ ExpressionComparisonRibbon.propTypes = {
 
 function mapStateToProps (state) {
   return {
-    orthology: selectOrthology(state),
+    orthology: selectOrthologs(state),
   };
 }
 

--- a/src/components/orthology/constants.js
+++ b/src/components/orthology/constants.js
@@ -47,9 +47,9 @@ const methodHeaderCellStyle = {
   display: 'inline-block',
 };
 
-const STRINGENCY_HIGH = 'stringent';
+const STRINGENCY_HIGH = 'high';
 const STRINGENCY_MED = 'moderate';
-const STRINGNECY_LOW = 'all';
+const STRINGNECY_LOW = 'low';
 
 export {
   ALL_METHODS,

--- a/src/components/orthology/constants.js
+++ b/src/components/orthology/constants.js
@@ -47,9 +47,9 @@ const methodHeaderCellStyle = {
   display: 'inline-block',
 };
 
-const STRINGENCY_HIGH = 'high';
+const STRINGENCY_HIGH = 'stringent';
 const STRINGENCY_MED = 'moderate';
-const STRINGNECY_LOW = 'low';
+const STRINGNECY_LOW = 'all';
 
 export {
   ALL_METHODS,

--- a/src/components/orthology/index.js
+++ b/src/components/orthology/index.js
@@ -2,12 +2,12 @@ import OrthologyTable from './orthologyTable';
 import OrthologyFilteredTable from './orthologyFilteredTable';
 import OrthologyUserGuide from './orthologyUserGuide';
 import OrthologyBasicInfo from './orthologyBasicInfo';
-import StringencySelector from './stringencySelector';
+import StringencySelection from './stringencySelection';
 
 export {
   OrthologyBasicInfo,
   OrthologyTable,
   OrthologyFilteredTable,
   OrthologyUserGuide,
-  StringencySelector,
+  StringencySelection,
 };

--- a/src/components/orthology/index.js
+++ b/src/components/orthology/index.js
@@ -11,3 +11,5 @@ export {
   OrthologyUserGuide,
   StringencySelection,
 };
+
+export * from './utils';

--- a/src/components/orthology/orthologyFilteredTable.js
+++ b/src/components/orthology/orthologyFilteredTable.js
@@ -6,7 +6,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'reactstrap';
-import { OrthologyTable, StringencySelector } from '.';
+import StringencySelection from './stringencySelection';
+import OrthologyTable from './orthologyTable';
 import { connect } from 'react-redux';
 import { selectOrthologs } from '../../selectors/geneSelectors';
 import { fetchOrthologs } from '../../actions/genes';
@@ -75,6 +76,13 @@ class OrthologyFilteredTable extends Component {
     );
   }
 
+  updateStringencyLevel(level) {
+    console.log(level);
+    this.setState({
+      stringencyLevel: level
+    });
+  }
+
   updateFilterMethod(event) {
     this.setState({
       filterMethod: event.target.value === 'all' ? null : event.target.value
@@ -132,11 +140,12 @@ class OrthologyFilteredTable extends Component {
     }
 
     const filteredData = this.props.data.filter((dat) => this.filterCallback(dat));
-    console.log(this.props.data);
     const all_methods = this.props.data[0].predictionMethodsMatched.concat(
       this.props.data[0].predictionMethodsNotCalled,
       this.props.data[0].predictionMethodsNotMatched
     ).sort(caseInsensitiveCompare);
+
+    console.log(this.props.filteredData);
 
     const labelStyle = {
       margin: '0em 1em 0em 0',
@@ -161,9 +170,9 @@ class OrthologyFilteredTable extends Component {
     return (
       <div>
         <ControlsContainer>
-          <StringencySelector
-            defaultLevel={this.state.stringencyLevel}
-            onChange={level => this.setState({stringencyLevel: level})}
+          <StringencySelection
+            level={this.state.stringencyLevel}
+            onChange={(level) => this.updateStringencyLevel(level)}
           />
           <Collapse isOpen={this.state.showFilterPanel}>
             <div>
@@ -310,7 +319,6 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     fetchData: (geneId) => {
-      console.log('gonna call fetch orthologs');
       dispatch(fetchOrthologs(geneId));
     },
   };

--- a/src/components/orthology/orthologyFilteredTable.js
+++ b/src/components/orthology/orthologyFilteredTable.js
@@ -68,7 +68,7 @@ class OrthologyFilteredTable extends Component {
       dat.predictionMethodsMatched.length > this.state.filterScoreGreaterThan &&
       (this.state.filterBest ? dat.best : true) &&
       (this.state.filterReverseBest ? dat.bestReverse : true) &&
-      (this.state.filterSpecies ? getOrthologSpeciesName(dat.homologGene) === this.state.filterSpecies : true) &&
+      (this.state.filterSpecies ? getOrthologSpeciesName(dat) === this.state.filterSpecies : true) &&
       orthologyMeetsStringency(dat, this.state.stringencyLevel)
     );
   }
@@ -217,9 +217,8 @@ class OrthologyFilteredTable extends Component {
                   <option value="all">All</option>
                   {
                     this.props.data.reduce((all_species, dat) => {
-                      const {homologGene = {}} = dat;
-                      if (all_species.indexOf(getOrthologSpeciesName(homologGene)) === -1) {
-                        return all_species.concat([getOrthologSpeciesName(homologGene)]);
+                      if (all_species.indexOf(getOrthologSpeciesName(dat)) === -1) {
+                        return all_species.concat([getOrthologSpeciesName(dat)]);
                       } else {
                         return all_species;
                       }

--- a/src/components/orthology/orthologyFilteredTable.js
+++ b/src/components/orthology/orthologyFilteredTable.js
@@ -48,9 +48,9 @@ class OrthologyFilteredTable extends Component {
     return (
       meetMethodFilter &&
       dat.predictionMethodsMatched.length > this.state.filterScoreGreaterThan &&
-      (this.state.filterBest ? dat.isBestScore : true) &&
-      (this.state.filterReverseBest ? dat.isBestRevScore : true) &&
-      (this.state.filterSpecies ? dat.gene2SpeciesName === this.state.filterSpecies : true) &&
+      (this.state.filterBest ? dat.best : true) &&
+      (this.state.filterReverseBest ? dat.bestReverse : true) &&
+      (this.state.filterSpecies ? (dat.homologGene || {}).speciesName === this.state.filterSpecies : true) &&
       orthologyMeetsStringency(dat, this.state.stringencyLevel)
     );
   }
@@ -184,8 +184,9 @@ class OrthologyFilteredTable extends Component {
                   <option value="all">All</option>
                   {
                     this.props.data.reduce((all_species, dat) => {
-                      if (all_species.indexOf(dat.gene2SpeciesName) === -1) {
-                        return all_species.concat([dat.gene2SpeciesName]);
+                      const {homologGene = {}} = dat;
+                      if (all_species.indexOf(homologGene.speciesName) === -1) {
+                        return all_species.concat([homologGene.speciesName]);
                       } else {
                         return all_species;
                       }
@@ -249,14 +250,15 @@ OrthologyFilteredTable.propTypes = {
   // filterReverseBest: PropTypes.bool
   data: PropTypes.arrayOf(
     PropTypes.shape({
-      gene2AgrPrimaryId: PropTypes.string,
-      gene2Symbol: PropTypes.string,
+      homologGene: PropTypes.shape({
+        speciesName: PropTypes.string,
+      }),
       gene2SpeciesName: PropTypes.string,
       predictionMethodsMatched: PropTypes.arrayOf(PropTypes.string),
       predictionMethodsNotCalled: PropTypes.arrayOf(PropTypes.string),
       predictionMethodsNotMatched: PropTypes.arrayOf(PropTypes.string),
-      isBestScore: PropTypes.bool,
-      isBestRevScore: PropTypes.bool,
+      best: PropTypes.bool,
+      bestReverse: PropTypes.bool,
     })
   )
 };

--- a/src/components/orthology/orthologyFilteredTable.js
+++ b/src/components/orthology/orthologyFilteredTable.js
@@ -74,7 +74,6 @@ class OrthologyFilteredTable extends Component {
   }
 
   updateStringencyLevel(level) {
-    console.log(level);
     this.setState({
       stringencyLevel: level
     });
@@ -141,8 +140,6 @@ class OrthologyFilteredTable extends Component {
       this.props.data[0].predictionMethodsNotCalled,
       this.props.data[0].predictionMethodsNotMatched
     ).sort(caseInsensitiveCompare);
-
-    console.log(this.props.filteredData);
 
     const labelStyle = {
       margin: '0em 1em 0em 0',
@@ -299,9 +296,9 @@ OrthologyFilteredTable.propTypes = {
       bestReverse: PropTypes.bool,
     })
   ),
-  loading: PropTypes.any,
   fetchData: PropTypes.func.isRequired, // provided via connect
   geneId: PropTypes.string.isRequired,
+  loading: PropTypes.any,
 };
 
 const mapStateToProps = (state) => {

--- a/src/components/orthology/orthologyFilteredTable.js
+++ b/src/components/orthology/orthologyFilteredTable.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { Collapse } from 'reactstrap';
 import StringencySelection from './stringencySelection';
 import OrthologyTable from './orthologyTable';
+import { getOrthologSpeciesName } from './utils';
 import { connect } from 'react-redux';
 import { selectOrthologs } from '../../selectors/geneSelectors';
 import { fetchOrthologs } from '../../actions/genes';
@@ -58,10 +59,6 @@ class OrthologyFilteredTable extends Component {
     }
   }
 
-  getOrthologSpeciesName(homologGene = {}) {
-    return (homologGene.species || {}).name;
-  }
-
   filterCallback(dat) {
     const meetMethodFilter = this.state.filterMethod ?
       dat.predictionMethodsMatched.indexOf(this.state.filterMethod) > -1 :
@@ -71,7 +68,7 @@ class OrthologyFilteredTable extends Component {
       dat.predictionMethodsMatched.length > this.state.filterScoreGreaterThan &&
       (this.state.filterBest ? dat.best : true) &&
       (this.state.filterReverseBest ? dat.bestReverse : true) &&
-      (this.state.filterSpecies ? this.getOrthologSpeciesName(dat.homologGene) === this.state.filterSpecies : true) &&
+      (this.state.filterSpecies ? getOrthologSpeciesName(dat.homologGene) === this.state.filterSpecies : true) &&
       orthologyMeetsStringency(dat, this.state.stringencyLevel)
     );
   }
@@ -224,8 +221,8 @@ class OrthologyFilteredTable extends Component {
                   {
                     this.props.data.reduce((all_species, dat) => {
                       const {homologGene = {}} = dat;
-                      if (all_species.indexOf(this.getOrthologSpeciesName(homologGene)) === -1) {
-                        return all_species.concat([this.getOrthologSpeciesName(homologGene)]);
+                      if (all_species.indexOf(getOrthologSpeciesName(homologGene)) === -1) {
+                        return all_species.concat([getOrthologSpeciesName(homologGene)]);
                       } else {
                         return all_species;
                       }

--- a/src/components/orthology/orthologyTable.js
+++ b/src/components/orthology/orthologyTable.js
@@ -5,7 +5,12 @@ import MethodHeader from './methodHeader';
 import MethodCell from './methodCell';
 import BooleanCell from './booleanCell';
 import HelpIcon from './helpIcon';
-import { getOrthologSpeciesId, getOrthologSpeciesName } from './utils';
+import {
+  getOrthologSpeciesId,
+  getOrthologSpeciesName,
+  getOrthologId,
+  getOrthologSymbol,
+} from './utils';
 import { sortBy, compareByFixedOrder } from '../../lib/utils';
 import { TAXON_ORDER } from '../../constants';
 
@@ -42,24 +47,23 @@ class OrthologyTable extends Component {
         <tbody>
           {
             sortBy(this.props.data, [
-              compareByFixedOrder(TAXON_ORDER, o => getOrthologSpeciesId(o.homologGene)),
+              compareByFixedOrder(TAXON_ORDER, o => getOrthologSpeciesId(o)),
               (orthDataA, orthDataB) => orthDataB.predictionMethodsMatched.length - orthDataA.predictionMethodsMatched.length
             ]).map((orthData, idx, orthList) => {
-              const gene2 = orthData.homologGene || {};
               const scoreNumerator = orthData.predictionMethodsMatched.length;
               const scoreDemominator = scoreNumerator +
                 orthData.predictionMethodsNotMatched.length;
+              const orthId = getOrthologId(orthData);
 
-              if (idx > 0 && getOrthologSpeciesName(orthList[idx - 1].homologGene) !== getOrthologSpeciesName(gene2)) {
+              if (idx > 0 && getOrthologSpeciesName(orthList[idx - 1]) !== getOrthologSpeciesName(orthData)) {
                 rowGroup += 1;
               }
 
-              const key = gene2.id;
               return (
-                <tr key={key} style={{backgroundColor: rowGroup % 2 === 0 ? '#eee' : ''}} >
-                  <td style={{fontStyle: 'italic'}}>{getOrthologSpeciesName(gene2)}</td>
+                <tr key={orthId} style={{backgroundColor: rowGroup % 2 === 0 ? '#eee' : ''}} >
+                  <td style={{fontStyle: 'italic'}}>{getOrthologSpeciesName(orthData)}</td>
                   <td>
-                    <Link to={`/gene/${gene2.id}`}>{gene2.symbol}</Link>
+                    <Link to={`/gene/${orthId}`}>{getOrthologSymbol(orthData)}</Link>
                   </td>
                   <td>{`${scoreNumerator} of ${scoreDemominator}`}</td>
                   <BooleanCell
@@ -73,7 +77,7 @@ class OrthologyTable extends Component {
                   <MethodCell
                     predictionMethodsMatched={orthData.predictionMethodsMatched}
                     predictionMethodsNotMatched={orthData.predictionMethodsNotMatched}
-                    rowKey={key}
+                    rowKey={orthId}
                   />
                 </tr>
               );

--- a/src/components/orthology/orthologyTable.js
+++ b/src/components/orthology/orthologyTable.js
@@ -17,6 +17,10 @@ const columns = [
   {name: 'Method'}
 ];
 
+function getOrthologSpeciesName(homologGene = {}) {
+  return (homologGene.species || {}).name;
+}
+
 class OrthologyTable extends Component {
 
   render() {
@@ -49,16 +53,16 @@ class OrthologyTable extends Component {
               const scoreDemominator = scoreNumerator +
                 orthData.predictionMethodsNotMatched.length;
 
-              if (idx > 0 && orthList[idx - 1].gene2Species !== gene2.speciesName) {
+              if (idx > 0 && orthList[idx - 1].gene2Species !== getOrthologSpeciesName(gene2)) {
                 rowGroup += 1;
               }
 
-              const key = gene2.geneID;
+              const key = gene2.id;
               return (
                 <tr key={key} style={{backgroundColor: rowGroup % 2 === 0 ? '#eee' : ''}} >
-                  <td style={{fontStyle: 'italic'}}>{gene2.speciesName}</td>
+                  <td style={{fontStyle: 'italic'}}>{getOrthologSpeciesName(gene2)}</td>
                   <td>
-                    <Link to={`/gene/${gene2.geneID}`}>{gene2.symbol}</Link>
+                    <Link to={`/gene/${gene2.id}`}>{gene2.symbol}</Link>
                   </td>
                   <td>{`${scoreNumerator} of ${scoreDemominator}`}</td>
                   <BooleanCell
@@ -88,9 +92,11 @@ OrthologyTable.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       gene: PropTypes.shape({
-        geneID: PropTypes.string,
+        id: PropTypes.string,
         symbol: PropTypes.string,
-        speciesName: PropTypes.string,
+        species: PropTypes.shape({
+          name: PropTypes.string,
+        }),
       }),
       predictionMethodsMatched: PropTypes.arrayOf(PropTypes.string),
       predictionMethodsNotCalled: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/orthology/orthologyTable.js
+++ b/src/components/orthology/orthologyTable.js
@@ -44,29 +44,30 @@ class OrthologyTable extends Component {
               compareByFixedOrder(TAXON_ORDER, o => o.gene2Species),
               (orthDataA, orthDataB) => orthDataB.predictionMethodsMatched.length - orthDataA.predictionMethodsMatched.length
             ]).map((orthData, idx, orthList) => {
+              const gene2 = orthData.homologGene || {};
               const scoreNumerator = orthData.predictionMethodsMatched.length;
               const scoreDemominator = scoreNumerator +
                 orthData.predictionMethodsNotMatched.length;
 
-              if (idx > 0 && orthList[idx - 1].gene2Species !== orthData.gene2Species) {
+              if (idx > 0 && orthList[idx - 1].gene2Species !== gene2.speciesName) {
                 rowGroup += 1;
               }
 
-              const key = orthData.gene2AgrPrimaryId;
+              const key = gene2.geneID;
               return (
                 <tr key={key} style={{backgroundColor: rowGroup % 2 === 0 ? '#eee' : ''}} >
-                  <td style={{fontStyle: 'italic'}}>{orthData.gene2SpeciesName}</td>
+                  <td style={{fontStyle: 'italic'}}>{gene2.speciesName}</td>
                   <td>
-                    <Link to={`/gene/${orthData.gene2AgrPrimaryId}`}>{orthData.gene2Symbol}</Link>
+                    <Link to={`/gene/${gene2.geneID}`}>{gene2.symbol}</Link>
                   </td>
                   <td>{`${scoreNumerator} of ${scoreDemominator}`}</td>
                   <BooleanCell
                     isTrueFunc={(value) => value === 'Yes'}
-                    value={orthData.isBestScore}
+                    value={orthData.best}
                   />
                   <BooleanCell
                     isTrueFunc={(value) => value === 'Yes'}
-                    value={orthData.isBestRevScore}
+                    value={orthData.bestReverse}
                   />
                   <MethodCell
                     predictionMethodsMatched={orthData.predictionMethodsMatched}
@@ -86,14 +87,16 @@ class OrthologyTable extends Component {
 OrthologyTable.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
-      gene2AgrPrimaryId: PropTypes.string,
-      gene2Symbol: PropTypes.string,
-      gene2SpeciesName: PropTypes.string,
+      gene: PropTypes.shape({
+        geneID: PropTypes.string,
+        symbol: PropTypes.string,
+        speciesName: PropTypes.string,
+      }),
       predictionMethodsMatched: PropTypes.arrayOf(PropTypes.string),
       predictionMethodsNotCalled: PropTypes.arrayOf(PropTypes.string),
       predictionMethodsNotMatched: PropTypes.arrayOf(PropTypes.string),
-      isBestScore: PropTypes.bool,
-      isBestRevScore: PropTypes.bool,
+      best: PropTypes.bool,
+      bestReverse: PropTypes.bool,
     })
   )
 };

--- a/src/components/orthology/orthologyTable.js
+++ b/src/components/orthology/orthologyTable.js
@@ -5,6 +5,7 @@ import MethodHeader from './methodHeader';
 import MethodCell from './methodCell';
 import BooleanCell from './booleanCell';
 import HelpIcon from './helpIcon';
+import { getOrthologSpeciesId, getOrthologSpeciesName } from './utils';
 import { sortBy, compareByFixedOrder } from '../../lib/utils';
 import { TAXON_ORDER } from '../../constants';
 
@@ -16,10 +17,6 @@ const columns = [
   {name: 'Best reverse', help: 'Within the species of the input gene, the input gene is called as an ortholog of this gene by the highest number of algorithms.'},
   {name: 'Method'}
 ];
-
-function getOrthologSpeciesName(homologGene = {}) {
-  return (homologGene.species || {}).name;
-}
 
 class OrthologyTable extends Component {
 
@@ -45,7 +42,7 @@ class OrthologyTable extends Component {
         <tbody>
           {
             sortBy(this.props.data, [
-              compareByFixedOrder(TAXON_ORDER, o => o.gene2Species),
+              compareByFixedOrder(TAXON_ORDER, o => getOrthologSpeciesId(o.homologGene)),
               (orthDataA, orthDataB) => orthDataB.predictionMethodsMatched.length - orthDataA.predictionMethodsMatched.length
             ]).map((orthData, idx, orthList) => {
               const gene2 = orthData.homologGene || {};
@@ -53,7 +50,7 @@ class OrthologyTable extends Component {
               const scoreDemominator = scoreNumerator +
                 orthData.predictionMethodsNotMatched.length;
 
-              if (idx > 0 && orthList[idx - 1].gene2Species !== getOrthologSpeciesName(gene2)) {
+              if (idx > 0 && getOrthologSpeciesName(orthList[idx - 1].homologGene) !== getOrthologSpeciesName(gene2)) {
                 rowGroup += 1;
               }
 

--- a/src/components/orthology/stringencySelection.js
+++ b/src/components/orthology/stringencySelection.js
@@ -3,18 +3,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { STRINGENCY_HIGH, STRINGENCY_MED, STRINGNECY_LOW } from './constants';
 
-class StringencySelector extends React.Component {
+class StringencySelection extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      stringencyLevel: this.props.defaultLevel
-    };
     this.handleChange = this.handleChange.bind(this);
   }
 
   handleChange(event) {
     const newLevel = event.target.value;
-    this.setState({stringencyLevel: newLevel});
     this.props.onChange(newLevel);
   }
 
@@ -29,7 +25,7 @@ class StringencySelector extends React.Component {
     return (
       <label style={labelStyle}>
         <input
-          checked={stringencyLevel === this.state.stringencyLevel}
+          checked={stringencyLevel === this.props.level}
           onChange={this.handleChange}
           style={inputStyle}
           type="radio"
@@ -52,9 +48,9 @@ class StringencySelector extends React.Component {
   }
 }
 
-StringencySelector.propTypes = {
-  defaultLevel: PropTypes.string,
+StringencySelection.propTypes = {
+  level: PropTypes.string,
   onChange: PropTypes.func,
 };
 
-export default StringencySelector;
+export default StringencySelection;

--- a/src/components/orthology/utils.js
+++ b/src/components/orthology/utils.js
@@ -1,0 +1,7 @@
+export function getOrthologSpeciesName(homologGene = {}) {
+  return (homologGene.species || {}).name;
+}
+
+export function getOrthologSpeciesId(homologGene = {}) {
+  return (homologGene.species || {}).taxonId;
+}

--- a/src/components/orthology/utils.js
+++ b/src/components/orthology/utils.js
@@ -1,7 +1,27 @@
-export function getOrthologSpeciesName(homologGene = {}) {
+export function getOrthologSpeciesName(ortholog = {}) {
+  const {
+    homologGene = {}
+  } = ortholog;
   return (homologGene.species || {}).name;
 }
 
-export function getOrthologSpeciesId(homologGene = {}) {
+export function getOrthologSpeciesId(ortholog = {}) {
+  const {
+    homologGene = {}
+  } = ortholog;
   return (homologGene.species || {}).taxonId;
+}
+
+export function getOrthologId(ortholog = {}) {
+  const {
+    homologGene = {}
+  } = ortholog;
+  return homologGene.id;
+}
+
+export function getOrthologSymbol(ortholog = {}) {
+  const {
+    homologGene = {}
+  } = ortholog;
+  return homologGene.symbol;
 }

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -25,7 +25,7 @@ import ExpressionLinks from './expressionLinks';
 import SpeciesIcon from '../../components/speciesIcon';
 import DataSourceLink from '../../components/dataSourceLink';
 import PhenotypeTable from './phenotypeTable';
-import { ExpressionComparisonRibbon } from '../../components/expression';
+//import { ExpressionComparisonRibbon } from '../../components/expression';
 
 class GenePage extends Component {
 
@@ -168,12 +168,8 @@ class GenePage extends Component {
 
           <Subsection title={ORTHOLOGY}>
             <OrthologyBasicInfo pantherCrossReference={data.crossReferences.panther} />
-            <Subsection hasData={(data.orthology || []).length > 0}>
-              <DataLoader url={`/api/gene/${data.primaryId}/homologs?stringencyFilter=all&rows=${1000}`}>
-                {({data}) => (
-                  <OrthologyFilteredTable data={data.results} />
-                )}
-              </DataLoader>
+            <Subsection>
+              <OrthologyFilteredTable geneId={data.id} />
               <OrthologyUserGuide />
             </Subsection>
           </Subsection>
@@ -205,7 +201,8 @@ class GenePage extends Component {
               spellCrossReference={data.crossReferences.spell}
               wildtypeExpressionCrossReference={data.crossReferences.wild_type_expression}
             />
-            <ExpressionComparisonRibbon geneId={data.id} geneSymbol={data.symbol} geneTaxon={data.species.taxonId} />
+            <i>Sorry, will be back shortly</i>
+            {/* <ExpressionComparisonRibbon geneId={data.id} geneSymbol={data.symbol} geneTaxon={data.species.taxonId} /> */}
           </Subsection>
 
           <Subsection title={ALLELES}>

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -169,7 +169,11 @@ class GenePage extends Component {
           <Subsection title={ORTHOLOGY}>
             <OrthologyBasicInfo pantherCrossReference={data.crossReferences.panther} />
             <Subsection hasData={(data.orthology || []).length > 0}>
-              <OrthologyFilteredTable data={data.orthology} />
+              <DataLoader url={`/api/gene/${data.primaryId}/homologs?stringencyFilter=all&rows=${1000}`}>
+                {({data}) => (
+                  <OrthologyFilteredTable data={data.results} />
+                )}
+              </DataLoader>
               <OrthologyUserGuide />
             </Subsection>
           </Subsection>

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -25,7 +25,7 @@ import ExpressionLinks from './expressionLinks';
 import SpeciesIcon from '../../components/speciesIcon';
 import DataSourceLink from '../../components/dataSourceLink';
 import PhenotypeTable from './phenotypeTable';
-//import { ExpressionComparisonRibbon } from '../../components/expression';
+import { ExpressionComparisonRibbon } from '../../components/expression';
 
 class GenePage extends Component {
 
@@ -201,8 +201,7 @@ class GenePage extends Component {
               spellCrossReference={data.crossReferences.spell}
               wildtypeExpressionCrossReference={data.crossReferences.wild_type_expression}
             />
-            <i>Sorry, will be back shortly</i>
-            {/* <ExpressionComparisonRibbon geneId={data.id} geneSymbol={data.symbol} geneTaxon={data.species.taxonId} /> */}
+            <ExpressionComparisonRibbon geneId={data.id} geneSymbol={data.symbol} geneTaxon={data.species.taxonId} />
           </Subsection>
 
           <Subsection title={ALLELES}>

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -64,8 +64,8 @@ function isHighStringency(orthology) {
   return (
     orthology.predictionMethodsMatched.indexOf('ZFIN') > -1 ||
     orthology.predictionMethodsMatched.indexOf('HGNC') > -1 ||
-    (orthology.predictionMethodsMatched.length > 2 && (orthology.isBestScore || orthology.isBestRevScore)) ||
-    (orthology.predictionMethodsMatched.length === 2 && orthology.isBestScore && orthology.isBestRevScore)
+    (orthology.predictionMethodsMatched.length > 2 && (orthology.best || orthology.bestReverse)) ||
+    (orthology.predictionMethodsMatched.length === 2 && orthology.best && orthology.bestReverse)
   );
 }
 
@@ -74,7 +74,7 @@ function isModerateStringency(orthology) {
     orthology.predictionMethodsMatched.indexOf('ZFIN') > -1 ||
     orthology.predictionMethodsMatched.indexOf('HGNC') > -1 ||
     orthology.predictionMethodsMatched.length > 2 ||
-    (orthology.predictionMethodsMatched.length === 2 && orthology.isBestScore && orthology.isBestRevScore)
+    (orthology.predictionMethodsMatched.length === 2 && orthology.best && orthology.bestReverse)
   );
 }
 

--- a/src/reducers/geneReducer.js
+++ b/src/reducers/geneReducer.js
@@ -1,6 +1,7 @@
 import { fromJS } from 'immutable';
 import {
   FETCH_GENE,
+  FETCH_ORTHOLOGS,
   FETCH_ALLELES,
   FETCH_PHENOTYPES,
   FETCH_DISEASE_VIA_EMPIRICAL,
@@ -10,6 +11,12 @@ import {
 import { handleActions, forObjectRequestAction, forCollectionRequestAction } from '../lib/handleActions';
 
 const DEFAULT_STATE = fromJS({
+  orthologs: {
+    data: [],
+    error: null,
+    loading: false,
+    total: 0,
+  },
   alleles: {
     data: [],
     error: null,
@@ -47,6 +54,7 @@ const DEFAULT_STATE = fromJS({
 
 const geneReducer = handleActions(DEFAULT_STATE,
   forObjectRequestAction(FETCH_GENE),
+  forCollectionRequestAction(FETCH_ORTHOLOGS, 'orthologs'),
   forCollectionRequestAction(FETCH_ALLELES, 'alleles'),
   forCollectionRequestAction(FETCH_PHENOTYPES, 'phenotypes'),
   forCollectionRequestAction(FETCH_DISEASE_VIA_EMPIRICAL, 'diseaseViaEmpirical'),

--- a/src/selectors/geneSelectors.js
+++ b/src/selectors/geneSelectors.js
@@ -7,9 +7,9 @@ export const selectGene = createSelector(
   (gene) => gene.toJS()
 );
 
-export const selectOrthology = createSelector(
+export const selectOrthologs = createSelector(
   [selectGeneDomain],
-  (gene) => gene.toJS().data.orthology
+  (gene) => gene.get('orthologs').toJS()
 );
 
 export const selectAlleles = createSelector(


### PR DESCRIPTION
AGR-1132 @paaatrick the orthology and expression section should be fixed now. Though you might want doublecheck the expression section, as I haven't done too much testing with it.

One catch though, the orthology stringency filter is still determined on the client side, because the API response is missing the stringencyLevel in many entries. It's related to the ticket https://agr-jira.atlassian.net/browse/AGR-1373 Once that's fixed, I will file a separate PR to use that value.


