### PR TITLE
Use supplemental data from homologs endpoint

### DIFF
--- a/src/actions/genes.js
+++ b/src/actions/genes.js
@@ -3,7 +3,6 @@ import { createFetchAction } from '../lib/createActions';
 
 export const FETCH_GENE = 'FETCH_GENE';
 export const FETCH_ORTHOLOGS = 'FETCH_ORTHOLOGS';
-export const FETCH_ORTHOLOGS_WITH_EXPRESSION = 'FETCH_ORTHOLOGS_WITH_EXPRESSION';
 export const FETCH_ALLELES = 'FETCH_ALLELES';
 export const FETCH_PHENOTYPES = 'FETCH_PHENOTYPES';
 export const FETCH_DISEASE_VIA_EMPIRICAL = 'FETCH_DISEASE_VIA_EMPIRICAL';
@@ -12,10 +11,6 @@ export const FETCH_INTERACTIONS = 'FETCH_INTERACTIONS';
 
 export const fetchGene = createFetchAction(FETCH_GENE, id => `/api/gene/${id}`);
 export const fetchOrthologs = createFetchAction(FETCH_ORTHOLOGS, id => `/api/gene/${id}/homologs?stringencyFilter=all`);
-export const fetchOrthologsWithExpression = createFetchAction(
-  FETCH_ORTHOLOGS_WITH_EXPRESSION,
-  id => `/api/gene/${id}/homologs-with-expression?stringencyFilter=all`
-);
 export const fetchAlleles = createFetchAction(
   FETCH_ALLELES,
   (id, opts) => `/api/gene/${id}/alleles?${buildTableQueryString(opts)}`

--- a/src/components/OrthologPicker.js
+++ b/src/components/OrthologPicker.js
@@ -180,16 +180,18 @@ class OrthologPicker extends React.Component {
 
     return (
       <React.Fragment>
-        <div className='form-check'>
-          <label>
-            <input
-              checked={enabled}
-              className='form-check-input'
-              onChange={e => this.setState({enabled: e.target.checked})}
-              type='checkbox'
-            />
-            <b>Compare ortholog genes</b>
-          </label>
+        <div className='form-group'>
+          <div className='form-check form-check-inline'>
+            <label className='form-check-label'>
+              <input
+                checked={enabled}
+                className='form-check-input'
+                onChange={e => this.setState({enabled: e.target.checked})}
+                type='checkbox'
+              />
+              <b>Compare ortholog genes</b>
+            </label>
+          </div>
         </div>
         <div>
           <UncontrolledDropdown className='pr-2' tag='span'>

--- a/src/components/OrthologPicker.js
+++ b/src/components/OrthologPicker.js
@@ -72,9 +72,10 @@ class OrthologPicker extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     const { allVertebrates, allInvertebrates, stringency, enabled, selectedSpecies } = this.state;
     const speciesChanged = !isEqual(prevState.selectedSpecies, selectedSpecies);
+    const orthologyChanged = !isEqual(prevProps.orthology, this.props.orthology);
 
-    // if the stringency or species filters have changed...
-    if (prevState.stringency !== stringency || speciesChanged) {
+    // if the filters or orthology itself have changed...
+    if (prevState.stringency !== stringency || speciesChanged || orthologyChanged) {
       // ...fire the parent component change callback...
       this.fireChangeCallback();
       // ...and enable or disable the main compare checkbox (may be a no-op in some cases)

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -7,6 +7,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash.isequal';
 
 import DiseaseAnnotationTable from './diseaseAnnotationTable';
 import HorizontalScroll from '../horizontalScroll';
@@ -53,8 +54,9 @@ class DiseaseComparisonRibbon extends Component {
       }));
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.geneId !== prevProps.geneId) {
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.geneId !== prevProps.geneId ||
+      !isEqual(this.state.selectedOrthologs, prevState.selectedOrthologs)) {
       this.fetchData();
     }
   }
@@ -64,7 +66,7 @@ class DiseaseComparisonRibbon extends Component {
   }
 
   handleOrthologyChange(selectedOrthologs) {
-    this.setState({selectedOrthologs}, () => this.fetchData());
+    this.setState({selectedOrthologs});
   }
 
   getGeneIdList() {

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -97,6 +97,9 @@ class ExpressionComparisonRibbon extends React.Component {
     //   category.id.startsWith('UBERON:')
     // ));
 
+    const genesWithData = Object.entries(orthology.supplementalData)
+      .reduce((prev, [geneId, data]) => ({...prev, [geneId]: data.hasExpressionAnnotations}), {});
+
     return (
       <React.Fragment>
         <div className='pb-4'>
@@ -108,6 +111,7 @@ class ExpressionComparisonRibbon extends React.Component {
             </span>
             <OrthologPicker
               disabledSpeciesMessage={`${geneSymbol} has no ortholog genes or no ortholog genes with expression annotations in this species`}
+              genesWithData={genesWithData}
               id='expression-ortho-picker'
               onChange={this.handleOrthologChange}
               orthology={orthology.data}

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import isEqual from 'lodash.isequal';
 
 import ControlsContainer from '../controlsContainer';
 import { getOrthologId } from '../orthology';
@@ -37,9 +38,9 @@ class ExpressionComparisonRibbon extends React.Component {
     this.dispatchFetchSummary();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const { geneId } = this.props;
-    if (prevProps.geneId !== geneId) {
+    if (prevProps.geneId !== geneId || !isEqual(prevState.selectedOrthologs, this.state.selectedOrthologs)) {
       this.dispatchFetchSummary();
     }
   }
@@ -53,7 +54,7 @@ class ExpressionComparisonRibbon extends React.Component {
   }
 
   handleOrthologChange(values) {
-    this.setState({selectedOrthologs: values}, () => this.dispatchFetchSummary());
+    this.setState({selectedOrthologs: values});
   }
 
   updateSelectedBlock(gene, term) {

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -6,10 +6,9 @@ import { connect } from 'react-redux';
 import ControlsContainer from '../controlsContainer';
 import { getOrthologId } from '../orthology';
 import { STRINGENCY_HIGH } from '../orthology/constants';
-import { selectOrthologsWithExpression } from '../../selectors/geneSelectors';
+import { selectOrthologs } from '../../selectors/geneSelectors';
 import ExpressionAnnotationTable from './expressionAnnotationTable';
 import HorizontalScroll from '../horizontalScroll';
-import { fetchOrthologsWithExpression } from '../../actions/genes';
 import HelpPopup from '../helpPopup';
 import ExpressionControlsHelp from './expressionControlsHelp';
 import OrthologPicker from '../OrthologPicker';
@@ -35,15 +34,12 @@ class ExpressionComparisonRibbon extends React.Component {
   }
 
   componentDidMount() {
-    const { dispatch, geneId } = this.props;
-    dispatch(fetchOrthologsWithExpression(geneId));
     this.dispatchFetchSummary();
   }
 
   componentDidUpdate(prevProps) {
-    const { dispatch, geneId } = this.props;
+    const { geneId } = this.props;
     if (prevProps.geneId !== geneId) {
-      dispatch(fetchOrthologsWithExpression(geneId));
       this.dispatchFetchSummary();
     }
   }
@@ -157,7 +153,7 @@ ExpressionComparisonRibbon.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  orthology: selectOrthologsWithExpression(state),
+  orthology: selectOrthologs(state),
   summary: selectExpressionRibbonSummary(state),
 });
 

--- a/src/lib/createActions.js
+++ b/src/lib/createActions.js
@@ -1,20 +1,30 @@
 import fetchData from './fetchData';
 
 export const createFetchAction = (type, url) => {
+  let abortController = null;
   return (...params) => {
     return (dispatch) => {
       dispatch({
         type: type + '_REQUEST',
       });
-      return fetchData(url(...params))
+      if (abortController) {
+        abortController.abort();
+      }
+      abortController = new AbortController();
+      return fetchData(url(...params), {signal: abortController.signal})
         .then((data) => dispatch({
           type: type + '_SUCCESS',
           payload: data,
         }))
-        .catch((error) => dispatch({
-          type: type + '_FAILURE',
-          payload: error,
-        }));
+        .catch((error) => {
+          if (error.name === 'AbortError') {
+            return;
+          }
+          dispatch({
+            type: type + '_FAILURE',
+            payload: error,
+          });
+        });
     };
   };
 };

--- a/src/reducers/geneReducer.js
+++ b/src/reducers/geneReducer.js
@@ -7,18 +7,11 @@ import {
   FETCH_DISEASE_VIA_EMPIRICAL,
   FETCH_DISEASE_VIA_ORTHOLOGY,
   FETCH_INTERACTIONS,
-  FETCH_ORTHOLOGS_WITH_EXPRESSION,
 } from '../actions/genes';
 import { handleActions, forObjectRequestAction, forCollectionRequestAction } from '../lib/handleActions';
 
 const DEFAULT_STATE = fromJS({
   orthologs: {
-    data: [],
-    error: null,
-    loading: false,
-    total: 0,
-  },
-  orthologsWithExpression: {
     data: [],
     error: null,
     loading: false,
@@ -62,7 +55,6 @@ const DEFAULT_STATE = fromJS({
 const geneReducer = handleActions(DEFAULT_STATE,
   forObjectRequestAction(FETCH_GENE),
   forCollectionRequestAction(FETCH_ORTHOLOGS, 'orthologs'),
-  forCollectionRequestAction(FETCH_ORTHOLOGS_WITH_EXPRESSION, 'orthologsWithExpression'),
   forCollectionRequestAction(FETCH_ALLELES, 'alleles'),
   forCollectionRequestAction(FETCH_PHENOTYPES, 'phenotypes'),
   forCollectionRequestAction(FETCH_DISEASE_VIA_EMPIRICAL, 'diseaseViaEmpirical'),

--- a/src/selectors/geneSelectors.js
+++ b/src/selectors/geneSelectors.js
@@ -12,11 +12,6 @@ export const selectOrthologs = createSelector(
   (gene) => gene.get('orthologs').toJS()
 );
 
-export const selectOrthologsWithExpression = createSelector(
-  [selectGeneDomain],
-  (gene) => gene.get('orthologsWithExpression').toJS()
-);
-
 export const selectAlleles = createSelector(
   [selectGeneDomain],
   (gene) => gene.get('alleles').toJS()


### PR DESCRIPTION
These changes replace the hardcoded disabled message on species in the ortholog picker with one that takes into account both whether the gene has an ortholog of a given species and optionally whether those orthologs have annotations.