### PR TITLE
AGR-2271 pass table state (filter, sort, and pagination) to sequence feature viewer

### DIFF
--- a/src/containers/genePage/VariantsSequenceViewer.js
+++ b/src/containers/genePage/VariantsSequenceViewer.js
@@ -32,7 +32,8 @@ const VariantsSequenceViewer = ({alleles,allelesSelected,allelesVisible, observe
     return null;
   }
 
-  console.log(observedTableOpts);
+  // TODO: remove this line when observedTableOpts is being used
+  console.log(observedTableOpts);  // eslint-disable-line
 
 
   const anyVariantData = alleles.data.some(allele => allele.variants.length > 0);
@@ -83,6 +84,7 @@ VariantsSequenceViewer.propTypes = {
     chromosome: PropTypes.string,
     strand: PropTypes.string,
   }),
+  observedTableOpts: PropTypes.object.isRequired,  // TODO: have type checking based on what this component actually uses
   onAllelesSelect: PropTypes.func.isRequired,
 };
 

--- a/src/containers/genePage/VariantsSequenceViewer.js
+++ b/src/containers/genePage/VariantsSequenceViewer.js
@@ -27,10 +27,12 @@ export function findFminFmax(genomeLocation,variants){
   return {fmin,fmax};
 }
 
-const VariantsSequenceViewer = ({alleles,allelesSelected,allelesVisible, gene, genomeLocation}) => {
+const VariantsSequenceViewer = ({alleles,allelesSelected,allelesVisible, observedTableOpts, gene, genomeLocation}) => {
   if (alleles.loading || alleles.error || alleles.data.length === 0 || !genomeLocation.chromosome) {
     return null;
   }
+
+  console.log(observedTableOpts);
 
 
   const anyVariantData = alleles.data.some(allele => allele.variants.length > 0);

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {selectAlleles} from '../../selectors/geneSelectors';
 import {connect} from 'react-redux';
@@ -194,6 +194,16 @@ const AlleleTable = ({alleles, dispatchFetchAlleles, gene, geneId, geneSymbol, g
     }));
   }, [alleles]);
 
+  const [observedTableOpts, setObservedTableOpts] = useState({});
+
+  const handleTableUpdate = useCallback(
+    (opts) => {
+      setObservedTableOpts(opts);
+      dispatchFetchAlleles(opts);
+    },
+    [dispatchFetchAlleles, setObservedTableOpts]
+  );
+
   const [alleleIdsSelected, setAlleleIdsSelected] = useState([]);
 
   const variantsSequenceViewerProps = useMemo(() => {
@@ -211,8 +221,9 @@ const AlleleTable = ({alleles, dispatchFetchAlleles, gene, geneId, geneSymbol, g
       allelesSelected: alleleIdsSelected.map(formatAllele),
       allelesVisible: data.map(({id}) => formatAllele(id)),
       onAllelesSelect: setAlleleIdsSelected,
+      observedTableOpts,
     };
-  }, [data, alleleIdsSelected, setAlleleIdsSelected]);
+  }, [data, alleleIdsSelected, setAlleleIdsSelected, observedTableOpts]);
 
   const selectRow = useMemo(() => ({
     mode: 'checkbox',
@@ -249,7 +260,7 @@ const AlleleTable = ({alleles, dispatchFetchAlleles, gene, geneId, geneSymbol, g
         key={geneId}
         keyField='id'
         loading={alleles.loading}
-        onUpdate={dispatchFetchAlleles}
+        onUpdate={handleTableUpdate}
         rowStyle={{cursor: 'pointer'}}
         selectRow={selectRow}
         sortOptions={sortOptions}


### PR DESCRIPTION
In order to support coordination between the variant table and the sequence feature viewer, I'm allowing the Sequence Feature Viewer component some visibility into the table's state. 

I'm spying on the table's representation of filtering, sorting, and pagination, and forward that information on the the Sequence Feature Viewer component. 

Not sure if this is a good idea. Thoughts and suggestions are welcome.