### PR TITLE
round two of variant fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1620,9 +1620,9 @@
       }
     },
     "agr_genomefeaturecomponent": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.2.19.tgz",
-      "integrity": "sha512-JJnnEJfP7gxq98xgZ0OyLrjdsy+PGYa+XKrONrHdbQgX27BDBfmthBjbMZbH5UOykkwlehMs61tVyYqh9ju68g==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.2.20.tgz",
+      "integrity": "sha512-tYWKVSBZ97+aE0v8H1vp40YaLStFk4XXPquYuOlAMlz+Q2kxU2EATf6ILKw2T4sZZKkDck97cR/TYQ1uCUTJ0Q==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "d3-axis": "^1.0.8",
     "d3-scale": "^1.0.6",
     "d3-selection": "^1.1.0",
-    "agr_genomefeaturecomponent": "^0.2.19",
+    "agr_genomefeaturecomponent": "^0.2.20",
     "html-react-parser": "^0.10.0",
     "immutable": "^3.8.1",
     "isomorphic-fetch": "^2.2.1",

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -148,7 +148,7 @@ class GenomeFeatureWrapper extends Component {
   }
 
   render() {
-    const {assembly, chromosome, fmin, fmax, id, strand} = this.props;
+    const {assembly, chromosome, fmin, fmax, id, strand, displayType} = this.props;
     const lengthValue = numeral((fmax - fmin) / 1000.0).format('0,0.00');
 
     return (
@@ -172,10 +172,15 @@ class GenomeFeatureWrapper extends Component {
               <LoadingSpinner/>
             </svg>
           </div>
-          <span className='mr-1'>Variant Types and Consequences</span>
-          <HelpPopup id='variant-legend' placement='bottom-start' popperClassName={style.variantLegendPopper}>
-            <span dangerouslySetInnerHTML={{__html: this.helpText}}/>
-          </HelpPopup>
+          {displayType === 'ISOFORM_AND_VARIANT' &&
+          <div>
+            <span className='mr-1'>Variant Types and Consequences</span>
+            <HelpPopup id='variant-legend' placement='bottom-start'
+              popperClassName={style.variantLegendPopper} >
+              <span dangerouslySetInnerHTML={{__html: this.helpText}}/>
+            </HelpPopup>
+          </div>
+          }
           {this.state.loadState === 'error' ?
             <div className='text-danger'>Unable to retrieve data</div> : ''}
         </HorizontalScroll>


### PR DESCRIPTION
https://agr-jira.atlassian.net/browse/AGR-2016

- [x] variant legend only showing up if variants present
- ~~should have an unknown (black?) and other (?) in the legend~~ (I checked and these were all good as AFAICT)
- [x] should flag 3_prime (versus three_prime) and 5_prime
- [x] when hovering over the things with the same number they both highlight: https://stage.alliancegenome.org/gene/FB:FBgn0002936#alleles-and-variants (small error)
- [x] remove console.log() from LegendService
- ~~make allele of genes unique~~ I think we agreed that this should be done later.

--- 


- ~~pair consequences and impact~~



![image](https://user-images.githubusercontent.com/751274/75814493-b12f9180-5d46-11ea-9048-4fe4ddf6acb8.png)
