### PR TITLE
excludeIBA removed

### DIFF
--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -76,7 +76,8 @@ class GeneOntologyRibbon extends Component {
   }
 
   ribbonOptions(subjects) {
-    var excludeIBA = this.state.excludeIBA && subjects.length > 1;
+    // var excludeIBA = this.state.excludeIBA && subjects.length > 1;
+    var excludeIBA = false;
     var exps = '';
     if(this.state.onlyEXP) {
       for(var exp of exp_codes) {


### PR DESCRIPTION
excludeIBA was a test introduced to see how to remove inferences when showing multiple genes; we now have show experimental annotations only, hence deactivating this

