### PR TITLE
AGR-2327 AGR-2326 AGR-2325 AGR-2324 SARS-CoV-2 gene page fixes

### DIFF
--- a/src/components/OrthologPicker.js
+++ b/src/components/OrthologPicker.js
@@ -14,11 +14,12 @@ import {
   UncontrolledDropdown,
   UncontrolledTooltip
 } from 'reactstrap';
-import {SPECIES, TAXON_ORDER} from '../constants';
+import {SPECIES as ALL_SPECIES, TAXON_ORDER} from '../constants';
 import {
   compareAlphabeticalCaseInsensitive,
   compareBy,
   compareByFixedOrder,
+  getSpecies,
   makeId,
   orthologyMeetsStringency
 } from '../lib/utils';
@@ -52,6 +53,8 @@ const STRINGENCY_OPTIONS = [
   },
 ];
 
+const SPECIES = ALL_SPECIES.filter(s => s.orthologComparison);
+
 const sortBySpecies = species => species.sort(
   compareByFixedOrder(SPECIES.map(s => s.taxonId), s => s.taxonId)
 );
@@ -64,7 +67,7 @@ class OrthologPicker extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      enabled: !!props.defaultEnabled,
+      inputDisabled: false,
       stringency: STRINGENCY_OPTIONS.find(o => o.value === props.defaultStringency),
       allVertebrates: false,
       allInvertebrates: false,
