### PR TITLE
Add category label to data page headers

### DIFF
--- a/src/components/dataPage/PageCategoryLabel.js
+++ b/src/components/dataPage/PageCategoryLabel.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CategoryLabel from '../../containers/search/categoryLabel';
+
+import style from './style.scss';
+
+const PageCategoryLabel = ({category}) => (
+  <div className={style.pageCategory}>
+    <CategoryLabel category={category} />
+  </div>
+);
+
+PageCategoryLabel.propTypes = {
+  category: PropTypes.string,
+};
+
+export default PageCategoryLabel;

--- a/src/components/dataPage/style.scss
+++ b/src/components/dataPage/style.scss
@@ -69,3 +69,10 @@ $page-nav-width: 220px;
     width: 100%;
   }
 }
+
+.pageCategory {
+  font-size: 0.8rem;
+  color: $gray-600;
+  text-transform: uppercase;
+  margin-bottom: 0.2rem;
+}

--- a/src/containers/allelePage/AllelePage.js
+++ b/src/containers/allelePage/AllelePage.js
@@ -24,6 +24,7 @@ import PageNavEntity from '../../components/dataPage/PageNavEntity';
 import DataSourceLink from '../../components/dataSourceLink';
 import {Link} from 'react-router-dom';
 import {setPageLoading} from '../../actions/loadingActions';
+import PageCategoryLabel from '../../components/dataPage/PageCategoryLabel';
 
 const SUMMARY = 'Summary';
 const SECTIONS = [
@@ -65,6 +66,7 @@ class AllelePage extends Component {
           </PageNavEntity>
         </PageNav>
         <PageData>
+          <PageCategoryLabel category='allele' />
           <PageHeader entityName={<AlleleSymbol allele={data} />}/>
 
           <Subsection hideTitle title={SUMMARY}>

--- a/src/containers/diseasePage/index.js
+++ b/src/containers/diseasePage/index.js
@@ -23,6 +23,7 @@ import DiseaseToGeneTable from './DiseaseToGeneTable';
 import DiseaseToModelTable from './DiseaseToModelTable';
 import {setPageLoading} from '../../actions/loadingActions';
 import PageNavEntity from '../../components/dataPage/PageNavEntity';
+import PageCategoryLabel from '../../components/dataPage/PageCategoryLabel';
 
 class DiseasePage extends Component {
   constructor(props) {
@@ -120,6 +121,7 @@ class DiseasePage extends Component {
           </PageNavEntity>
         </PageNav>
         <PageData>
+          <PageCategoryLabel category='disease' />
           <PageHeader entityName={disease.name} />
 
           <Subsection hideTitle title={SUMMARY}>

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -27,6 +27,7 @@ import GeneModelsTable from './GeneModelsTable';
 import GeneMetaTags from './GeneMetaTags';
 import {setPageLoading} from '../../actions/loadingActions';
 import PageNavEntity from '../../components/dataPage/PageNavEntity';
+import PageCategoryLabel from '../../components/dataPage/PageCategoryLabel';
 
 const SUMMARY = 'Summary';
 const SEQUENCE_FEATURE_VIEWER = 'Sequence Feature Viewer';
@@ -120,6 +121,7 @@ class GenePage extends Component {
           </PageNavEntity>
         </PageNav>
         <PageData>
+          <PageCategoryLabel category='gene' />
           <PageHeader entityName={data.symbol} />
 
           <Subsection hideTitle title={SUMMARY}>

--- a/src/containers/search/categoryLabel.js
+++ b/src/containers/search/categoryLabel.js
@@ -8,7 +8,7 @@ const CategoryLabel = ({category, hideImage, hideLabel}) => {
   let current = CATEGORIES.find(cat => cat.name === category);
   return (
     <span className={`${style.categoryLabel} ${style[category]} ${hideImage ? style.noIcon : ''}`}>
-      {!hideLabel && current.displayName}
+      {!hideLabel && current && current.displayName}
     </span>
   );
 };

--- a/src/containers/search/categoryLabel.js
+++ b/src/containers/search/categoryLabel.js
@@ -1,36 +1,22 @@
-
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import style from './style.scss';
-import { CATEGORIES } from '../../constants';
+import {CATEGORIES} from '../../constants';
 
-class CategoryLabel extends Component {
-  getCurrentOption() {
-    return CATEGORIES.find(cat => cat.name === this.props.category);
-  }
-
-  renderSprite() {
-    return <span className={`${style[this.props.category]} ${style.categoryIcon}`}>&#x2B22;</span>;
-  }
-
-  render() {
-    let current = this.getCurrentOption();
-    let label = current ? current.displayName : '';
-    let labelNode = this.props.hideLabel ? null : <span className={style.catLabel}> {label}</span>;
-    let spriteNode = this.props.hideImage ? null : <span>{this.renderSprite()}</span>;
-    return <span>{spriteNode}{labelNode}</span>;
-  }
-}
+const CategoryLabel = ({category, hideImage, hideLabel}) => {
+  let current = CATEGORIES.find(cat => cat.name === category);
+  return (
+    <span className={`${style.categoryLabel} ${style[category]} ${hideImage ? style.noIcon : ''}`}>
+      {!hideLabel && current.displayName}
+    </span>
+  );
+};
 
 CategoryLabel.propTypes = {
   category: PropTypes.string,
   hideImage: PropTypes.bool,
   hideLabel: PropTypes.bool,
-};
-
-CategoryLabel.defaultProps = {
-  spriteColor: 'black',
 };
 
 export default CategoryLabel;

--- a/src/containers/search/style.scss
+++ b/src/containers/search/style.scss
@@ -114,11 +114,19 @@ a > span > .sprite {
 	background-position-x: -2.25rem;
 }
 
-.categoryIcon {
-  position: relative;
-  bottom: 0.10rem;
+.categoryLabel {
+  &::before {
+    content: '\2B22';
+    position: relative;
+    bottom: 0.1rem;
+    margin-right: 0.15rem;
+  }
+  &.go::before { color: #9467bd; }
+  &.gene::before { color: #1f77b4; }
+  &.disease::before { color: #D95F02; }
+  &.model::before { color: #bcbd22; }
+  &.allele::before { color: #8c564b; }
 }
-
 /*
 Category colors (from SGD) that aren't used yet
 .reference{background:#ff7f0e}
@@ -134,12 +142,6 @@ Category colors (from SGD) that aren't used yet
 .chemical{background:#ff9896}
 .complex{background:#E6AB03}
  */
-
-.categoryIcon.go { color: #9467bd; }
-.categoryIcon.gene { color: #1f77b4; }
-.categoryIcon.disease { color: #D95F02; }
-.categoryIcon.model { color: #bcbd22; }
-.categoryIcon.allele { color: #8c564b; }
 
 .resultSpeciesIcon {
   float: right;


### PR DESCRIPTION
Reusing the category label component we already use for search on data pages. @kevinschaper @felixgondwe I reworked the implementation of the category label component but it should still function the same.