### PR TITLE
Bump Viewer Version and Covid Padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@geneontology/wc-ribbon-table": "0.0.51",
     "@geneontology/wc-ribbon-strips": "0.0.34",
     "abortcontroller-polyfill": "^1.2.5",
-    "agr_genomefeaturecomponent": "^0.3.7",
+    "agr_genomefeaturecomponent": "^0.3.8",
     "bootstrap": "4.3.1",
     "caniuse-lite": "^1.0.30000975",
     "core-js": "^2.6.5",

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -80,6 +80,12 @@ class GenomeFeatureWrapper extends Component {
     let transcriptTypes = getTranscriptTypes();
     const speciesInfo = getSpecies(species);
     const apolloPrefix = speciesInfo.apolloName;
+    //add padding for SARS-Cov-2
+    if(species === 'NCBITaxon:2697049'){
+      const padding = 500;
+      fmin = (fmin - padding) > 1 ? fmin - padding : 1;
+      fmax = (fmax + padding);
+    }
     if (displayType === 'ISOFORM') {
       return {
         'locale': 'global',


### PR DESCRIPTION
Fixes for AGR-2342.  Adding 500bp padding to viewer window and fixed a bug in the viewer for displaying features with no sub-features.