### PR TITLE
(DO NOT MERGE) - adds allele to variant page - no merge    AGR-1851

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6823,9 +6823,9 @@
       }
     },
     "genomefeaturecomponent": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/genomefeaturecomponent/-/genomefeaturecomponent-0.2.8.tgz",
-      "integrity": "sha512-c4rwcKpv5cpOcYOYDg5F2rETm7pD0OLSaNhimQEhHv4e5yzF5F4ZKj50XNxHFRWHaczj//QIhxb5JJpUiRZtHw==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/genomefeaturecomponent/-/genomefeaturecomponent-0.2.9.tgz",
+      "integrity": "sha512-yQK8RAojtALvz5ExOcXxg+8ViCiSOpKoyX5M1q29x3YZWLUObfCax3GXDZQhiOY7/qapXaYp00Hb4GZMkRDeyQ==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "d3-axis": "^1.0.8",
     "d3-scale": "^1.0.6",
     "d3-selection": "^1.1.0",
-    "genomefeaturecomponent": "^0.2.8",
+    "genomefeaturecomponent": "^0.2.9",
     "html-react-parser": "^0.10.0",
     "immutable": "^3.8.1",
     "isomorphic-fetch": "^2.2.1",

--- a/src/containers/allelePage/AllelePage.js
+++ b/src/containers/allelePage/AllelePage.js
@@ -28,14 +28,17 @@ import AlleleToPhenotypeTable from './AlleleToPhenotypeTable';
 import PageCategoryLabel from '../../components/dataPage/PageCategoryLabel';
 import AlleleToDiseaseTable from './AlleleToDiseaseTable';
 import AlleleToVariantTable from './AlleleToVariantTable';
+import AlleleSequenceView from './AlleleSequenceView';
 
 const SUMMARY = 'Summary';
+const SEQUENCE_VIEW = 'Sequence View';
 const PHENOTYPES = 'Phenotypes';
 const DISEASE = 'Disease Associations';
 const VARIANTS = 'Variants';
 const SECTIONS = [
   {name: SUMMARY},
   {name: VARIANTS},
+  {name: SEQUENCE_VIEW},
   {name: PHENOTYPES},
   {name: DISEASE}
 ];
