### PR TITLE
Fix ribbon strips update when nb annotations =0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1315,9 +1315,9 @@
       }
     },
     "@geneontology/wc-ribbon-strips": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.24.tgz",
-      "integrity": "sha512-Duid2XKi2/zv18Un1t92j1RYIpLXptYPSBoN1e3nRjvNtisED69sW4w2ry21wLRR5DvMeh02pHkfmrRdATNh5Q==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.25.tgz",
+      "integrity": "sha512-I7ajr5uRpM4BcXHzgd+9QSOZJxfjA8qdQm2+ri7WmGD1dkQVQR+v/exLRRe5YGLMzWkB9KCBjWxjZDbrG8BwCQ==",
       "requires": {
         "@geneontology/wc-spinner": "0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
-    "@geneontology/wc-ribbon-strips": "0.0.24",
+    "@geneontology/wc-ribbon-strips": "0.0.25",
     "@geneontology/wc-ribbon-table": "0.0.41",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.3.2",


### PR DESCRIPTION
I noticed that when clicking on "show only experimental annotations", the background color of the cells without annotation were not updated; I fixed it on ribbon code and this is just an update of the package to use.

https://github.com/geneontology/wc-ribbon/commit/35803c1545199f2a0b3b81e5175ff3361730c182