### PR TITLE
default to jbrowse-build subdomain

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -68,8 +68,7 @@ const plugins = [
   }),
   new webpack.EnvironmentPlugin({
     APOLLO_URL: 'https://agr-apollo.berkeleybop.io/apollo/',
-    JBROWSE_PORT: '8891',
-    JBROWSE_URL: 'http://jbrowse-dev.alliancegenome.org',
+    JBROWSE_URL: 'http://jbrowse-build.alliancegenome.org',
     RELEASE: '[dev]',
   }),
   new MiniCssExtractPlugin({


### PR DESCRIPTION
- default `JBROWSE_URL` environment variable to jbrowse-build subdomain
- remove `JBROWSE_PORT` environment variable, as it's no longer being used