### PR TITLE
AGR-2276 - Fix skewed lines and filter PMID/DOI/GO_REF/Reactome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1323,9 +1323,9 @@
       }
     },
     "@geneontology/wc-ribbon-table": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-table/-/wc-ribbon-table-0.0.41.tgz",
-      "integrity": "sha512-TNcGS1JQGuo9jr4bPJyvha/Li0meaP83z56mNN2Ey0nThz00WTE5ARj96CFC3vTpheIkwOD6WsaMVd8YJjbVgA==",
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-table/-/wc-ribbon-table-0.0.43.tgz",
+      "integrity": "sha512-tTIKBv2nyaFfLGpmer3Paj6Y+N01Cq+tzJ2pU253FB58Gn22Tr4yPIcMsDeAEoi1sYRaReH3tBAXQ7bgJHZXLg==",
       "requires": {
         "@geneontology/curie-util-es5": "^1.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
     "@geneontology/wc-ribbon-strips": "0.0.26",
-    "@geneontology/wc-ribbon-table": "0.0.41",
+    "@geneontology/wc-ribbon-table": "0.0.43",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.3.7",
     "bootstrap": "4.3.1",

--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -33,6 +33,7 @@ class GeneOntologyRibbon extends Component {
       stringency: STRINGENCY_HIGH,
       selectedOrthologs: [],
       crossAspect : false,
+      filterReference : true,
       excludePB : true,
       excludeIBA : true,
       onlyEXP : false,
@@ -131,7 +132,14 @@ class GeneOntologyRibbon extends Component {
           return aspect == undefined || cat == aspect[1];              
         });
       }
+      if(this.state.filterReference) {
+        filtered[sub].assocs = filtered[sub].assocs.filter(assoc => {
+          assoc.reference = assoc.reference.filter(ref => ref.includes('PMID:') || ref.includes('DOI:') || ref.includes('GO_REF:') || ref.includes('Reactome:'));
+          return assoc;
+        });
+      }
     }
+    console.log(filtered);
     return filtered;
   }
 

--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -54,7 +54,7 @@ class GeneOntologyRibbon extends Component {
 
   componentDidMount() {
     document.addEventListener('cellClick', this.onGroupClicked);
-    document.addEventListener('subjectClick', this.onSubjectClicked);    
+    document.addEventListener('subjectClick', this.onSubjectClicked);
   }
 
 
@@ -129,7 +129,7 @@ class GeneOntologyRibbon extends Component {
         let aspect = this.getCategoryIdLabel(group);
         filtered[sub].assocs = filtered[sub].assocs.filter(assoc => {
           let cat = assoc.object.category[0] == 'molecular_activity' ? 'molecular_function' : assoc.object.category[0];
-          return aspect == undefined || cat == aspect[1];              
+          return aspect == undefined || cat == aspect[1];
         });
       }
       if(this.state.filterReference) {
@@ -139,7 +139,6 @@ class GeneOntologyRibbon extends Component {
         });
       }
     }
-    console.log(filtered);
     return filtered;
   }
 
@@ -148,7 +147,7 @@ class GeneOntologyRibbon extends Component {
   // ===================================================================
   //                          EVENTS HANDLER
   // ===================================================================
-  
+
   onSubjectClicked(e) {
     // to ensure we are only considering events coming from the disease ribbon
     if(this.hasParentElementId(e.target, 'go-ribbon')) {
@@ -187,7 +186,7 @@ class GeneOntologyRibbon extends Component {
     }});
 
     // if no group selected, no association to fetch
-    if(!group) { return ; } 
+    if(!group) { return ; }
 
     // other group
     if(group.type == 'Other') {
@@ -207,7 +206,7 @@ class GeneOntologyRibbon extends Component {
               for(let array of data_terms) {
                 concat_assocs = concat_assocs.concat(array.assocs);
               }
-              
+
               let other_assocs = this.diffAssociations(data_all[0].assocs, concat_assocs);
               data_all[0].assocs = other_assocs;
 
@@ -246,7 +245,7 @@ class GeneOntologyRibbon extends Component {
         this.setState({ applyingFilters : false, loading : false, ribbon : data }, () => {
           if(this.state.selected.subject && !this.state.ribbon.subjects.some(sub => sub.id == this.state.selected.subject.id)) {
             this.selectGroup(null, null);
-          }            
+          }
         });
 
       }).catch(() => {
@@ -254,7 +253,7 @@ class GeneOntologyRibbon extends Component {
       });
     });
   }
-  
+
   handleExpAnnotations(event) {
     this.setState({ 'applyingFilters' : true });
     this.setState({'onlyEXP' : event.target.checked}, () => {
@@ -276,7 +275,7 @@ class GeneOntologyRibbon extends Component {
           ];
         }
         this.setState({ applyingFilters : false, loading : false, ribbon : data });
-        
+
       }).catch(() => {
         this.setState({ loading : false });
       });
@@ -287,7 +286,7 @@ class GeneOntologyRibbon extends Component {
 
 
   // ===================================================================
-  //                      UTILITY FUNCTIONS 
+  //                      UTILITY FUNCTIONS
   //            (ideally this belong to somewhere else)
   // ===================================================================
 
@@ -358,7 +357,7 @@ class GeneOntologyRibbon extends Component {
     }
     return list;
   }
-  
+
 
 
   // ===================================================================
@@ -410,7 +409,7 @@ class GeneOntologyRibbon extends Component {
   renderRibbonStrips() {
     return(
       <HorizontalScroll className='text-nowrap'>
-        <wc-ribbon-strips 
+        <wc-ribbon-strips
           category-all-style='1'
           color-by='0'
           data={JSON.stringify(this.state.ribbon)}
@@ -441,19 +440,19 @@ class GeneOntologyRibbon extends Component {
         if(EXP_CODES.includes(key)) {
           hasEXP = true;
         }
-      }    
+      }
       if(!hasEXP) { return ''; }
     }
-      
+
     return(
       <wc-ribbon-table
-        bio-link-data={JSON.stringify(this.state.selected.data)} 
-        filter-by={this.state.onlyEXP ? 'evidence:' + EXP_CODES.join(',') : ''} 
-        group-by='term' 
+        bio-link-data={JSON.stringify(this.state.selected.data)}
+        filter-by={this.state.onlyEXP ? 'evidence:' + EXP_CODES.join(',') : ''}
+        group-by='term'
         hide-columns={'qualifier,' + (this.state.selectedOrthologs.length == 0 ? 'gene,' : '') + (this.state.selected.group.id != 'all' ? ',aspect' : '')}
-        order-by='term' 
+        order-by='term'
       />
-    );   
+    );
   }
 
   render() {


### PR DESCRIPTION
As I thought, I needed a default height for my <li> tags. Long story short, the table directly read the data from the BioLink association model, so the table has some generic grouping/ordering/filtering to achieve the desired results.

When grouping rows based on a column (eg by term), in order to keep the ordering of subcell list (eg 1 cell contains several references), we have to create <li> to keep the table aligned after ordering.

A bit complicated but it does the trick, is generic and can work with any data. Anyhow, it's solved. I also solved an associated issue where we want to display only reference that are PMID/DOI/GO_REF/Reactome.

Off next week