### PR TITLE
Fix ribbon routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,9 +1310,9 @@
       }
     },
     "@geneontology/wc-ribbon-strips": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.16.tgz",
-      "integrity": "sha512-R1pVJBnSCelQmYIyOQp+lYqvD/X3O+xJdue/96mm23hvm8hXLbUl3le1UHfqL13NrtCtPhzATGoNEb9qradFcQ==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.18.tgz",
+      "integrity": "sha512-OthRvfc20Ac5PLt4LukYTp+2zYfM1gxk4v7Eb8DybX26CTcCyDZCgiX1T5KIHb0PvaaAFHqKVhRjV37YXZzNAA==",
       "requires": {
         "@geneontology/wc-spinner": "0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
-    "@geneontology/wc-ribbon-strips": "0.0.16",
+    "@geneontology/wc-ribbon-strips": "0.0.18",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.2.29",
     "bootstrap": "4.3.1",

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -23,6 +23,8 @@ import { fetchDiseaseRibbonSummary } from '../../actions/diseaseRibbonActions';
 import LoadingSpinner from '../loadingSpinner';
 import OrthologPicker from '../OrthologPicker';
 
+import { withRouter } from 'react-router-dom';
+
 class DiseaseComparisonRibbon extends Component {
 
   constructor(props){
@@ -38,6 +40,7 @@ class DiseaseComparisonRibbon extends Component {
     this.onDiseaseGroupClicked = this.onDiseaseGroupClicked.bind(this);
     this.handleOrthologyChange = this.handleOrthologyChange.bind(this);
     this.onGroupClicked = this.onGroupClicked.bind(this);
+    this.onSubjectClicked = this.onSubjectClicked.bind(this);
   }
 
   componentDidMount() {
@@ -55,6 +58,7 @@ class DiseaseComparisonRibbon extends Component {
       }));
 
     document.addEventListener('cellClick', this.onGroupClicked);
+    document.addEventListener('subjectClick', this.onSubjectClicked);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -78,6 +82,28 @@ class DiseaseComparisonRibbon extends Component {
 
   getGeneIdList() {
     return [this.props.geneId].concat(this.state.selectedOrthologs.map(getOrthologId));
+  }
+
+  hasParentElementId(elt, id) {
+    if(elt.id == id)
+      return true;
+    if(!elt.parentElement)
+      return false;
+    return this.hasParentElementId(elt.parentElement, id);
+  }
+
+  onSubjectClicked(e) {
+    // to ensure we are only considering events coming from the disease ribbon
+    if(this.hasParentElementId(e.target, 'disease-ribbon')) {
+      // don't use the ribbon default action upon subject click
+      e.detail.originalEvent.preventDefault();
+
+      // but re-route to alliance gene page
+      let { history } = this.props;
+      history.push({
+        pathname: '/gene/' + e.detail.subject.id
+      });
+    }
   }
 
   onGroupClicked(e) {
@@ -193,4 +219,4 @@ const mapStateToProps = (state) => ({
   summary: selectDiseaseRibbonSummary(state),
 });
 
-export default connect(mapStateToProps)(DiseaseComparisonRibbon);
+export default withRouter(connect(mapStateToProps)(DiseaseComparisonRibbon));

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -210,6 +210,7 @@ DiseaseComparisonRibbon.propTypes = {
   geneId: PropTypes.string,
   geneSymbol: PropTypes.string,
   geneTaxon: PropTypes.string,
+  history: PropTypes.object,
   orthology: PropTypes.object,
   summary: PropTypes.object
 };

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -16,6 +16,8 @@ import OrthologPicker from '../OrthologPicker';
 import { selectExpressionRibbonSummary } from '../../selectors/expressionSelectors';
 import { fetchExpressionRibbonSummary } from '../../actions/expression';
 
+import { withRouter } from 'react-router-dom';
+
 import LoadingSpinner from '../loadingSpinner';
 
 class ExpressionComparisonRibbon extends React.Component {
@@ -32,11 +34,13 @@ class ExpressionComparisonRibbon extends React.Component {
     this.handleOrthologChange = this.handleOrthologChange.bind(this);
     this.onExpressionGroupClicked = this.onExpressionGroupClicked.bind(this);
     this.onGroupClicked = this.onGroupClicked.bind(this);
+    this.onSubjectClicked = this.onSubjectClicked.bind(this);
   }
 
   componentDidMount() {
     this.dispatchFetchSummary();
     document.addEventListener('cellClick', this.onGroupClicked);
+    document.addEventListener('subjectClick', this.onSubjectClicked);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -60,6 +64,28 @@ class ExpressionComparisonRibbon extends React.Component {
 
   handleOrthologChange(values) {
     this.setState({selectedOrthologs: values});
+  }
+
+  hasParentElementId(elt, id) {
+    if(elt.id == id)
+      return true;
+    if(!elt.parentElement)
+      return false;
+    return this.hasParentElementId(elt.parentElement, id);
+  }
+
+  onSubjectClicked(e) {
+    // to ensure we are only considering events coming from the disease ribbon
+    if(this.hasParentElementId(e.target, 'expression-ribbon')) {
+      // don't use the ribbon default action upon subject click
+      e.detail.originalEvent.preventDefault();
+
+      // but re-route to alliance gene page
+      let { history } = this.props;
+      history.push({
+        pathname: '/gene/' + e.detail.subject.id
+      });
+    }
   }
 
   onGroupClicked(e) {
@@ -155,7 +181,7 @@ class ExpressionComparisonRibbon extends React.Component {
                   new-tab={false}
                   selection-mode='1'
                   subject-base-url='/gene/'
-                  subject-open-new-tab={false}
+                  subject-open-new-tab={true}
                   subject-position='1'
                 />
             }
@@ -190,4 +216,4 @@ const mapStateToProps = state => ({
   summary: selectExpressionRibbonSummary(state),
 });
 
-export default connect(mapStateToProps)(ExpressionComparisonRibbon);
+export default withRouter(connect(mapStateToProps)(ExpressionComparisonRibbon));

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -181,7 +181,7 @@ class ExpressionComparisonRibbon extends React.Component {
                   new-tab={false}
                   selection-mode='1'
                   subject-base-url='/gene/'
-                  subject-open-new-tab={true}
+                  subject-open-new-tab={false}
                   subject-position='1'
                 />
             }
@@ -207,6 +207,7 @@ ExpressionComparisonRibbon.propTypes = {
   geneId: PropTypes.string.isRequired,
   geneSymbol: PropTypes.string.isRequired,
   geneTaxon: PropTypes.string.isRequired,
+  history: PropTypes.object,
   orthology: PropTypes.object,
   summary: PropTypes.object,
 };


### PR DESCRIPTION
As requested, this version preventDefault() of the anchor tag and use react router to reroute to the correct alliance page, to avoid page reload.

@paaatrick If you wish, feel free to use other react router functionality.