### PR TITLE
Abort in-flight autocomplete requests before sending new one

### DIFF
--- a/src/containers/layout/searchBar/index.js
+++ b/src/containers/layout/searchBar/index.js
@@ -21,6 +21,7 @@ class SearchBarComponent extends Component {
     super(props);
     let initValue = parseQueryString(this.props.location.search).q || '';
     this.state = {
+      abortController: null,
       autoOptions: [],
       catOption: DEFAULT_CAT,
       value: initValue
@@ -60,10 +61,24 @@ class SearchBarComponent extends Component {
     let cat = this.state.catOption.name;
     let catSegment = cat === DEFAULT_CAT.name ? '' : ('&category=' + cat);
     let url = AUTO_BASE_URL + '?q=' + query + catSegment;
-    fetchData(url)
-      .then( (data) => {
+    if (this.state.abortController) {
+      this.state.abortController.abort();
+    }
+    const abortController = new AbortController();
+    this.setState({abortController});
+    fetchData(url, {signal: abortController.signal})
+      .then(data => {
         let newOptions = data.results || [];
-        this.setState({ autoOptions: newOptions });
+        this.setState({
+          autoOptions: newOptions,
+          abortController: null,
+        });
+      })
+      .catch(error => {
+        if (error.name === 'AbortError') {
+          return;
+        }
+        throw error;
       });
   }
 


### PR DESCRIPTION
I don't think there was an open case about it, but this fixes something that always bugged me. Depending on how fast you type into the search box and how fast the backend responds you could get responses back in the wrong order. The result is the autocomplete shows invalid suggestions once you stop typing. 

These changes fix that by aborting the last request if it's still pending before making a new one. Eventually the same concept should probably be applied to all requests we make, but that'll require some more thought and unlike the search box it's hard to trigger page or table requests quickly enough to get into a bad state. These changes also simplify a little of the logic in fetchData.js around timeouts as well.