### PR TITLE
Stop mocha from testing sass files (MERGE first, then https://github.com/alliance-genome/agr_ui/pull/384)

### DIFF
--- a/webpack.config-test.js
+++ b/webpack.config-test.js
@@ -1,5 +1,9 @@
 var nodeExternals = require('webpack-node-externals');
 
+require.extensions['.scss'] = function () {
+  return null;
+};
+
 module.exports = {
   mode: 'development',
   target: 'node', // in order to ignore built-in modules like path, fs, etc.


### PR DESCRIPTION
This issue was blocking the Ribbon PR since the beginning of the week.

Mocha should not be testing SASS files as we don't currently have a real strategy yet to test styling features.

Please merge the Ribbon PR after merging this one and the tests should now pass.