@@ -74,15 +77,20 @@ class OrthologPicker extends React.Component {
   }
 
   componentDidMount() {
+    this.updateInputDisabled();
     this.fireChangeCallback();
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { stringency, enabled, selectedSpecies } = this.state;
+    const { stringency, selectedSpecies } = this.state;
     const stringencyChanged = prevState.stringency !== stringency;
     const speciesChanged = !isEqual(prevState.selectedSpecies, selectedSpecies);
     const orthologyChanged = !isEqual(prevProps.orthology, this.props.orthology);
-    const enabledChanged = prevState.enabled !== enabled;
+    const enabledChanged = prevProps.checkboxValue !== this.props.checkboxValue;
+
+    if (this.props.focusTaxonId !== prevProps.focusTaxonId) {
+      this.updateInputDisabled();
+    }
 
     // if the filters or orthology itself have changed...
     if (enabledChanged || stringencyChanged || speciesChanged || orthologyChanged) {
@@ -91,15 +99,24 @@ class OrthologPicker extends React.Component {
 
       // enable the main compare checkbox (may be a no-op in some cases)
       if ((stringencyChanged && stringency) || (speciesChanged && selectedSpecies.length)) {
-        this.setState({enabled: true});
+        this.props.onCheckboxValueChange(true);
       }
     }
   }
 
+  updateInputDisabled() {
+    if (!getSpecies(this.props.focusTaxonId).orthologComparison) {
+      this.props.onCheckboxValueChange(false);
+      this.setState({ inputDisabled: true });
+    } else {
+      this.setState({ inputDisabled: false });
+    }
+  }
+
   fireChangeCallback() {
-    const { orthology, onChange, genesWithData } = this.props;
-    const { enabled, stringency, selectedSpecies } = this.state;
-    if (!enabled) {
+    const { checkboxValue, orthology, onChange, genesWithData } = this.props;
+    const { stringency, selectedSpecies } = this.state;
+    if (!checkboxValue) {
       return onChange([]);
     }
     const filteredOrthology = orthology
@@ -195,27 +212,29 @@ class OrthologPicker extends React.Component {
   }
 
   render() {
-    const { focusTaxonId, id, orthology } = this.props;
-    const { allInvertebrates, allVertebrates, enabled, selectedSpecies, stringency } = this.state;
+    const { checkboxValue, focusTaxonId, id, orthology } = this.props;
+    const { inputDisabled, allInvertebrates, allVertebrates, selectedSpecies, stringency } = this.state;
 
     return (
       <div className='mb-3'>
         <div className='form-group mb-1'>
           <div className='form-check form-check-inline'>
-            <label className='form-check-label'>
-              <input
-                checked={enabled}
-                className='form-check-input'
-                onChange={e => this.setState({enabled: e.target.checked})}
-                type='checkbox'
-              />
+            <input
+              checked={checkboxValue}
+              className='form-check-input'
+              disabled={inputDisabled}
+              id={id + '-checkbox'}
+              onChange={e => this.props.onCheckboxValueChange(e.target.checked)}
+              type='checkbox'
+            />
+            <label className='form-check-label' htmlFor={id + '-checkbox'}>
               <b>Compare ortholog genes</b>
             </label>
           </div>
         </div>
         <div className='ml-3'>
           <UncontrolledDropdown className='pr-2' tag='span'>
-            <DropdownToggle caret className='align-baseline' color='primary' outline={!enabled || !stringency}>
+            <DropdownToggle caret className='align-baseline' color='primary' disabled={inputDisabled} outline={!checkboxValue || !stringency}>
               <span>Stringency{stringency && `: ${stringency.label}`}</span>
             </DropdownToggle>
             <DropdownMenu>
@@ -247,7 +266,7 @@ class OrthologPicker extends React.Component {
             </DropdownMenu>
           </UncontrolledDropdown>
           <UncontrolledDropdown className='pr-2' tag='span'>
-            <DropdownToggle caret className='align-baseline' color='primary' outline={!enabled || !selectedSpecies.length}>
+            <DropdownToggle caret className='align-baseline' color='primary' disabled={inputDisabled} outline={!checkboxValue || !selectedSpecies.length}>
               Species
               {selectedSpecies.length > 0 && <span>: <i>{selectedSpecies[0].fullName}</i></span>}
               {selectedSpecies.length > 1 && <span className='ml-1'>+{selectedSpecies.length - 1} species</span>}
@@ -336,12 +355,13 @@ class OrthologPicker extends React.Component {
 }
 
 OrthologPicker.propTypes = {
-  defaultEnabled: PropTypes.bool,
+  checkboxValue: PropTypes.bool.isRequired,
   defaultStringency: PropTypes.string,
   focusTaxonId: PropTypes.string,
   genesWithData: PropTypes.object,
   id: PropTypes.string.isRequired,
   onChange: PropTypes.func,
+  onCheckboxValueChange: PropTypes.func.isRequired,
   orthology: PropTypes.array,
   value: PropTypes.array,
 };

--- a/src/components/OrthologPicker.js
+++ b/src/components/OrthologPicker.js
@@ -53,7 +53,7 @@ const STRINGENCY_OPTIONS = [
   },
 ];
 
-const SPECIES = ALL_SPECIES.filter(s => s.orthologComparison);
+const SPECIES = ALL_SPECIES.filter(s => s.enableOrthologComparison);
 
 const sortBySpecies = species => species.sort(
   compareByFixedOrder(SPECIES.map(s => s.taxonId), s => s.taxonId)
@@ -105,7 +105,7 @@ class OrthologPicker extends React.Component {
   }
 
   updateInputDisabled() {
-    if (!getSpecies(this.props.focusTaxonId).orthologComparison) {
+    if (!getSpecies(this.props.focusTaxonId).enableOrthologComparison) {
       this.props.onCheckboxValueChange(false);
       this.setState({ inputDisabled: true });
     } else {

--- a/src/components/dataPage/PageNavEntity.js
+++ b/src/components/dataPage/PageNavEntity.js
@@ -18,7 +18,7 @@ const PageNavEntity = ({children, entityName, icon, truncateName}) => {
     <div className={`${style.entity}`}>
       <div className='w-100'>
         <div className='d-flex align-items-center'>
-          {icon && <span className='mr-2'>{icon}</span>}
+          {icon && <span>{icon}</span>}
           <h5 className={truncateName ? 'text-truncate' : ''} id='PageNavEntityTitle' ref={titleRef}>{entityName}</h5>
           {truncateName && attachTooltip &&
             <UncontrolledTooltip innerClassName={style.titleTooltip} placement='bottom' target='PageNavEntityTitle'>

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -30,6 +30,7 @@ class DiseaseComparisonRibbon extends Component {
   constructor(props){
     super(props);
     this.state = {
+      compareOrthologs: true,
       stringency: STRINGENCY_HIGH,
       selectedOrthologs: [],
       selectedBlock : {
@@ -39,6 +40,7 @@ class DiseaseComparisonRibbon extends Component {
     };
     this.onDiseaseGroupClicked = this.onDiseaseGroupClicked.bind(this);
     this.handleOrthologyChange = this.handleOrthologyChange.bind(this);
+    this.handleCompareOrthologsChange = this.handleCompareOrthologsChange.bind(this);
     this.onGroupClicked = this.onGroupClicked.bind(this);
     this.onSubjectClicked = this.onSubjectClicked.bind(this);
   }
@@ -81,6 +83,10 @@ class DiseaseComparisonRibbon extends Component {
     if(this.state.selectedBlock.group) {
       document.getElementById('disease-ribbon').selectGroup(this.state.selectedBlock.group.id);
     }
+  }
+
+  handleCompareOrthologsChange(compareOrthologs) {
+    this.setState({ compareOrthologs });
   }
 
   getGeneIdList() {
@@ -130,7 +136,7 @@ class DiseaseComparisonRibbon extends Component {
 
   render(){
     const { geneTaxon, orthology, summary } = this.props;
-    const { selectedBlock, selectedOrthologs } = this.state;
+    const { compareOrthologs, selectedBlock, selectedOrthologs } = this.state;
 
     if (!summary) {
       return null;
@@ -156,11 +162,12 @@ class DiseaseComparisonRibbon extends Component {
               </HelpPopup>
             </span>
             <OrthologPicker
-              defaultEnabled
+              checkboxValue={compareOrthologs}
               defaultStringency={STRINGENCY_HIGH}
               focusTaxonId={geneTaxon}
               id='disease-ortho-picker'
               onChange={this.handleOrthologyChange}
+              onCheckboxValueChange={this.handleCompareOrthologsChange}
               orthology={orthology.data}
               value={selectedOrthologs}
             />
@@ -182,23 +189,18 @@ class DiseaseComparisonRibbon extends Component {
               selection-mode='1'
               subject-base-url='/gene/'
               subject-open-new-tab={false}
-              subject-position='1'
+              subject-position={compareOrthologs ? '1' : '0'}
             />
           </div>
-          <div>{summary.loading && <LoadingSpinner />}</div>
+          <div className='ribbon-loading-overlay'>{summary.loading && <LoadingSpinner />}</div>
           <div className='text-muted mt-2'>
             <i>Cell color indicative of annotation volume</i>
           </div>
         </HorizontalScroll>
 
-
-
-
-
         {selectedBlock.group && <div className='pt-4'>
           <DiseaseAnnotationTable genes={this.getGeneIdList()} term={selectedBlock.group.id} />
         </div>}
-
       </div>
     );
   }

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -24,6 +24,7 @@ class ExpressionComparisonRibbon extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      compareOrthologs: true,
       stringency: STRINGENCY_HIGH,
       selectedOrthologs: [],
       selectedBlock : {
@@ -32,6 +33,7 @@ class ExpressionComparisonRibbon extends React.Component {
       }
     };
     this.handleOrthologChange = this.handleOrthologChange.bind(this);
+    this.handleCompareOrthologsChange = this.handleCompareOrthologsChange.bind(this);
     this.onExpressionGroupClicked = this.onExpressionGroupClicked.bind(this);
     this.onGroupClicked = this.onGroupClicked.bind(this);
     this.onSubjectClicked = this.onSubjectClicked.bind(this);
@@ -67,6 +69,10 @@ class ExpressionComparisonRibbon extends React.Component {
     if(this.state.selectedBlock.group) {
       document.getElementById('expression-ribbon').selectGroup(this.state.selectedBlock.group.id);
     }
+  }
+
+  handleCompareOrthologsChange(compareOrthologs) {
+    this.setState({ compareOrthologs });
   }
 
   hasParentElementId(elt, id) {
@@ -112,7 +118,7 @@ class ExpressionComparisonRibbon extends React.Component {
 
   render() {
     const { geneTaxon, orthology, summary } = this.props;
-    const { selectedOrthologs, selectedBlock } = this.state;
+    const { compareOrthologs, selectedOrthologs, selectedBlock } = this.state;
 
     // const genes = [geneId].concat(selectedOrthologs.map(o => getOrthologId(o)));
     // if only looking at a single yeast gene, just show CC group
@@ -156,12 +162,13 @@ class ExpressionComparisonRibbon extends React.Component {
               </HelpPopup>
             </span>
             <OrthologPicker
-              defaultEnabled
+              checkboxValue={compareOrthologs}
               defaultStringency={STRINGENCY_HIGH}
               focusTaxonId={geneTaxon}
               genesWithData={genesWithData}
               id='expression-ortho-picker'
               onChange={this.handleOrthologChange}
+              onCheckboxValueChange={this.handleCompareOrthologsChange}
               orthology={orthology.data}
               value={selectedOrthologs}
             />
@@ -184,10 +191,10 @@ class ExpressionComparisonRibbon extends React.Component {
               selection-mode='1'
               subject-base-url='/gene/'
               subject-open-new-tab={false}
-              subject-position='1'
+              subject-position={compareOrthologs ? '1' : '0'}
             />
           </div>
-          <div>{summary.loading && <LoadingSpinner />}</div>
+          <div className='ribbon-loading-overlay'>{summary.loading && <LoadingSpinner />}</div>
           <div className='text-muted mt-2'>
             <i>Cell color indicative of annotation volume; red slash indicates species lacks anatomical structure.</i>
           </div>

--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -30,6 +30,7 @@ class GeneOntologyRibbon extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      compareOrthologs: false,
       applyingFilters : false,      // if ortholgs are loading or any other filtering is happening
       loading : true,               // if ribbon strips loading
       subjectBaseURL : '/gene/',
@@ -50,6 +51,7 @@ class GeneOntologyRibbon extends Component {
       search : ''
     };
     this.handleOrthologyChange = this.handleOrthologyChange.bind(this);
+    this.handleCompareOrthologsChange = this.handleCompareOrthologsChange.bind(this);
     this.selectGroup = this.selectGroup.bind(this);
     this.onGroupClicked = this.onGroupClicked.bind(this);
     this.onSubjectClicked = this.onSubjectClicked.bind(this);
@@ -257,6 +259,10 @@ class GeneOntologyRibbon extends Component {
     });
   }
 
+  handleCompareOrthologsChange(compareOrthologs) {
+    this.setState({ compareOrthologs });
+  }
+
   handleExpAnnotations(event) {
     this.setState({ 'applyingFilters' : true });
     this.setState({'onlyEXP' : event.target.checked}, () => {
@@ -369,7 +375,7 @@ class GeneOntologyRibbon extends Component {
 
   renderControls() {
     const { geneTaxon, orthology } = this.props;
-    const { selectedOrthologs } = this.state;
+    const { compareOrthologs, selectedOrthologs } = this.state;
 
     return(
       <ControlsContainer>
@@ -380,11 +386,12 @@ class GeneOntologyRibbon extends Component {
         </span>
 
         <OrthologPicker
+          checkboxValue={compareOrthologs}
           defaultStringency={STRINGENCY_HIGH}
-          enabled={false}
           focusTaxonId={geneTaxon}
           id='go-ortho-picker'
           onChange={this.handleOrthologyChange}
+          onCheckboxValueChange={this.handleCompareOrthologsChange}
           orthology={orthology.data}
           value={selectedOrthologs}
         />
@@ -401,21 +408,18 @@ class GeneOntologyRibbon extends Component {
             <b>Show only experimental annotations</b>
           </label>
         </div>
-
-        <div style={{'width':'100%', 'text-align':'right'}}>
-          { this.state.applyingFilters ? <LoadingSpinner/> : '' }
-        </div>
       </ControlsContainer>
     );
   }
 
   renderRibbonStrips() {
+    const { applyingFilters, compareOrthologs, ribbon } = this.state;
     return(
       <HorizontalScroll className='text-nowrap'>
         <wc-ribbon-strips
           category-all-style='1'
           color-by='0'
-          data={JSON.stringify(this.state.ribbon)}
+          data={JSON.stringify(ribbon)}
           fire-event-on-empty-cells={false}
           group-clickable={false}
           group-open-new-tab={false}
@@ -425,8 +429,9 @@ class GeneOntologyRibbon extends Component {
           show-other-group
           subject-base-url='/gene/'
           subject-open-new-tab={false}
-          subject-position={this.state.ribbon.subjects.length == 1 ? '0' : '1'}
+          subject-position={compareOrthologs ? '1' : '0'}
         />
+        <div className='ribbon-loading-overlay'>{applyingFilters && <LoadingSpinner />}</div>
         <div className='text-muted mt-2'>
           <i>Cell color indicative of annotation volume</i>
         </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -163,6 +163,7 @@ export const SPECIES = [
     shortName: 'Hsa',
     apolloName: 'human',
     vertebrate: true,
+    showSingleCellExpressionAtlasLink: true,
   },
   {
     taxonId: 'NCBITaxon:10090',
@@ -170,6 +171,7 @@ export const SPECIES = [
     shortName: 'Mmu',
     apolloName: 'mouse',
     vertebrate: true,
+    showSingleCellExpressionAtlasLink: true,
   },
   {
     taxonId: 'NCBITaxon:10116',
@@ -177,6 +179,7 @@ export const SPECIES = [
     shortName: 'Rno',
     apolloName: 'rat',
     vertebrate: true,
+    showSingleCellExpressionAtlasLink: true,
   },
   {
     taxonId: 'NCBITaxon:7955',
@@ -184,6 +187,7 @@ export const SPECIES = [
     shortName: 'Dre',
     apolloName: 'zebrafish',
     vertebrate: true,
+    showSingleCellExpressionAtlasLink: true,
   },
   {
     taxonId: 'NCBITaxon:7227',
@@ -191,6 +195,7 @@ export const SPECIES = [
     shortName: 'Dme',
     apolloName: 'fly',
     vertebrate: false,
+    showSingleCellExpressionAtlasLink: true,
   },
   {
     taxonId: 'NCBITaxon:6239',
@@ -198,6 +203,7 @@ export const SPECIES = [
     shortName: 'Cel',
     apolloName: 'worm',
     vertebrate: false,
+    showSingleCellExpressionAtlasLink: true,
   },
   {
     taxonId: 'NCBITaxon:559292',
@@ -205,7 +211,15 @@ export const SPECIES = [
     shortName: 'Sce',
     apolloName: 'yeast',
     vertebrate: false,
+    showSingleCellExpressionAtlasLink: true,
   },
+  {
+    taxonId: 'NCBITaxon:2697049',
+    fullName: 'Severe acute respiratory syndrome coronavirus 2',
+    shortName: 'SARS-CoV-2',
+    vertebrate: false,
+    showSingleCellExpressionAtlasLink: false,
+  }
 ];
 
 export const TAXON_ORDER = SPECIES.map(s => s.taxonId);

--- a/src/constants.js
+++ b/src/constants.js
@@ -164,6 +164,7 @@ export const SPECIES = [
     apolloName: 'human',
     vertebrate: true,
     showSingleCellExpressionAtlasLink: true,
+    orthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:10090',
@@ -172,6 +173,7 @@ export const SPECIES = [
     apolloName: 'mouse',
     vertebrate: true,
     showSingleCellExpressionAtlasLink: true,
+    orthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:10116',
@@ -180,6 +182,7 @@ export const SPECIES = [
     apolloName: 'rat',
     vertebrate: true,
     showSingleCellExpressionAtlasLink: true,
+    orthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:7955',
@@ -188,6 +191,7 @@ export const SPECIES = [
     apolloName: 'zebrafish',
     vertebrate: true,
     showSingleCellExpressionAtlasLink: true,
+    orthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:7227',
@@ -196,6 +200,7 @@ export const SPECIES = [
     apolloName: 'fly',
     vertebrate: false,
     showSingleCellExpressionAtlasLink: true,
+    orthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:6239',
@@ -204,6 +209,7 @@ export const SPECIES = [
     apolloName: 'worm',
     vertebrate: false,
     showSingleCellExpressionAtlasLink: true,
+    orthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:559292',
@@ -212,6 +218,7 @@ export const SPECIES = [
     apolloName: 'yeast',
     vertebrate: false,
     showSingleCellExpressionAtlasLink: true,
+    orthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:2697049',
@@ -219,6 +226,7 @@ export const SPECIES = [
     shortName: 'SARS-CoV-2',
     vertebrate: false,
     showSingleCellExpressionAtlasLink: false,
+    orthologComparison: false,
   }
 ];
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -163,8 +163,8 @@ export const SPECIES = [
     shortName: 'Hsa',
     apolloName: 'human',
     vertebrate: true,
-    showSingleCellExpressionAtlasLink: true,
-    orthologComparison: true,
+    enableSingleCellExpressionAtlasLink: true,
+    enableOrthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:10090',
@@ -172,8 +172,8 @@ export const SPECIES = [
     shortName: 'Mmu',
     apolloName: 'mouse',
     vertebrate: true,
-    showSingleCellExpressionAtlasLink: true,
-    orthologComparison: true,
+    enableSingleCellExpressionAtlasLink: true,
+    enableOrthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:10116',
@@ -181,8 +181,8 @@ export const SPECIES = [
     shortName: 'Rno',
     apolloName: 'rat',
     vertebrate: true,
-    showSingleCellExpressionAtlasLink: true,
-    orthologComparison: true,
+    enableSingleCellExpressionAtlasLink: true,
+    enableOrthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:7955',
@@ -190,8 +190,8 @@ export const SPECIES = [
     shortName: 'Dre',
     apolloName: 'zebrafish',
     vertebrate: true,
-    showSingleCellExpressionAtlasLink: true,
-    orthologComparison: true,
+    enableSingleCellExpressionAtlasLink: true,
+    enableOrthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:7227',
@@ -199,8 +199,8 @@ export const SPECIES = [
     shortName: 'Dme',
     apolloName: 'fly',
     vertebrate: false,
-    showSingleCellExpressionAtlasLink: true,
-    orthologComparison: true,
+    enableSingleCellExpressionAtlasLink: true,
+    enableOrthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:6239',
@@ -208,8 +208,8 @@ export const SPECIES = [
     shortName: 'Cel',
     apolloName: 'worm',
     vertebrate: false,
-    showSingleCellExpressionAtlasLink: true,
-    orthologComparison: true,
+    enableSingleCellExpressionAtlasLink: true,
+    enableOrthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:559292',
@@ -217,16 +217,16 @@ export const SPECIES = [
     shortName: 'Sce',
     apolloName: 'yeast',
     vertebrate: false,
-    showSingleCellExpressionAtlasLink: true,
-    orthologComparison: true,
+    enableSingleCellExpressionAtlasLink: true,
+    enableOrthologComparison: true,
   },
   {
     taxonId: 'NCBITaxon:2697049',
     fullName: 'Severe acute respiratory syndrome coronavirus 2',
     shortName: 'SARS-CoV-2',
     vertebrate: false,
-    showSingleCellExpressionAtlasLink: false,
-    orthologComparison: false,
+    enableSingleCellExpressionAtlasLink: false,
+    enableOrthologComparison: false,
   }
 ];
 

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -28,6 +28,7 @@ import GeneMetaTags from './GeneMetaTags';
 import {setPageLoading} from '../../actions/loadingActions';
 import PageNavEntity from '../../components/dataPage/PageNavEntity';
 import PageCategoryLabel from '../../components/dataPage/PageCategoryLabel';
+import { getSpecies } from '../../lib/utils';
 
 const SUMMARY = 'Summary';
 const SEQUENCE_FEATURE_VIEWER = 'Sequence Feature Viewer';
@@ -106,10 +107,13 @@ class GenePage extends Component {
 
     // manufacture a single cell atlas cross reference since this isn't stored
     // in the database (see AGR-1406)
-    const singleCellAtlasXRef = {
-      name: 'Single Cell Expression Atlas',
-      url: `https://www.ebi.ac.uk/gxa/sc/search?q=${data.symbol}&species=${data.species.name}`,
-    };
+    let singleCellAtlasXRef;
+    if (getSpecies(data.species.taxonId).showSingleCellExpressionAtlasLink) {
+      singleCellAtlasXRef = {
+        name: 'Single Cell Expression Atlas',
+        url: `https://www.ebi.ac.uk/gxa/sc/search?q=${data.symbol}&species=${data.species.name}`,
+      };
+    }
 
     return (
       <DataPage key={data.id}>

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -108,7 +108,7 @@ class GenePage extends Component {
     // manufacture a single cell atlas cross reference since this isn't stored
     // in the database (see AGR-1406)
     let singleCellAtlasXRef;
-    if (getSpecies(data.species.taxonId).showSingleCellExpressionAtlasLink) {
+    if (getSpecies(data.species.taxonId).enableSingleCellExpressionAtlasLink) {
       singleCellAtlasXRef = {
         name: 'Single Cell Expression Atlas',
         url: `https://www.ebi.ac.uk/gxa/sc/search?q=${data.symbol}&species=${data.species.name}`,

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -138,7 +138,11 @@ class GenePage extends Component {
           </Subsection>
 
           <Subsection help={<GoUserGuide />} title={FUNCTION}>
-            <GeneOntologyRibbon geneId={data.id} geneTaxon={data.species.taxonId} />
+            <GeneOntologyRibbon
+              geneId={data.id}
+              geneSpecies={data.species}
+              geneSymbol={data.symbol}
+            />
           </Subsection>
 
           <Subsection title={PHENOTYPES}>

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -115,7 +115,7 @@ class GenePage extends Component {
       <DataPage key={data.id}>
         <GeneMetaTags gene={data} />
         <PageNav sections={SECTIONS}>
-          <PageNavEntity entityName={data.symbol} icon={<SpeciesIcon scale={0.5} species={data.species.name} />} truncateName>
+          <PageNavEntity entityName={data.symbol} icon={<SpeciesIcon iconClass='mr-2' scale={0.5} species={data.species.name} />} truncateName>
             <i>{data.species.name}</i>
             <DataSourceLink reference={data.crossReferences.primary} />
           </PageNavEntity>

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -101,10 +101,14 @@ export function filterOrthologyByStringency(orthologyList, stringency) {
   return orthologyList.filter(o => orthologyMeetsStringency(o, stringency));
 }
 
+export function getSpecies(taxonId) {
+  return SPECIES.find(s => s.taxonId === taxonId) || {};
+}
+
 export const shortSpeciesName = taxonId => {
-  return (SPECIES.find(s => s.taxonId === taxonId) || {}).shortName;
+  return getSpecies(taxonId).shortName;
 };
 
 export const fullSpeciesName = taxonId => {
-  return (SPECIES.find(s => s.taxonId === taxonId) || {}).fullName;
+  return getSpecies(taxonId).fullName;
 };

--- a/src/style.scss
+++ b/src/style.scss
@@ -114,5 +114,10 @@ wc-ribbon-cell.ribbon__subject--cell--no-annotation {
 
 .table__row__supercell__cell__link {
   color: $link-color
-}    
+}
 
+.ribbon-loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+}


### PR DESCRIPTION
Apologies for dumping all these into one branch. When I started I thought there would be fewer changes.

- For AGR-2327 I added a new property to the `SPECIES` objects (`enableSingleCellExpressionAtlasLink`) which controls whether that link is presented on the gene page
- For AGR-2326 I just needed to move a margin CSS class to lower in the tree
- For AGR-2325, the "undefined" string was being produced by the ribbon web component (the species name "SARS-CoV-2" breaks assumptions it has about what species names look like). After talking with Chris Grove, we decided it was best to just do an end run around the immediate problem by 1) ensuring that the gene name label doesn't appear when you're not comparing orthologs (this is good because I believe this was the pre-3.1.0 behavior that may have regressed with the ribbon web component) and 2) disabling ortholog comparison for SARS-CoV-2 genes (this is also good because it wouldn't really make sense to do anyway). This required a bit of refactoring in the `OrthologPicker` component to hoist the state of the checkbox up to the parent components and also to pick up another new property (`enableOrthologComparison`) on the `SPECIES` constants so that SARS-CoV-2 doesn't appear in the species list.
- For AGR-2324, I applied the fix for AGR-2000 to both places where new data is fetched to ensure the focus gene is always in the `subjects` list.