### PR TITLE
Agr 1543 fetching interactions

### DIFF
--- a/src/components/interaction/genePhysicalInteractionDetailTable.js
+++ b/src/components/interaction/genePhysicalInteractionDetailTable.js
@@ -369,6 +369,10 @@ class GenePhysicalInteractionDetailTable extends React.Component {
       return 0;
     });
 
+    if (interactions.error) {
+      throw new Error(interactions.error.msg);
+    }
+
     if (interactions.loading) {
       return <LoadingSpinner />;
     }

--- a/src/lib/fetchData.js
+++ b/src/lib/fetchData.js
@@ -2,7 +2,7 @@ require('abortcontroller-polyfill/dist/abortcontroller-polyfill-only');
 import 'isomorphic-fetch';
 
 
-const TIMEOUT = 30000;
+const TIMEOUT = 300000;
 const CONTROLLER = new AbortController();
 
 //resolve promise


### PR DESCRIPTION
To fix the client-side timeout of interactions table, I bumped the timeout limit up. I also triggers the error display instead the misleading fallback to "No Data", when an error occurs. 