@@ -80,6 +83,10 @@ class AllelePage extends Component {
 
           <Subsection hideTitle title={SUMMARY}>
             <AlleleSummary allele={data} />
+          </Subsection>
+
+          <Subsection title={SEQUENCE_VIEW}>
+            <AlleleSequenceView allele={data} />
           </Subsection>
 
           <Subsection title={VARIANTS}>

--- a/src/containers/allelePage/AlleleSequenceView.js
+++ b/src/containers/allelePage/AlleleSequenceView.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import GenomeFeatureWrapper from '../genePage/genomeFeatureWrapper';
+// import GenomeFeatureWrapper from '../genePage/genomeFeatureWrapper';
+
+const AlleleSequenceView = ({allele}) => {
+  console.log('allele',allele);
+
+  // myl7
+  // http://localhost:2992/gene/ZFIN:ZDB-GENE-991019-3#alleles-and-variants
+  // az2
+  // http://localhost:2992/allele/ZFIN:ZDB-ALT-181010-2
+
+
+  let genomeLocation = {
+    assembly: 'GRCz11',
+    chromosome:'8',
+    start:40457107,
+    end:40464935,
+    strand:'+',
+  };
+  return (
+    <div>
+      Allele viewer here
+      {/*{allele}*/}
+      <ul>
+        <li>assembly: N/A fake {genomeLocation.assembly}</li>
+        <li>fmin : N/A fake {genomeLocation.start}</li>
+        <li>fmax: N/A  fake {genomeLocation.end}</li>
+        <li>strand: N/A fake {genomeLocation.end}</li>
+        <li>chromosome : N/A fake {genomeLocation.chromosome}</li>
+        <li>biotype: {allele.type}, though maybe mapped as a gene</li>
+        <li>symbol: {allele.symbol}</li>
+        <li>id: {allele.id}</li>
+        <li>species: {allele.species.name}</li>
+        <li>synonyms: {allele.synonyms}</li>
+      </ul>
+      <GenomeFeatureWrapper
+        assembly={genomeLocation.assembly}
+        biotype='gene'
+        chromosome={genomeLocation.chromosome}
+        fmax={genomeLocation.end}
+        fmin={genomeLocation.start}
+        geneSymbol={allele.symbol}
+        height='200px'
+        id='genome-feature-location-id'
+        primaryId={allele.id}
+        species={allele.species.name}
+        strand={genomeLocation.strand}
+        synonyms={allele.synonyms}
+        variant={allele.symbol}
+        width='600px'
+      />
+    </div>
+  );
+};
+
+AlleleSequenceView.propTypes = {
+  allele: PropTypes.object,
+};
+
+export default AlleleSequenceView;

--- a/src/containers/allelePage/AlleleToVariantTable.js
+++ b/src/containers/allelePage/AlleleToVariantTable.js
@@ -20,7 +20,7 @@ const AlleleToVariantTable = ({alleleId, fetchVariants, variants}) => {
     {
       dataField: 'type',
       text: 'Variant type',
-      formatter: ({name = ''} = {}) => name.replace(/_/g, ''),
+      formatter: ({name = ''} = {}) => name.replace(/_/g, ' '),
       headerStyle: {width: '100px'},
     },
     {

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -35,7 +35,7 @@ class GenomeFeatureWrapper extends Component {
     let bufferedMax = Math.round(this.props.fmax + (linkLength * linkBuffer / 2.0));
     let externalLocationString = this.props.chromosome + ':' + bufferedMin + '..' + bufferedMax;
     // TODO: handle bufferedMax exceeding chromosome length, though I think it has a good default.
-    const tracks = ['All Genes', 'Variants'];
+    const tracks = ['Variants','All Genes'];
     let externalJbrowseUrl = externalJBrowsePrefix +
       '&tracks=' + encodeURIComponent(tracks.join(',')) +
       '&highlight=' + geneSymbolUrl +

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -113,7 +113,7 @@ class GenomeFeatureWrapper extends Component {
   }
 
   loadGenomeFeature() {
-    const {chromosome, fmin, fmax, species,id,primaryId,geneSymbol, synonyms = []} = this.props;
+    const {chromosome, fmin, fmax, species,id,primaryId,geneSymbol, synonyms = [],variant} = this.props;
     // provide unique names
     let nameSuffix = [geneSymbol, ...synonyms,primaryId].filter((x, i, a) => a.indexOf(x) === i).map( x => encodeURI(x));
     let nameSuffixString = nameSuffix.length ===0 ? '': nameSuffix.join('&name=');
@@ -128,7 +128,7 @@ class GenomeFeatureWrapper extends Component {
     // [0] should be apollo_url: https://agr-apollo.berkeleybop.io/apollo/track
     // [1] should be track name : ALL_Genes
     // [2] should be track name : name suffix string
-    const trackConfig = this.generateTrackConfig(fmin,fmax,chromosome,species,nameSuffixString,undefined);
+    const trackConfig = this.generateTrackConfig(fmin,fmax,chromosome,species,nameSuffixString,variant);
     new GenomeFeatureViewer(trackConfig, `#${id}`, 900, undefined);
   }
 
@@ -176,6 +176,7 @@ GenomeFeatureWrapper.propTypes = {
   species: PropTypes.string.isRequired,
   strand: PropTypes.string,
   synonyms: PropTypes.array,
+  variant: PropTypes.string,
   width: PropTypes.string,
 };
 

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -61,6 +61,7 @@ class GenomeFeatureWrapper extends Component {
   }
 
   generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString,variantFilter) {
+    console.log('generating with variant filter',variantFilter);
     let transcriptTypes = getTranscriptTypes();
     if(species==='Saccharomyces cerevisiae' || species ==='Homo sapiens'){
       return {
@@ -90,7 +91,7 @@ class GenomeFeatureWrapper extends Component {
       'start': fmin,
       'end': fmax,
       'showVariantLabel': false,
-      'variantFilter': variantFilter ? variantFilter : [],
+      'variantFilter': variantFilter ? [variantFilter] : [],
       'tracks': [
         {
           'id': 1,


### PR DESCRIPTION
adds variant to allelle page: 

https://agr-jira.atlassian.net/browse/AGR-1851

- [ ] needs gene genomeLocation data separately or on allele call
- [ ] move to the variant section (instead of own section)
- [x] add allele to variant page with filter with fake data

```
  // myl7
  // http://localhost:2992/gene/ZFIN:ZDB-GENE-991019-3#alleles-and-variants
  // az2
  // http://localhost:2992/allele/ZFIN:ZDB-ALT-181010-2
```
