### PR TITLE
AGR-2162 vep round 5

### DIFF
--- a/src/components/dataTable/remoteDataTable.js
+++ b/src/components/dataTable/remoteDataTable.js
@@ -87,7 +87,7 @@ class RemoteDataTable extends Component {
   }
 
   render() {
-    const { columns, data = [], downloadUrl, keyField, loading, noDataMessage, sortOptions, summaryProps, totalRows, ...bootstrapTableProps } = this.props;
+    const { columns, data = [], downloadUrl, keyField, loading, noDataMessage, sortOptions, summaryProps, totalRows, className, ...bootstrapTableProps } = this.props;
     const { filters, page, sizePerPage, sort } = this.state;
 
     if (!loading && filters == null && totalRows === 0) {
@@ -145,7 +145,7 @@ class RemoteDataTable extends Component {
     });
 
     return (
-      <div ref={this.containerRef} style={{position: 'relative'}}>
+      <div className={className} ref={this.containerRef} style={{position: 'relative'}}>
         <LoadingOverlay loading={loading} />
         <PaginationProvider pagination={pagination}>
           {
@@ -206,6 +206,7 @@ class RemoteDataTable extends Component {
 }
 
 RemoteDataTable.propTypes = {
+  className: PropTypes.string,
   columns: PropTypes.array,
   data: PropTypes.arrayOf(PropTypes.object),
   downloadUrl: PropTypes.string,

--- a/src/containers/allelePage/AlleleMolecularConsequences.js
+++ b/src/containers/allelePage/AlleleMolecularConsequences.js
@@ -9,11 +9,11 @@ import LoadingSpinner from '../../components/loadingSpinner';
 import NoData from '../../components/noData';
 import { VariantJBrowseLink } from '../../components/variant';
 import VariantToTranscriptTable from './VariantToTranscriptTable';
-import VariantToTranscriptDetails from './VariantToTranscriptDetails';
+// import VariantToTranscriptDetails from './VariantToTranscriptDetails';
 import useAlleleVariant from './useAlleleVariants';
 import style from './style.scss';
 
-const MOLECULAR_CONSEQUENCE_DETAILS = 'Genomic Variants Molecular Consequences Details';
+// const MOLECULAR_CONSEQUENCE_DETAILS = 'Genomic Variants Molecular Consequences Details';
 
 const AlleleMolecularConsequences = ({
   alleleId,
@@ -56,18 +56,6 @@ const AlleleMolecularConsequences = ({
               </AttributeList>
               <VariantToTranscriptTable variant={variant} />
             </div>
-          );
-        })
-      }
-      <br />
-      <h4>{MOLECULAR_CONSEQUENCE_DETAILS}</h4>
-      {
-        variants.map((variant) => {
-          const {id: variantId} = variant;
-          return (
-            <React.Fragment key={`consequnce-details-${variantId}`}>
-              <VariantToTranscriptDetails variant={variant} />
-            </React.Fragment>
           );
         })
       }

--- a/src/containers/allelePage/Translation.js
+++ b/src/containers/allelePage/Translation.js
@@ -85,7 +85,7 @@ const Translation = ({
   cdsStartPosition: cdsStartPositionRaw,
   cdsEndPosition: cdsEndPositionRaw,
 
-  maxAminoAcidsPerRow = 5,
+  maxAminoAcidsPerRow = 10,
 
   title,
 

--- a/src/containers/allelePage/Translation.js
+++ b/src/containers/allelePage/Translation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Position from './Position';
+// import Position from './Position';
 import translationStyles from './translation.scss';
 
 const TranslationRow = ({
@@ -23,7 +23,7 @@ const TranslationRow = ({
         {
           isReference && codons.length ?
             <td className={translationStyles.position}>
-              <Position end={cdsEndPosition} start={cdsStartPosition} />
+              {cdsStartPosition ? cdsStartPosition : 'N/A'}
             </td> :
             null
         }
@@ -32,12 +32,19 @@ const TranslationRow = ({
             <span className={translationStyles.codon} key={index}>{codon}</span>
           ))}
         </td>
+        {
+          isReference && codons.length ?
+            <td className={translationStyles.position}>
+              {cdsEndPosition ? cdsEndPosition : 'N/A'}
+            </td> :
+            null
+        }
       </tr>
       <tr className={translationStyles.aminoAcidRow}>
         {
           isReference && aminoAcids.length ?
             <td className={translationStyles.position}>
-              [<Position end={proteinEndPosition} start={proteinStartPosition} />]
+              [{proteinStartPosition ? proteinStartPosition : 'N/A'}]
             </td> :
             null
         }
@@ -47,6 +54,13 @@ const TranslationRow = ({
           ))}
           {isFrameshift ? <span className="badge badge-secondary">frameshift</span> : null}
         </td>
+        {
+          isReference && aminoAcids.length ?
+            <td className={translationStyles.position}>
+              [{proteinEndPosition ? proteinEndPosition : 'N/A'}]
+            </td> :
+            null
+        }
       </tr>
     </>
   );

--- a/src/containers/allelePage/VariantEffectDetails.js
+++ b/src/containers/allelePage/VariantEffectDetails.js
@@ -106,7 +106,7 @@ const VariantEffectDetails = ({
       <AttributeValue>
         {
           codonVariation ? (
-            <div className="row container">
+            <div className="row container flex-nowrap">
               <div className='col'>
                 <Translation
                   aminoAcids={aminoAcidReference.split('')}

--- a/src/containers/allelePage/VariantToTranscriptTable.js
+++ b/src/containers/allelePage/VariantToTranscriptTable.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { RemoteDataTable } from '../../components/dataTable';
 import { CollapsibleList } from '../../components/collapsibleList';
 import Translation from './Translation';
+import VariantEffectDetails from './VariantEffectDetails';
 import useVariantTranscripts from './useVariantTranscripts';
 import styles from './style.scss';
 
@@ -141,9 +142,20 @@ const VariantToTranscriptTable = ({variant}) => {
   ];
 
   const expandRow = {
-    renderer: () => (
-      <div>....</div>
-    ),
+    renderer: (row) => {
+      const {
+        consequences = [],
+        ...transcript
+      } = row;
+      return consequences.map((consequence, index) => (
+        <VariantEffectDetails
+          consequence={consequence}
+          key={`${transcript.id}-${index}`}
+          transcript={transcript}
+          variant={variant}
+        />
+      ));
+    },
     showExpandColumn: true,
     expandByColumnOnly: true,
   };

--- a/src/containers/allelePage/VariantToTranscriptTable.js
+++ b/src/containers/allelePage/VariantToTranscriptTable.js
@@ -100,7 +100,7 @@ const VariantToTranscriptTable = ({variant}) => {
                       {
                         codonVariation ? (
                           <div className="row flex-nowrap">
-                            <div className='col-7'>
+                            <div className='col'>
                               <Translation
                                 aminoAcids={aminoAcidReference.split('')}
                                 cdsEndPosition={cdsEndPosition}
@@ -111,10 +111,10 @@ const VariantToTranscriptTable = ({variant}) => {
                                 proteinStartPosition={proteinStartPosition}
                               />
                             </div>
-                            <div className='col' style={{textAlign: 'center', alignSelf: 'center'}}>
+                            <div className='col-1' style={{textAlign: 'center', alignSelf: 'center'}}>
                               {codonVariation ? '=>' : null}
                             </div>
-                            <div className='col-4'>
+                            <div className='col'>
                               <Translation aminoAcids={aminoAcidVariation.split('')} codons={codonVariation.split('')} />
                             </div>
                           </div>

--- a/src/containers/allelePage/VariantToTranscriptTable.js
+++ b/src/containers/allelePage/VariantToTranscriptTable.js
@@ -98,7 +98,7 @@ const VariantToTranscriptTable = ({variant}) => {
                     <div className='col-9'>
                       {
                         codonVariation ? (
-                          <div className="row">
+                          <div className="row flex-nowrap">
                             <div className='col-7'>
                               <Translation
                                 aminoAcids={aminoAcidReference.split('')}
@@ -140,11 +140,20 @@ const VariantToTranscriptTable = ({variant}) => {
     },
   ];
 
+  const expandRow = {
+    renderer: () => (
+      <div>....</div>
+    ),
+    showExpandColumn: true,
+    expandByColumnOnly: true,
+  };
+
   return (<>
     <RemoteDataTable
       columns={columns}
       data={data}
       // downloadUrl={`/api/allele/${alleleId}/variants/download`}
+      expandRow={expandRow}
       keyField='id'
       loading={loading}
       noDataMessage='No variant effect information available'

--- a/src/containers/allelePage/VariantToTranscriptTable.js
+++ b/src/containers/allelePage/VariantToTranscriptTable.js
@@ -141,6 +141,22 @@ const VariantToTranscriptTable = ({variant}) => {
     },
   ];
 
+  const ExpandIndicator = ({ expanded }) => (
+    <button className="btn btn-link btn-sm" type="button">{expanded ? 'Hide details' : 'Show details'}</button>
+  );
+
+  ExpandIndicator.propTypes = {
+    expanded: PropTypes.bool,
+  };
+
+  const ExpandAllIndicator = ({ isAnyExpands }) => (
+    <button className="btn btn-link btn-sm" type="button">{isAnyExpands ? 'Hide all details' : 'Show all details'}</button>
+  );
+
+  ExpandAllIndicator.propTypes = {
+    isAnyExpands: PropTypes.bool,
+  };
+
   const expandRow = {
     renderer: (row) => {
       const {
@@ -158,10 +174,17 @@ const VariantToTranscriptTable = ({variant}) => {
     },
     showExpandColumn: true,
     expandByColumnOnly: true,
+    expandHeaderColumnRenderer: ({ isAnyExpands }) => { // eslint-disable-line react/prop-types
+      return <ExpandAllIndicator isAnyExpands={isAnyExpands} />;
+    },
+    expandColumnRenderer: ({ expanded }) => { // eslint-disable-line react/prop-types
+      return <ExpandIndicator expanded={expanded} />;
+    },
   };
 
   return (<>
     <RemoteDataTable
+      className={styles.variantToTranscriptTable}
       columns={columns}
       data={data}
       // downloadUrl={`/api/allele/${alleleId}/variants/download`}

--- a/src/containers/allelePage/style.scss
+++ b/src/containers/allelePage/style.scss
@@ -1,10 +1,15 @@
 .row {
   padding: 0.5em 0;
   border-bottom: 1px solid #eee;
-}
 
-.row:last-child {
-  border-bottom: none;
+  &:first-child {
+    padding-top: 0;
+  }
+
+  &:last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+  }
 }
 
 .detailRow {

--- a/src/containers/allelePage/style.scss
+++ b/src/containers/allelePage/style.scss
@@ -8,7 +8,8 @@
 }
 
 .detailRow {
-  margin: 1em;
+  padding: 1em;
+  border-left: 4px solid #eee;
 }
 
 
@@ -18,4 +19,10 @@
 
 .attributeList {
   margin: 0;
+}
+
+.variantToTranscriptTable {
+  :global(.react-bootstrap-table th[data-row-selection]) {
+    width: 120px;
+  }
 }

--- a/src/containers/allelePage/translation.scss
+++ b/src/containers/allelePage/translation.scss
@@ -26,7 +26,7 @@
 .table {
   td, th {
     border: none;
-    padding: 0 1em;
+    padding: 0 0.5em;
   }
 
   th.position {
@@ -34,13 +34,20 @@
   }
 
   td.position {
-    border-right: 4px solid #eee;
-    width: 100%;
-    text-align: right;
     font-family: monospace;
     font-size: 10pt;
     color: #666;
     vertical-align: bottom;
+  }
+
+  td.position:first-child {
+    width: 100%;
+    // border-right: 4px solid #eee;
+    text-align: right;
+  }
+
+  td.position:last-child {
+    // border-left: 4px solid #eee;
   }
 
   .codonRow {


### PR DESCRIPTION
- expandable row for molecular consequence details
- wrap at 30 bases instead of 15
- avoid odd wrapping for long sequence
- display end position on the right side of the sequence