### PR TITLE
Fix AGR-2316

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1315,17 +1315,17 @@
       }
     },
     "@geneontology/wc-ribbon-strips": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.26.tgz",
-      "integrity": "sha512-xlkJetPvdBRlrbLcZ+bCy+G2EZ2IndORb4cCbkB87oAg/BXlIB4Sj8PN1RZS2ud4auenD+XWTWO3gJX65WSBFg==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.30.tgz",
+      "integrity": "sha512-ZcmxM+e5X+K7gPQBgadywVONPr7/8S1SXGgU+F2qFl0JbZ7HynvAdsiKI4BKskB+V+FsNzGkE9Zmf4/6LlaNVg==",
       "requires": {
         "@geneontology/wc-spinner": "0.0.2"
       }
     },
     "@geneontology/wc-ribbon-table": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-table/-/wc-ribbon-table-0.0.43.tgz",
-      "integrity": "sha512-tTIKBv2nyaFfLGpmer3Paj6Y+N01Cq+tzJ2pU253FB58Gn22Tr4yPIcMsDeAEoi1sYRaReH3tBAXQ7bgJHZXLg==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-table/-/wc-ribbon-table-0.0.51.tgz",
+      "integrity": "sha512-bnxLyei/h6GZnVoiDeEtfjoG03Owk9OZQQTt1GijQF+uZUG2v2lb7gWlHXIiA0EUSmKMqcgKsRnYU8GPXi0qQQ==",
       "requires": {
         "@geneontology/curie-util-es5": "^1.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
-    "@geneontology/wc-ribbon-strips": "0.0.26",
-    "@geneontology/wc-ribbon-table": "0.0.43",
+    "@geneontology/wc-ribbon-strips": "0.0.30",
+    "@geneontology/wc-ribbon-table": "0.0.51",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.3.7",
     "bootstrap": "4.3.1",

--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -15,6 +15,9 @@ import { getOrthologId } from '../orthology';
 import fetchData from '../../lib/fetchData';
 
 import LoadingSpinner from '../loadingSpinner';
+
+import { withRouter } from 'react-router';
+
 // import NoData from '../noData';
 
 
@@ -449,7 +452,8 @@ class GeneOntologyRibbon extends Component {
         bio-link-data={JSON.stringify(this.state.selected.data)}
         filter-by={this.state.onlyEXP ? 'evidence:' + EXP_CODES.join(',') : ''}
         group-by='term'
-        hide-columns={'qualifier,' + (this.state.selectedOrthologs.length == 0 ? 'gene,' : '') + (this.state.selected.group.id != 'all' ? ',aspect' : '')}
+        // hide-columns={'qualifier,' + (this.state.selectedOrthologs.length == 0 ? 'gene,' : '') + (this.state.selected.group.id != 'all' ? ',aspect' : '')}
+        hide-columns={'qualifier,gene,' + (this.state.selected.group.id != 'all' ? ',aspect' : '')}
         order-by='term'
       />
     );
@@ -482,4 +486,4 @@ const mapStateToProps = (state) => ({
   orthology: selectOrthologs(state)
 });
 
-export default connect(mapStateToProps)(GeneOntologyRibbon);
+export default connect(mapStateToProps)(withRouter(GeneOntologyRibbon));

--- a/src/style.scss
+++ b/src/style.scss
@@ -113,6 +113,6 @@ wc-ribbon-cell.ribbon__subject--cell--no-annotation {
 }
 
 .table__row__supercell__cell__link {
-  color: rgb(38, 129, 166)
+  color: $link-color
 }    
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -112,3 +112,7 @@ wc-ribbon-cell.ribbon__subject--cell--no-annotation {
   }
 }
 
+.table__row__supercell__cell__link {
+  color: rgb(38, 129, 166)
+}    
+


### PR DESCRIPTION
This PR fixes AGR-2316 and a few other issues:

* The GO table should not display the "Gene" column as the GO ribbon is designed to handle selection of a single cell and not of a column. This column was simply removed
* I think someone has removed the HOC withRouter of the GO ribbon component as clicking on the gene link to the left of the ribbon strips was now triggering an error (history missing in props) and not rerouting the page to the gene of interest. I don't know what happened, but i re-added the withRouter and this is now working correctly
* updated the NPM package of both the ribbon strips and table and updated the CSS for the GO ribbon table so that the color of the links matches the color of other links on the Alliance pages