### PR TITLE
Fix AGR-2202, AGR-2256, AGR-1093 and missing functionalities from former PR (MERGE FIRST)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1315,9 +1315,9 @@
       }
     },
     "@geneontology/wc-ribbon-strips": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.25.tgz",
-      "integrity": "sha512-I7ajr5uRpM4BcXHzgd+9QSOZJxfjA8qdQm2+ri7WmGD1dkQVQR+v/exLRRe5YGLMzWkB9KCBjWxjZDbrG8BwCQ==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.26.tgz",
+      "integrity": "sha512-xlkJetPvdBRlrbLcZ+bCy+G2EZ2IndORb4cCbkB87oAg/BXlIB4Sj8PN1RZS2ud4auenD+XWTWO3gJX65WSBFg==",
       "requires": {
         "@geneontology/wc-spinner": "0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
-    "@geneontology/wc-ribbon-strips": "0.0.25",
+    "@geneontology/wc-ribbon-strips": "0.0.26",
     "@geneontology/wc-ribbon-table": "0.0.41",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.3.5",

--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -264,22 +264,83 @@ class GeneOntologyRibbon extends Component {
 
 
   // ===================================================================
-  //                            RENDERING
+  //                      UTILITY FUNCTIONS 
+  //            (ideally this belong to somewhere else)
   // ===================================================================
 
-  render() {
-    return (
-      <div>
-
-        { this.renderControls() }
-
-        { this.state.loading ? <LoadingSpinner/> : this.renderRibbonStrips() }
-
-        { this.state.selected.group ? this.state.selected.loading ? <LoadingSpinner/> : this.renderRibbonTable() : '' }
-
-      </div>
-    );
+  /**
+   * Return the category object for a given group
+   * @param {*} group group object (eg ontology term)
+   */
+  getCategory(group) {
+    let cat = this.state.ribbon.categories.filter(cat => {
+      return cat.groups.some(gp => gp.id == group.id);
+    });
+    return cat.length > 0 ? cat[0] : undefined;
   }
+
+  /**
+   * Return the category [id, label] for a given group
+   * @param {*} group group object (eg ontology term)
+   */
+  getCategoryIdLabel(group) {
+    let cat = this.state.ribbon.categories.filter(cat => {
+      return cat.groups.some(gp => gp.id == group.id);
+    });
+    return cat.length > 0 ? [ cat[0].id, cat[0].label ] : undefined;
+  }
+
+  /**
+   * Check if a HTML element has a parent with provided id
+   * @param {} elt HTML element to check
+   * @param {*} id id to look in the parents of provided element
+   */
+  hasParentElementId(elt, id) {
+    if(elt.id == id) { return true; }
+    if(!elt.parentElement) { return false; }
+    return this.hasParentElementId(elt.parentElement, id);
+  }
+
+  getGeneIdList() {
+    return [this.props.geneId].concat(this.state.selectedOrthologs.map(getOrthologId));
+  }
+
+  associationKey(assoc) {
+    if(assoc.qualifier) {
+      return assoc.subject.id + '@' + assoc.object.id + '@' + assoc.negated + '@' + assoc.qualifier.join('-');
+    }
+    return assoc.subject.id + '@' + assoc.object.id + '@' + assoc.negated;
+  }
+
+  fullAssociationKey(assoc) {
+    var key = this.associationKey(assoc) + '@' + assoc.evidence_type + '@' + assoc.provided_by + '@' + assoc.reference.join('#');
+    return key;
+  }
+
+  diffAssociations(assocs_all, assocs_exclude) {
+    var list = [];
+    for(let assoc of assocs_all) {
+      let found = false;
+      let key_all = this.fullAssociationKey(assoc);
+      for(let exclude of assocs_exclude) {
+        let key_exclude= this.fullAssociationKey(exclude);
+        if(key_all == key_exclude) {
+          found = true;
+          break;
+        }
+      }
+      if(!found) {
+        list.push(assoc);
+      }
+    }
+    return list;
+  }
+  
+
+
+  // ===================================================================
+  //                            RENDERING
+  // ===================================================================
 
   renderControls() {
     const { geneTaxon, orthology } = this.props;
@@ -371,80 +432,19 @@ class GeneOntologyRibbon extends Component {
       />
     );   
   }
+  
+  render() {
+    return (
+      <div>
 
+        { this.renderControls() }
 
+        { this.state.loading ? <LoadingSpinner/> : this.renderRibbonStrips() }
 
-  // ===================================================================
-  //                      UTILITY FUNCTIONS 
-  //            (ideally this belong to somewhere else)
-  // ===================================================================
+        { this.state.selected.group ? this.state.selected.loading ? <LoadingSpinner/> : this.renderRibbonTable() : '' }
 
-  /**
-   * Return the category object for a given group
-   * @param {*} group group object (eg ontology term)
-   */
-  getCategory(group) {
-    let cat = this.state.ribbon.categories.filter(cat => {
-      return cat.groups.some(gp => gp.id == group.id);
-    });
-    return cat.length > 0 ? cat[0] : undefined;
-  }
-
-  /**
-   * Return the category [id, label] for a given group
-   * @param {*} group group object (eg ontology term)
-   */
-  getCategoryIdLabel(group) {
-    let cat = this.state.ribbon.categories.filter(cat => {
-      return cat.groups.some(gp => gp.id == group.id);
-    });
-    return cat.length > 0 ? [ cat[0].id, cat[0].label ] : undefined;
-  }
-
-  /**
-   * Check if a HTML element has a parent with provided id
-   * @param {} elt HTML element to check
-   * @param {*} id id to look in the parents of provided element
-   */
-  hasParentElementId(elt, id) {
-    if(elt.id == id) { return true; }
-    if(!elt.parentElement) { return false; }
-    return this.hasParentElementId(elt.parentElement, id);
-  }
-
-  getGeneIdList() {
-    return [this.props.geneId].concat(this.state.selectedOrthologs.map(getOrthologId));
-  }
-
-  associationKey(assoc) {
-    if(assoc.qualifier) {
-      return assoc.subject.id + '@' + assoc.object.id + '@' + assoc.negated + '@' + assoc.qualifier.join('-');
-    }
-    return assoc.subject.id + '@' + assoc.object.id + '@' + assoc.negated;
-  }
-
-  fullAssociationKey(assoc) {
-    var key = this.associationKey(assoc) + '@' + assoc.evidence_type + '@' + assoc.provided_by + '@' + assoc.reference.join('#');
-    return key;
-  }
-
-  diffAssociations(assocs_all, assocs_exclude) {
-    var list = [];
-    for(let assoc of assocs_all) {
-      let found = false;
-      let key_all = this.fullAssociationKey(assoc);
-      for(let exclude of assocs_exclude) {
-        let key_exclude= this.fullAssociationKey(exclude);
-        if(key_all == key_exclude) {
-          found = true;
-          break;
-        }
-      }
-      if(!found) {
-        list.push(assoc);
-      }
-    }
-    return list;
+      </div>
+    );
   }
 
 }

--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -1,10 +1,8 @@
 /* eslint-disable react/no-set-state */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import HorizontalScroll from '../horizontalScroll';
-
-// import { POSITION, COLOR_BY, SELECTION } from '@geneontology/ribbon/lib/enums';
-// import AssociationsView from '@geneontology/ribbon/lib/view/AssociationsView';
 
 import { STRINGENCY_HIGH } from '../orthology/constants';
 import HelpPopup from '../helpPopup';
@@ -14,20 +12,23 @@ import { selectOrthologs } from '../../selectors/geneSelectors';
 import OrthologPicker from '../OrthologPicker';
 import { connect } from 'react-redux';
 import { getOrthologId } from '../orthology';
-import LoadingSpinner from '../loadingSpinner';
 import fetchData from '../../lib/fetchData';
-import NoData from '../noData';
 
-const goApiUrl = 'https://api.geneontology.org/api/';
+import LoadingSpinner from '../loadingSpinner';
+// import NoData from '../noData';
 
-const exp_codes = ['EXP', 'IDA', 'IPI', 'IMP', 'IGI', 'IEP', 'HTP', 'HDA', 'HMP', 'HGI', 'HEP'];
+
+const GO_API_URL = 'https://api.geneontology.org/api/';
+const EXP_CODES = ['EXP', 'IDA', 'IPI', 'IMP', 'IGI', 'IEP', 'HTP', 'HDA', 'HMP', 'HGI', 'HEP'];
+
 
 class GeneOntologyRibbon extends Component {
 
   constructor(props) {
     super(props);
     this.state = {
-      loading : true,
+      applyingFilters : false,      // if ortholgs are loading or any other filtering is happening
+      loading : true,               // if ribbon strips loading
       noData : false,
       subjectBaseURL : '/gene/',
       stringency: STRINGENCY_HIGH,
@@ -36,36 +37,111 @@ class GeneOntologyRibbon extends Component {
       excludePB : true,
       excludeIBA : true,
       onlyEXP : false,
+      subset : 'goslim_agr',
       selected : {
         subject : null,
         group : null,
         data : null,
-        ready : false,
-        loading : false   // secondary loading for table
+        loading : false             // if ribbon table loading
       },
       search : ''
     };
     this.handleOrthologyChange = this.handleOrthologyChange.bind(this);
-    this.onGOGroupClicked = this.onGOGroupClicked.bind(this);
+    this.selectGroup = this.selectGroup.bind(this);
     this.onGroupClicked = this.onGroupClicked.bind(this);
     this.onSubjectClicked = this.onSubjectClicked.bind(this);
   }
 
   componentDidMount() {
-    // this.fetchSummaryData('goslim_agr', this.getGeneIdList());
     document.addEventListener('cellClick', this.onGroupClicked);
     document.addEventListener('subjectClick', this.onSubjectClicked);    
   }
 
 
-  hasParentElementId(elt, id) {
-    if(elt.id == id)
-      return true;
-    if(!elt.parentElement)
-      return false;
-    return this.hasParentElementId(elt.parentElement, id);
+
+  // ===================================================================
+  //                      API QUERY SECTION
+  // ===================================================================
+
+  ribbonOptions() {
+    // var excludeIBA = this.state.excludeIBA && subjects.length > 1;
+    var excludeIBA = false;
+    var exps = '';
+    if(this.state.onlyEXP) {
+      for(var exp of EXP_CODES) {
+        exps += '&ecodes=' + exp;
+      }
+    }
+    return  '&exclude_PB=' + this.state.excludePB + '&exclude_IBA=' + excludeIBA +
+            '&cross_aspect=' + this.state.crossAspect + exps;
   }
 
+  /**
+   * Fetch ribbon data to fill the ribbon strips
+   * @param {*} subset a subset or slim id (eg goslim_agr)
+   * @param {*} subjects an array of subjects (gene ids)
+   */
+  fetchSummaryData(subset, subjects) {
+    let subs = '';
+    if(subjects instanceof Array) {
+      subs = subjects.join('&subject=');
+    }
+    let query = GO_API_URL + 'ontology/ribbon/?subset=' + subset + '&subject=' + subs + this.ribbonOptions(subjects);
+    return fetchData(query);
+  }
+
+  /**
+   * Fetch ribbon data to fill the ribbon table
+   * @param {*} subject a single subject (gene id)
+   * @param {*} group one or more group ids. "all" to fetch data for all groups
+   */
+  fetchAssociationData(subject, group) {
+    if(group == 'all') {
+      group = this.state.ribbon.categories.map(elt => {
+        return elt.id;
+      });
+    }
+    if (group instanceof Array) {
+      group = group.join('&slim=');
+    }
+    let query = GO_API_URL + 'bioentityset/slimmer/function?slim=' + group + '&subject=' + subject + '&rows=-1';
+    return fetchData(query);
+  }
+
+
+
+  // ===================================================================
+  //                    CLIENT-SIDE FILTERING (should be minimized)
+  // ===================================================================
+
+  /**
+   * Create a deep copy of table data and returns a filtered data object
+   * @param {*} group group (eg ontology term) for which we retrieved the associated data
+   * @param {*} data association data related to the selected group/term
+   */
+  applyTableFilters(group, data) {
+    let filtered = JSON.parse(JSON.stringify(data));
+    for(let sub = 0; sub < filtered.length; sub++) {
+      if(this.state.excludePB) {
+        filtered[sub].assocs = filtered[sub].assocs.filter(assoc => assoc.object.id != 'GO:0005515');
+      }
+      if(!this.state.crossAspect) {
+        let aspect = this.getCategoryIdLabel(group);
+        filtered[sub].assocs = filtered[sub].assocs.filter(assoc => {
+          let cat = assoc.object.category[0] == 'molecular_activity' ? 'molecular_function' : assoc.object.category[0];
+          return aspect == undefined || cat == aspect[1];              
+        });
+      }
+    }
+    return filtered;
+  }
+
+
+
+  // ===================================================================
+  //                          EVENTS HANDLER
+  // ===================================================================
+  
   onSubjectClicked(e) {
     // to ensure we are only considering events coming from the disease ribbon
     if(this.hasParentElementId(e.target, 'go-ribbon')) {
@@ -82,23 +158,67 @@ class GeneOntologyRibbon extends Component {
 
   onGroupClicked(e) {
     // to ensure we are only considering events coming from the disease ribbon
-    if(e.target.id == 'go-ribbon') {
-      this.onGOGroupClicked(e.detail.subjects[0], e.detail.group);
+    if(e.target.id != 'go-ribbon') { return; }
+    this.selectGroup(e.detail.subjects[0], e.detail.group);
+  }
+
+  selectGroup(subject, group) {
+    if(this.state.selected.group) {
+      var sameGroupID = group.id == this.state.selected.group.id;
+      var sameGroupType = group.type == this.state.selected.group.type;
+      var sameSubject = subject.id == this.state.selected.subject.id;
+      if(sameGroupID && sameGroupType && sameSubject) {
+        group = undefined;
+      }
+    }
+
+    console.log('group click: ', subject, group);
+
+    this.setState({ selected : {
+      subject : subject,
+      group : group,
+      data : null,
+      loading : true
+    }});
+
+    if(group) {
+      let groupids;
+
+      // other group
+      if(group.type == 'Other') {
+        let aspect = this.getCategory(group);
+        var terms = aspect.groups.filter(elt => {
+          return elt.type == 'Term';
+        });
+        groupids = terms.map(elt => { return elt.id; });
+      
+      // regular group
+      } else {
+        groupids = group.id;
+
+      }
+
+      this.fetchAssociationData(subject.id, groupids)
+        .then(data => {
+          console.log('data: ', data);
+          let filtered = this.applyTableFilters(group, data);
+          console.log('filtered data: ', filtered);
+
+          this.setState({ selected : {
+            subject : subject,
+            group : group,
+            data : filtered, // assoc data from BioLink
+            loading : false
+          }});
+        });
+      
     }
   }
 
-  onGOGroupClicked(gene, term) {
-    // console.log('GENE: ', gene, 'TERM: ', term);
-    this.itemClick(gene, term);
-  }
-
-  getGeneIdList() {
-    return [this.props.geneId].concat(this.state.selectedOrthologs.map(getOrthologId));
-  }
-
   handleOrthologyChange(selectedOrthologs) {
+    this.setState({ 'applyingFilters' : true });
     this.setState({selectedOrthologs}, () => {
-      this.fetchSummaryData('goslim_agr', this.getGeneIdList()).then(data => {
+      this.fetchSummaryData(this.state.subset, this.getGeneIdList()).then(data => {
         var oldSubs = [];
         if(this.state.ribbon) {
           oldSubs = this.state.ribbon.subjects;
@@ -113,31 +233,23 @@ class GeneOntologyRibbon extends Component {
           group = this.state.selected.group;
         }
 
-        // Check if the subject exists and if it's still in the list of species to show
-        if(subject) {
-          var found = false;
-          for(let sub of data.subjects) {
-            if(subject.id == sub.id) {
-              found = true;
-            }
-          }
-          if(!found) {
-            subject = null;
-            group = null;
-          }
-        }
+        // this.setState({ loadingOrthologs : false, ribbon : data, subjects : oldSubs}, () => {
+        //   if(subject && group) {
+        //     this.selectGroup(subject, group);
+        //   }
+        // });
 
-        this.setState({ loading : false, ribbon : data, subjects : oldSubs,
+
+        this.setState({ applyingFilters: false, loading : false, ribbon : data, subjects : oldSubs, 
           selected : {
             subject : null,
             group : null,
             data : null,
-            ready : false,
             loading :  false
           }
         }, () => {
           if(subject && group) {
-            this.itemClick(subject, group);
+            this.selectGroup(subject, group);
           }
         });
       }).catch(() => {
@@ -145,167 +257,12 @@ class GeneOntologyRibbon extends Component {
       });
     });
   }
-
-  ribbonOptions() {
-    // var excludeIBA = this.state.excludeIBA && subjects.length > 1;
-    var excludeIBA = false;
-    var exps = '';
-    if(this.state.onlyEXP) {
-      for(var exp of exp_codes) {
-        exps += '&ecodes=' + exp;
-      }
-    }
-    return  '&exclude_PB=' + this.state.excludePB + '&exclude_IBA=' + excludeIBA +
-            '&cross_aspect=' + this.state.crossAspect + exps;
-  }
-
-  fetchSummaryData(subset, subjects) {
-    var subs = '';
-    if(subjects instanceof Array) {
-      subs = subjects.join('&subject=');
-    }
-    let query = goApiUrl + 'ontology/ribbon/?subset=' + subset + '&subject=' + subs + this.ribbonOptions(subjects);
-    // console.log('Query is ' + query);
-    return fetchData(query);
-  }
-
-  fetchAssociationData(subject, group) {
-    if(group == 'all') {
-      var groups = this.state.ribbon.categories.map(elt => {
-        return elt.id;
-      });
-      group = groups.join('&slim=');
-    } else if (group instanceof Array) {
-      group = group.join('&slim=');
-    }
-    let query = goApiUrl + 'bioentityset/slimmer/function?slim=' + group + '&subject=' + subject + '&rows=-1';
-    // console.log('Query is ' + query);
-    return fetchData(query);
-  }
-
-
-  itemClick(subject, group) {
-    if(this.state.selected.group) {
-      var sameGroupID = group.id == this.state.selected.group.id;
-      var sameGroupType = group.type == this.state.selected.group.type;
-      var sameSubject = subject.id == this.state.selected.subject.id;
-      if(sameGroupID && sameGroupType && sameSubject) {
-        group = undefined;
-      }
-    }
-
-    this.setState({ selected : {
-      subject : subject,
-      group : group,
-      data : null,
-      ready : false,
-      loading : true
-    }});
-
-    if(group) {
-      // other group
-      if(group.type == 'Other') {
-      
-      // regular group
-      } else {
-
-        this.fetchAssociationData(subject.id, group.id)
-          .then(data => {
-            // console.log('data ', data);
-            // if(this.state.excludePB) {
-            //   filtered = this.filterPB(data);
-            // }
-            // if(this.state.onlyEXP) {
-            //   filtered = this.getEXP(filtered);
-            // }
-            // if(!this.state.crossAspect) {
-            //   filtered = this.filterCrossAspect(group, filtered);
-            // }
-            this.setState({ selected : {
-              subject : subject,
-              group : group,
-              data : data, // assoc data from BioLink
-              ready : false,
-              loading : false
-            }});
-            // this.buildEvidenceMap();
-          });
-      }
-    }
-  }
-
-  filterPB(assocs) {
-    var list = [];
-    for(var assoc of assocs) {
-      if(assoc.object.id != 'GO:0005515') {
-        list.push(assoc);
-      }
-    }
-    return list;
-  }
-
-  getEXP(assocs) {
-    var list = [];
-    for(var assoc of assocs) {
-      if(exp_codes.includes(assoc.evidence_type)) {
-        list.push(assoc);
-      }
-    }
-    return list;
-  }
-
-  /**
-   * returns undefined for "ALL" slim term
-   * @param {*} group
-   */
-  getAspect(group) {
-    for(let cat of this.state.ribbon.categories) {
-      let found = cat.groups.filter(elt => {
-        return elt.id == group.id;
-      });
-      if(found.length > 0) {
-        return cat;
-      }
-    }
-    return undefined;
-  }
-
-  getAspectIdLabel(group) {
-    for(let cat of this.state.ribbon.categories) {
-      let found = cat.groups.filter(elt => {
-        return elt.id == group.id;
-      });
-      if(found.length > 0) {
-        return [ cat.id , cat.label ];
-      }
-    }
-    return undefined;
-  }
-
-  filterCrossAspect(group, assocs) {
-    var list = [];
-    var aspect = this.getAspectIdLabel(group);
-    for(var assoc of assocs) {
-      let cat = assoc.object.category[0] == 'molecular_activity' ? 'molecular_function' : assoc.object.category[0];
-      if(aspect == undefined || cat == aspect[1]) {
-        list.push(assoc);
-      }
-    }
-    return list;
-  }
-
-
-  defaultConfig() {
-    return {
-      termUrlFormatter : this.state.subjectBaseURL
-    };
-  }
-
+  
   showExperimentalAnnotations(event) {
-    this.setState({'onlyEXP' : event.target.checked}, () => {
-      // console.log('show only experimental annotations:'  , this.state.onlyEXP);
+    this.setState({ 'applyingFilters' : true });
 
-      this.fetchSummaryData('goslim_agr', this.getGeneIdList()).then(data => {
+    this.setState({'onlyEXP' : event.target.checked}, () => {
+      this.fetchSummaryData(this.state.subset, this.getGeneIdList()).then(data => {
         var oldSubs = [];
         if(this.state.ribbon) {
           oldSubs = this.state.ribbon.subjects;
@@ -315,18 +272,17 @@ class GeneOntologyRibbon extends Component {
         }
         const subject = this.state.selected.subject;
         const group = this.state.selected.group;
-        this.setState({ loading : false, ribbon : data, subjects : oldSubs,
+        this.setState({ applyingFilters: false, loading : false, ribbon : data, subjects : oldSubs,
           selected : {
             subject : null,
             group : null,
             data : null,
-            ready : false,
             loading : false
           }
         } , () => {
           // not necessary anymore since exp codes filtered by ribbon table
           if(subject && group) {
-            this.itemClick(subject, group);
+            this.selectGroup(subject, group);
           }
         });
       }).catch(() => {
@@ -336,88 +292,150 @@ class GeneOntologyRibbon extends Component {
     });
   }
 
+
+
+  // ===================================================================
+  //                            RENDERING
+  // ===================================================================
+
   render() {
-    // console.log('state: ', this.state);
-    // console.log('props: ', this.props);
-    const { geneTaxon, orthology } = this.props;
-    const { selectedOrthologs } = this.state;
     return (
       <div>
-        <div>
-          <ControlsContainer>
-            <span className='pull-right'>
-              <HelpPopup id='go-controls-help'>
-                <GoControlsHelp />
-              </HelpPopup>
-            </span>
-            <OrthologPicker
-              defaultStringency={STRINGENCY_HIGH}
-              enabled={false}
-              focusTaxonId={geneTaxon}
-              id='go-ortho-picker'
-              onChange={this.handleOrthologyChange}
-              orthology={orthology.data}
-              value={selectedOrthologs}
-            />
 
-            <div className='form-check form-check-inline'>
-              <label className='form-check-label'>
-                <input
-                  checked={this.state.onlyEXP}
-                  className='form-check-input'
-                  onChange={this.showExperimentalAnnotations.bind(this)}
-                  title='When showing the GO functions for multiple orthologs, we recommend switching this on as a number of GO functions are inferred through phylogeny (see PAINT tool)'
-                  type='checkbox'
-                />
-                <b>Show only experimental annotations</b>
-              </label>
-            </div>
-          </ControlsContainer>
-        </div>
+        { this.renderControls() }
 
-        <HorizontalScroll>
-          <div className='text-nowrap'>
-            {
-              this.state.loading ? <LoadingSpinner /> :
-                <wc-ribbon-strips 
-                  category-all-style='1'
-                  color-by='0'
-                  data={JSON.stringify(this.state.ribbon)}
-                  fire-event-on-empty-cells={false}
-                  group-clickable={false}
-                  group-open-new-tab={false}
-                  id='go-ribbon'
-                  new-tab={false}
-                  selection-mode='0'
-                  subject-base-url='/gene/'
-                  subject-open-new-tab={false}
-                  subject-position={this.state.ribbon.subjects.length == 1 ? '0' : '1'}
-                />
-            }
-          </div>
-          <div>{this.state.loading && <LoadingSpinner />}</div>
-          <div className='text-muted mt-2'>
-            <i>Cell color indicative of annotation volume</i>
-          </div>
-        </HorizontalScroll>
+        { this.state.loading ? <LoadingSpinner/> : this.renderRibbonStrips() }
 
-        {
-          (this.state.loading || this.state.selected.loading) ? <LoadingSpinner /> : 
-            (this.state.selected.data && this.state.selected.data.length > 0) ?
-              <wc-ribbon-table
-                bio-link-data={JSON.stringify(this.state.selected.data)} 
-                filter-by={this.state.onlyEXP ? 'evidence:' + exp_codes.join(',') : ''} 
-                group-by='term' 
-                hide-columns={'qualifier,gene' + (this.state.selected.group.id != 'all' ? ',aspect' : '')}
-                order-by='term' 
-              />
-              : (this.state.selected.group) ? ((this.state.selected.data) ? <NoData/> : <LoadingSpinner />)
-                : ''
-        }
+        { this.state.selected.group ? this.state.selected.loading ? <LoadingSpinner/> : this.renderRibbonTable() : '' }
 
       </div>
     );
   }
+
+  renderControls() {
+    const { geneTaxon, orthology } = this.props;
+    const { selectedOrthologs } = this.state;
+
+    return(
+      <ControlsContainer>
+        <span className='pull-right'>
+          <HelpPopup id='go-controls-help'>
+            <GoControlsHelp />
+          </HelpPopup>
+        </span>
+
+
+        <OrthologPicker
+          defaultStringency={STRINGENCY_HIGH}
+          enabled={false}
+          focusTaxonId={geneTaxon}
+          id='go-ortho-picker'
+          onChange={this.handleOrthologyChange}
+          orthology={orthology.data}
+          value={selectedOrthologs}
+        />
+
+        <div className='form-check form-check-inline'>
+          <label className='form-check-label'>
+            <input
+              checked={this.state.onlyEXP}
+              className='form-check-input'
+              onChange={this.showExperimentalAnnotations.bind(this)}
+              title='When showing the GO functions for multiple orthologs, we recommend switching this on as a number of GO functions are inferred through phylogeny (see PAINT tool)'
+              type='checkbox'
+            />
+            <b>Show only experimental annotations</b>
+          </label>
+        </div>
+
+        <div style={{'width':'100%', 'text-align':'right'}}>
+          { this.state.applyingFilters ? <LoadingSpinner/> : '' }
+        </div>
+      </ControlsContainer>
+    );
+  }
+
+  renderRibbonStrips() {
+    return(
+      <HorizontalScroll className='text-nowrap'>
+        <wc-ribbon-strips 
+          category-all-style='1'
+          color-by='0'
+          data={JSON.stringify(this.state.ribbon)}
+          fire-event-on-empty-cells={false}
+          group-clickable={false}
+          group-open-new-tab={false}
+          id='go-ribbon'
+          new-tab={false}
+          selection-mode='0'
+          show-other-group
+          subject-base-url='/gene/'
+          subject-open-new-tab={false}
+          subject-position={this.state.ribbon.subjects.length == 1 ? '0' : '1'}
+        />
+        <div className='text-muted mt-2'>
+          <i>Cell color indicative of annotation volume</i>
+        </div>
+      </HorizontalScroll>
+    );
+  }
+
+  renderRibbonTable() {
+    return(
+      <wc-ribbon-table
+        bio-link-data={JSON.stringify(this.state.selected.data)} 
+        filter-by={this.state.onlyEXP ? 'evidence:' + EXP_CODES.join(',') : ''} 
+        group-by='term' 
+        hide-columns={'qualifier,gene' + (this.state.selected.group.id != 'all' ? ',aspect' : '')}
+        order-by='term' 
+      />
+    );   
+  }
+
+
+  // ===================================================================
+  //                      UTILITY FUNCTIONS
+  // ===================================================================
+
+  /**
+   * Return the category object for a given group
+   * @param {*} group group object (eg ontology term)
+   */
+  getCategory(group) {
+    let cat = this.state.ribbon.categories.filter(cat => {
+      return cat.groups.some(gp => gp.id == group.id);
+    });
+    return cat.length > 0 ? cat[0] : undefined;
+  }
+
+  /**
+   * Return the category [id, label] for a given group
+   * @param {*} group group object (eg ontology term)
+   */
+  getCategoryIdLabel(group) {
+    let cat = this.state.ribbon.categories.filter(cat => {
+      return cat.groups.some(gp => gp.id == group.id);
+    });
+    return cat.length > 0 ? [ cat[0].id, cat[0].label ] : undefined;
+  }
+
+
+
+  /**
+   * Check if a HTML element has a parent with provided id
+   * @param {} elt HTML element to check
+   * @param {*} id id to look in the parents of provided element
+   */
+  hasParentElementId(elt, id) {
+    if(elt.id == id) { return true; }
+    if(!elt.parentElement) { return false; }
+    return this.hasParentElementId(elt.parentElement, id);
+  }
+
+  getGeneIdList() {
+    return [this.props.geneId].concat(this.state.selectedOrthologs.map(getOrthologId));
+  }
+
 
 }
 
@@ -433,4 +451,3 @@ const mapStateToProps = (state) => ({
 });
 
 export default connect(mapStateToProps)(GeneOntologyRibbon);
-


### PR DESCRIPTION
This is a major update / fix / clean up of the GO ribbon integration in agr_ui.

The wiring of the GO ribbon was still using old code and old events handling causing various. issues (https://agr-jira.atlassian.net/browse/AGR-2202, https://agr-jira.atlassian.net/browse/AGR-2256).

While fixing https://agr-jira.atlassian.net/browse/AGR-2256, I also added a spinner in the control box (appearing to the right side of the box) whenever the ribbon strips or table is updating. This allows to keep the display on and to update it when the work has finished. Essentially, there are 3 loading parameters: 1 for ribbon strips, 1 for ribbon table and 1 for applying filters (eg orthologs or experimental annotations)

This also solve issue: https://agr-jira.atlassian.net/browse/AGR-1093 on showing GO aspect when clicking on the "all" of a ribbon line.

In addition this PR solves missing functionalities mentioned in former PR (https://github.com/alliance-genome/agr_ui/pull/663#issuecomment-641046541):
* filter out direct annotations to protein binding
* filter out annotations resulting from a cross-aspect relationship mapping
* 'other' group was missing.

PS: just passed some additional comments about the LINT here:
https://agr-jira.atlassian.net/browse/AGR-2230
