### PR TITLE
AGR-1928: integrating the ribbon web component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1309,6 +1309,19 @@
         "react-transition-group": "^2.3.1"
       }
     },
+    "@geneontology/wc-ribbon-strips": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.14.tgz",
+      "integrity": "sha512-4XkLnrf0XhBHwVaV5vdMGOrzXMI0c8HdjGv0+wX+GVVlksG23X+zpNKwhI1KKhYZEXrSB5wx8mO2avdDnI0ydA==",
+      "requires": {
+        "@geneontology/wc-spinner": "0.0.2"
+      }
+    },
+    "@geneontology/wc-spinner": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-spinner/-/wc-spinner-0.0.2.tgz",
+      "integrity": "sha512-LUbE3DvgxtXcLokPMtY+ex5i02chSA+V3XLbCJgSVxExvdyhy3ZK55mI+ojSnXkRTQHRHitzniAhs+DkhZ4JgQ=="
+    },
     "@iamstarkov/listr-update-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,9 +1310,9 @@
       }
     },
     "@geneontology/wc-ribbon-strips": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.14.tgz",
-      "integrity": "sha512-4XkLnrf0XhBHwVaV5vdMGOrzXMI0c8HdjGv0+wX+GVVlksG23X+zpNKwhI1KKhYZEXrSB5wx8mO2avdDnI0ydA==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.16.tgz",
+      "integrity": "sha512-R1pVJBnSCelQmYIyOQp+lYqvD/X3O+xJdue/96mm23hvm8hXLbUl3le1UHfqL13NrtCtPhzATGoNEb9qradFcQ==",
       "requires": {
         "@geneontology/wc-spinner": "0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
+    "@geneontology/wc-ribbon-strips": "0.0.14",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.2.29",
     "bootstrap": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
-    "@geneontology/wc-ribbon-strips": "0.0.14",
+    "@geneontology/wc-ribbon-strips": "0.0.16",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.2.29",
     "bootstrap": "4.3.1",

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -81,3 +81,20 @@ $ribbon-strip-tile-border-radius: 0px;
     box-sizing: content-box;
   }
 }
+
+.ribbon__category--cell, .ribbon__subject--cell, .ribbon__subject--cell--no-annotation, .ribbon__subject__label--link, tr, th, td {
+  font-size: 14px !important;
+  line-height: 1.0 !important;
+}
+
+.ribbon__subject--cell {
+  box-shadow: 0 1px 1px rgba(0,0,0,.26);            
+}
+
+.ribbon__category--cell:hover {
+  font-weight: 800 !important;
+}
+
+.wc-ribbon-cell, wc-ribbon-subject, wc-ribbon-strips {
+  line-height: 1.0 !important;
+}

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -139,7 +139,7 @@ class DiseaseComparisonRibbon extends Component {
         </div>
 
         <HorizontalScroll>
-          <div className='text-nowrap' style={{'width' : '1100px' }} >
+          <div className='text-nowrap'>
             {
               summary.loading ? <LoadingSpinner /> :
                 <wc-ribbon-strips 

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -151,6 +151,7 @@ class DiseaseComparisonRibbon extends Component {
                   group-open-new-tab={false}
                   id='disease-ribbon'
                   new-tab={false}
+                  selected='all'
                   selection-mode={SELECTION.COLUMN}
                   subject-base-url='/gene/'
                   subject-open-new-tab={false}

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -159,6 +159,9 @@ class DiseaseComparisonRibbon extends Component {
             }
           </div>
           <div>{summary.loading && <LoadingSpinner />}</div>
+          <div className='text-muted mt-2'>
+            <i>Cell color indicative of annotation volume</i>
+          </div>
         </HorizontalScroll>
 
 

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -56,19 +56,17 @@ class DiseaseComparisonRibbon extends Component {
       }));
 
     document.addEventListener('cellClick', this.onGroupClicked);
-
   }
