### PR TITLE
Fix AGR-1643

### DIFF
--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -100,6 +100,7 @@ class DiseaseComparisonRibbon extends Component {
 
     let geneIdList = ['geneID=' + geneId].concat(this.getOrthologGeneIds(selectedOrthologs));
     dispatch(fetchDiseaseSummary('*', geneIdList)).then(data => {
+      this.setState( { summary : { } });
       this.setState({
         selectedOrthologs: selectedOrthologs,
         summary : data.summary


### PR DESCRIPTION
Something that I noticed before. The setState does not always merge correctly when we have a substructure that looks like the one already present, hence this brut force update to setState on the first summary level, since the subsequent merge does not replace items in the array.

Anyhow, we'll move away from setState possibly in profit of REACT hooks.