### PR TITLE
AGR-1707 - condense all Work Products pages into one Working Groups page

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -88,26 +88,9 @@ export const NAV_MENU = [
     ]
   },
   {
-    label: 'Work Products',
-    wordpressId: 257,
-    sub: [
-      {
-        label: 'Working Groups',
-        route: '/working-groups',
-      },
-      {
-        label: 'Genome Features',
-        route: '/genome-features'
-      },
-      {
-        label: 'Orthology',
-        route: '/orthology'
-      },
-      {
-        label: 'Phenotypes and Disease Models',
-        route: '/phenotypes-and-disease-models'
-      }
-    ]
+    label: 'Working Groups',
+    route: '/working-groups',
+    wordpressId: 1184,
   },
   {
     label: 'News',

--- a/src/containers/wordpress/secondaryNav.js
+++ b/src/containers/wordpress/secondaryNav.js
@@ -13,8 +13,8 @@ class SecondaryNav extends Component {
       return style.aboutMenuContainer;
     case 3:
       return style.contactMenuContainer;
-    case 257:
-      return style.projectsMenuContainer;
+    case 1184:
+      return style.workingGroupsMenuContainer;
     case 473:
       return style.postMenuContainer;
     case 179:

--- a/src/containers/wordpress/style.scss
+++ b/src/containers/wordpress/style.scss
@@ -1,5 +1,5 @@
 .wordPressContainer {
-  margin-top: -1rem;
+  margin-top: -.5rem;
 }
 
 .postContainer {
@@ -13,7 +13,7 @@
 }
 
 .postMenuContainer, .homeMenuContainer,
-.aboutMenuContainer, .projectsMenuContainer,
+.aboutMenuContainer, .workingGroupsMenuContainer,
 .contactMenuContainer, .helpMenuContainer {
   background-size: cover;
   background: #222222 no-repeat center center;
@@ -33,8 +33,8 @@
   background-image: url('https://alliancegenome.files.wordpress.com/2019/05/contact-6.jpg');
 }
 
-.projectsMenuContainer {
-  background-image: url('http://alliancegenome.files.wordpress.com/2016/11/contact_banner.jpg');
+.workingGroupsMenuContainer {
+  background-image: url('https://alliancegenome.files.wordpress.com/2019/09/working-groups.jpg');
 }
 
 .helpMenuContainer {


### PR DESCRIPTION
The actual WordPress page is currently https://alliancegenome.org/working-groups-new this url slug will be changed to working-groups in the WordPress GUI once the code is released. 