-
-  componentWillUnmount() {
-    document.removeEventListener('cellClick', this.onGroupClicked);
-  }
-
 
   componentDidUpdate(prevProps, prevState) {
     if (this.props.geneId !== prevProps.geneId ||
       !isEqual(this.state.selectedOrthologs, prevState.selectedOrthologs)) {
       this.fetchData();
     }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('cellClick', this.onGroupClicked);
   }
 
   fetchData() {
@@ -84,7 +82,10 @@ class DiseaseComparisonRibbon extends Component {
   }
 
   onGroupClicked(e) {
-    this.onDiseaseGroupClicked(e.detail.subjects, e.detail.group);
+    // to ensure we are only considering events coming from the disease ribbon
+    if(e.target.id == 'disease-ribbon') {
+      this.onDiseaseGroupClicked(e.detail.subjects, e.detail.group);
+    }
   }
 
   onDiseaseGroupClicked(gene, disease) {
@@ -148,6 +149,7 @@ class DiseaseComparisonRibbon extends Component {
                   data={JSON.stringify(summary.data)}
                   group-clickable={false}
                   group-open-new-tab={false}
+                  id='disease-ribbon'
                   new-tab={false}
                   selection-mode={SELECTION.COLUMN}
                   subject-base-url='/gene/'

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -14,7 +14,6 @@ import HorizontalScroll from '../horizontalScroll';
 import { STRINGENCY_HIGH } from '../orthology/constants';
 import { getOrthologId } from '../orthology';
 
-import { SELECTION, POSITION, COLOR_BY, FONT_STYLE } from '@geneontology/wc-ribbon-strips/dist/collection/globals/enums';
 import HelpPopup from '../helpPopup';
 import DiseaseControlsHelp from './diseaseControlsHelp';
 import ControlsContainer from '../controlsContainer';
@@ -144,18 +143,18 @@ class DiseaseComparisonRibbon extends Component {
             {
               summary.loading ? <LoadingSpinner /> :
                 <wc-ribbon-strips 
-                  category-all-style={FONT_STYLE.BOLD}
-                  color-by={COLOR_BY.CLASS_COUNT}
+                  category-all-style='1'
+                  color-by='0'
                   data={JSON.stringify(summary.data)}
                   group-clickable={false}
                   group-open-new-tab={false}
                   id='disease-ribbon'
                   new-tab={false}
                   selected='all'
-                  selection-mode={SELECTION.COLUMN}
+                  selection-mode='1'
                   subject-base-url='/gene/'
                   subject-open-new-tab={false}
-                  subject-position={POSITION.LEFT}
+                  subject-position='1'
                 />
             }
           </div>

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -142,7 +142,7 @@ class ExpressionComparisonRibbon extends React.Component {
 
 
         <HorizontalScroll>
-          <div className='text-nowrap' style={{'width' : '1100px' }} >
+          <div className='text-nowrap'>
             {
               summary.loading ? <LoadingSpinner /> :
                 <wc-ribbon-strips 

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -15,10 +15,9 @@ import ExpressionControlsHelp from './expressionControlsHelp';
 import OrthologPicker from '../OrthologPicker';
 import { selectExpressionRibbonSummary } from '../../selectors/expressionSelectors';
 import { fetchExpressionRibbonSummary } from '../../actions/expression';
-import { GenericRibbon } from '@geneontology/ribbon';
-import { POSITION, COLOR_BY, SELECTION } from '@geneontology/ribbon/lib/enums';
+
+import { SELECTION, POSITION, COLOR_BY, FONT_STYLE } from '@geneontology/wc-ribbon-strips/dist/collection/globals/enums';
 import LoadingSpinner from '../loadingSpinner';
-import RibbonGeneSubjectLabel from '../RibbonGeneSubjectLabel';
 
 class ExpressionComparisonRibbon extends React.Component {
   constructor(props) {
@@ -32,11 +31,13 @@ class ExpressionComparisonRibbon extends React.Component {
       }
     };
     this.handleOrthologChange = this.handleOrthologChange.bind(this);
-    this.updateSelectedBlock = this.updateSelectedBlock.bind(this);
+    this.onExpressionGroupClicked = this.onExpressionGroupClicked.bind(this);
+    this.onGroupClicked = this.onGroupClicked.bind(this);
   }
 
   componentDidMount() {
     this.dispatchFetchSummary();
+    document.addEventListener('cellClick', this.onGroupClicked);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -44,6 +45,10 @@ class ExpressionComparisonRibbon extends React.Component {
     if (prevProps.geneId !== geneId || !isEqual(prevState.selectedOrthologs, this.state.selectedOrthologs)) {
       this.dispatchFetchSummary();
     }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('cellClick', this.onGroupClicked);
   }
 
   dispatchFetchSummary() {
@@ -58,7 +63,14 @@ class ExpressionComparisonRibbon extends React.Component {
     this.setState({selectedOrthologs: values});
   }
 
-  updateSelectedBlock(gene, term) {
+  onGroupClicked(e) {
+    // to ensure we are only considering events coming from the disease ribbon
+    if(e.target.id == 'expression-ribbon') {
+      this.onExpressionGroupClicked(e.detail.subjects, e.detail.group);
+    }
+  }
+
+  onExpressionGroupClicked(gene, term) {
     this.setState(state => {
       const current = state.selectedBlock;
       return {
@@ -71,7 +83,7 @@ class ExpressionComparisonRibbon extends React.Component {
   }
 
   render() {
-    const { geneId, geneTaxon, orthology, summary } = this.props;
+    const { geneTaxon, orthology, summary } = this.props;
     const { selectedOrthologs, selectedBlock } = this.state;
 
     // const genes = [geneId].concat(selectedOrthologs.map(o => getOrthologId(o)));
@@ -100,6 +112,9 @@ class ExpressionComparisonRibbon extends React.Component {
       category.id.startsWith('UBERON:')
     ));
 
+    let updatedSummary = summary.data;
+    updatedSummary.categories = categories;
+
     const genesWithData = orthology.supplementalData && Object.entries(orthology.supplementalData)
       .reduce((prev, [geneId, data]) => ({...prev, [geneId]: data.hasExpressionAnnotations}), {});
 
@@ -125,20 +140,26 @@ class ExpressionComparisonRibbon extends React.Component {
           </ControlsContainer>
         </div>
 
+
+
         <HorizontalScroll>
-          <div className='text-nowrap'>
-            <GenericRibbon
-              categories={categories}
-              colorBy={COLOR_BY.CLASS_COUNT}
-              hideFirstSubjectLabel
-              itemClick={this.updateSelectedBlock}
-              newTab={false}
-              selected={selectedBlock}
-              selectionMode={SELECTION.COLUMN}
-              subjectLabel={subject => <RibbonGeneSubjectLabel gene={subject} isFocusGene={subject.id === geneId} />}
-              subjectLabelPosition={POSITION.LEFT}
-              subjects={summary.data.subjects}
-            />
+          <div className='text-nowrap' style={{'width' : '1100px' }} >
+            {
+              summary.loading ? <LoadingSpinner /> :
+                <wc-ribbon-strips 
+                  category-all-style={FONT_STYLE.BOLD}
+                  color-by={COLOR_BY.CLASS_COUNT}
+                  data={JSON.stringify(updatedSummary)}
+                  group-clickable={false}
+                  group-open-new-tab={false}
+                  id='expression-ribbon'
+                  new-tab={false}
+                  selection-mode={SELECTION.COLUMN}
+                  subject-base-url='/gene/'
+                  subject-open-new-tab={false}
+                  subject-position={POSITION.LEFT}
+                />
+            }
           </div>
           <div>{summary.loading && <LoadingSpinner />}</div>
           <div className='text-muted mt-2'>

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -16,7 +16,6 @@ import OrthologPicker from '../OrthologPicker';
 import { selectExpressionRibbonSummary } from '../../selectors/expressionSelectors';
 import { fetchExpressionRibbonSummary } from '../../actions/expression';
 
-import { SELECTION, POSITION, COLOR_BY, FONT_STYLE } from '@geneontology/wc-ribbon-strips/dist/collection/globals/enums';
 import LoadingSpinner from '../loadingSpinner';
 
 class ExpressionComparisonRibbon extends React.Component {
@@ -147,17 +146,17 @@ class ExpressionComparisonRibbon extends React.Component {
             {
               summary.loading ? <LoadingSpinner /> :
                 <wc-ribbon-strips 
-                  category-all-style={FONT_STYLE.BOLD}
-                  color-by={COLOR_BY.CLASS_COUNT}
+                  category-all-style='1'
+                  color-by='0'
                   data={JSON.stringify(updatedSummary)}
                   group-clickable={false}
                   group-open-new-tab={false}
                   id='expression-ribbon'
                   new-tab={false}
-                  selection-mode={SELECTION.COLUMN}
+                  selection-mode='1'
                   subject-base-url='/gene/'
                   subject-open-new-tab={false}
-                  subject-position={POSITION.LEFT}
+                  subject-position='1'
                 />
             }
           </div>

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ import './style.scss';
 
 import ReactApp from './reactApplication';
 
+import { applyPolyfills, defineCustomElements } from '@geneontology/wc-ribbon-strips/loader';
+
 analytics.initialize();
 
 render(
@@ -24,3 +26,7 @@ render(
 if (module.hot) {
   module.hot.accept();
 }
+
+applyPolyfills().then(() => {
+  defineCustomElements(window);
+});


### PR DESCRIPTION
This PR allows the usage of the ribbon web component in both expression and disease ribbons. Aside from ticket 1928, this should take care of : AGR-1565, AGR-1253, AGR-1902. Once the GO ribbon is also integrated (later PR), this will also solve AGR-1471, AGR-1093 and AGR-2000.

**Notes**:
* ~~the “all annotations” selection on startup for disease is not yet working~~
* subjectFocus: the main gene was shown in bold in the previous ribbon, have to reintroduced this capability
* hideFirstSubject: this was used in the old ribbon to show/hide the subject label when only a single gene was shown
* empty cells have a cursor stating not-allowed but under the hood, if one click on that empty cell, an event is still triggered - will correct that at the ribbon level code
