### PR TITLE
AGR-1946 Handle nulls in variant consequence

### DIFF
--- a/src/containers/allelePage/AlleleToVariantTable.js
+++ b/src/containers/allelePage/AlleleToVariantTable.js
@@ -49,7 +49,7 @@ const AlleleToVariantTable = ({alleleId, fetchVariants, variants}) => {
     {
       dataField: 'consequence',
       text: 'Most severe consequence',
-      formatter: (term = '') => term.replace(/_/g, ' '),
+      formatter: term => term && term.replace(/_/g, ' '),
       headerStyle: {width: '150px'},
     },
   ];


### PR DESCRIPTION
@sibyl229 I like the default parameter syntax but I guess it only works when the value is `undefined`? So to handle `null` values I guess we just need old fashioned boolean-style checking.