### PR TITLE
AGR-2204 Prevent scroll indicators from interfering with sort dropdown

### DIFF
--- a/src/components/dataTable/remoteDataTable.js
+++ b/src/components/dataTable/remoteDataTable.js
@@ -157,7 +157,7 @@ class RemoteDataTable extends Component {
                     null
                 }
                 {sortOptions && sortOptions.length > 0 &&
-                  <Form className='pull-right' inline>
+                  <Form className='d-flex justify-content-end' inline>
                     <Label className="mr-1">Sort by</Label>
                     <Input onChange={this.handleSortChange} type='select' value={sort || ''}>
                       <option value=''>Default</option>

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -16,7 +16,7 @@ import VariantsSequenceViewer from './VariantsSequenceViewer';
 const AlleleTable = ({alleles, dispatchFetchAlleles, gene, geneId, geneSymbol, geneLocation = {}, species, geneDataProvider}) => {
 
   const variantNameColWidth = 300;
-  const variantTypeColWidth = 150;
+  const variantTypeColWidth = 110;
   const variantConsequenceColWidth = 150;
 
   const columns = [
@@ -69,7 +69,7 @@ const AlleleTable = ({alleles, dispatchFetchAlleles, gene, geneId, geneSymbol, g
           ))}
         </CollapsibleList>
       ),
-      headerStyle: {width: '275px'},
+      headerStyle: {width: '200px'},
       filterable: true,
       filterName: 'phenotype',
     },


### PR DESCRIPTION
I also squeezed the alleles table a little so that it doesn't overflow at the maximum viewport width