### PR TITLE
AGR-2202 Do not re-mount ribbon when orthologs change

### DIFF
--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -166,24 +166,21 @@ class DiseaseComparisonRibbon extends Component {
 
         <HorizontalScroll>
           <div className='text-nowrap'>
-            {
-              summary.loading ? <LoadingSpinner /> :
-                <wc-ribbon-strips 
-                  category-all-style='1'
-                  color-by='0'
-                  data={JSON.stringify(summary.data)}
-                  fire-event-on-empty-cells={false}
-                  group-clickable={false}
-                  group-open-new-tab={false}
-                  id='disease-ribbon'
-                  new-tab={false}
-                  selected='all'
-                  selection-mode='1'
-                  subject-base-url='/gene/'
-                  subject-open-new-tab={false}
-                  subject-position='1'
-                />
-            }
+            <wc-ribbon-strips
+              category-all-style='1'
+              color-by='0'
+              data={JSON.stringify(summary.data)}
+              fire-event-on-empty-cells={false}
+              group-clickable={false}
+              group-open-new-tab={false}
+              id='disease-ribbon'
+              new-tab={false}
+              selected='all'
+              selection-mode='1'
+              subject-base-url='/gene/'
+              subject-open-new-tab={false}
+              subject-position='1'
+            />
           </div>
           <div>{summary.loading && <LoadingSpinner />}</div>
           <div className='text-muted mt-2'>

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -169,23 +169,20 @@ class ExpressionComparisonRibbon extends React.Component {
 
         <HorizontalScroll>
           <div className='text-nowrap'>
-            {
-              summary.loading ? <LoadingSpinner /> :
-                <wc-ribbon-strips 
-                  category-all-style='1'
-                  color-by='0'
-                  data={JSON.stringify(updatedSummary)}
-                  fire-event-on-empty-cells={false}
-                  group-clickable={false}
-                  group-open-new-tab={false}
-                  id='expression-ribbon'
-                  new-tab={false}
-                  selection-mode='1'
-                  subject-base-url='/gene/'
-                  subject-open-new-tab={false}
-                  subject-position='1'
-                />
-            }
+            <wc-ribbon-strips
+              category-all-style='1'
+              color-by='0'
+              data={JSON.stringify(updatedSummary)}
+              fire-event-on-empty-cells={false}
+              group-clickable={false}
+              group-open-new-tab={false}
+              id='expression-ribbon'
+              new-tab={false}
+              selection-mode='1'
+              subject-base-url='/gene/'
+              subject-open-new-tab={false}
+              subject-position='1'
+            />
           </div>
           <div>{summary.loading && <LoadingSpinner />}</div>
           <div className='text-muted mt-2'>


### PR DESCRIPTION
Remounting the ribbon component causes its own internal selection state to reset. Even with this fix there is still an issue with getting out of sync as orthologs change which I believe will need to be fixed in the ribbon code. I'll open a separate issue about that.