### PR TITLE
AGR-2290

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1315,9 +1315,9 @@
       }
     },
     "@geneontology/wc-ribbon-strips": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.26.tgz",
-      "integrity": "sha512-xlkJetPvdBRlrbLcZ+bCy+G2EZ2IndORb4cCbkB87oAg/BXlIB4Sj8PN1RZS2ud4auenD+XWTWO3gJX65WSBFg==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.34.tgz",
+      "integrity": "sha512-H374EOgO13bDTuLXMu1UDMYWRZZtUAwL4Bso7R2Gmd4OfL0KPYj3XpGjMjT8L0rYdXXb6A97nGtR7lxZlPC/fQ==",
       "requires": {
         "@geneontology/wc-spinner": "0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@geneontology/ribbon": "^1.11.2",
-    "@geneontology/wc-ribbon-strips": "0.0.26",
+    "@geneontology/wc-ribbon-strips": "0.0.34",
     "@geneontology/wc-ribbon-table": "0.0.43",
     "abortcontroller-polyfill": "^1.2.5",
     "agr_genomefeaturecomponent": "^0.3.7",

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -78,6 +78,9 @@ class DiseaseComparisonRibbon extends Component {
 
   handleOrthologyChange(selectedOrthologs) {
     this.setState({selectedOrthologs});
+    if(this.state.selectedBlock.group) {
+      document.getElementById('disease-ribbon').selectGroup(this.state.selectedBlock.group.id);
+    }
   }
 
   getGeneIdList() {

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -64,6 +64,9 @@ class ExpressionComparisonRibbon extends React.Component {
 
   handleOrthologChange(values) {
     this.setState({selectedOrthologs: values});
+    if(this.state.selectedBlock.group) {
+      document.getElementById('expression-ribbon').selectGroup(this.state.selectedBlock.group.id);
+    }
   }
 
   hasParentElementId(elt, id) {


### PR DESCRIPTION
Fix AGR-2290.

There was one fix on the ribbon repo and one fix here consisting in explicitly calling ribbon.selectGroup() after an orthology change event.

