### PR TITLE
Fix-ribbon-click-on-empty-cells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,9 +1310,9 @@
       }
     },
     "@geneontology/wc-ribbon-strips": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.18.tgz",
-      "integrity": "sha512-OthRvfc20Ac5PLt4LukYTp+2zYfM1gxk4v7Eb8DybX26CTcCyDZCgiX1T5KIHb0PvaaAFHqKVhRjV37YXZzNAA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.19.tgz",
+      "integrity": "sha512-p0fJzx7vswAFog7vtQbL3sCOrPKja8fy5aPs++owssUxnkglbcmzzC6toVpVjCPeNcxnB9Sqk4juKZAXWNGtlg==",
       "requires": {
         "@geneontology/wc-spinner": "0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
-    "@geneontology/wc-ribbon-strips": "0.0.18",
+    "@geneontology/wc-ribbon-strips": "0.0.19",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.2.29",
     "bootstrap": "4.3.1",

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -172,6 +172,7 @@ class DiseaseComparisonRibbon extends Component {
                   category-all-style='1'
                   color-by='0'
                   data={JSON.stringify(summary.data)}
+                  fire-event-on-empty-cells={false}
                   group-clickable={false}
                   group-open-new-tab={false}
                   id='disease-ribbon'

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -175,6 +175,7 @@ class ExpressionComparisonRibbon extends React.Component {
                   category-all-style='1'
                   color-by='0'
                   data={JSON.stringify(updatedSummary)}
+                  fire-event-on-empty-cells={false}
                   group-clickable={false}
                   group-open-new-tab={false}
                   id='expression-ribbon'


### PR DESCRIPTION
I added a parameter to prevent an event to be fired on empty cells.

The current behavior differs depending of the selection mode.

If selection mode == cell (go ribbon), no event will be fired on empty cells
If selection mode == column (disease & expression ribbons), an event will be fired if at least one cell of the column has annotations