### PR TITLE
Revert "Bump Viewer Version and Covid Padding"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@geneontology/wc-ribbon-table": "0.0.51",
     "@geneontology/wc-ribbon-strips": "0.0.34",
     "abortcontroller-polyfill": "^1.2.5",
-    "agr_genomefeaturecomponent": "^0.3.7",
+    "agr_genomefeaturecomponent": "^0.3.8",
     "bootstrap": "4.3.1",
     "caniuse-lite": "^1.0.30000975",
     "core-js": "^2.6.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@geneontology/wc-ribbon-table": "0.0.51",
     "@geneontology/wc-ribbon-strips": "0.0.34",
     "abortcontroller-polyfill": "^1.2.5",
-    "agr_genomefeaturecomponent": "^0.3.8",
+    "agr_genomefeaturecomponent": "^0.3.7",
     "bootstrap": "4.3.1",
     "caniuse-lite": "^1.0.30000975",
     "core-js": "^2.6.5",

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -80,12 +80,6 @@ class GenomeFeatureWrapper extends Component {
     let transcriptTypes = getTranscriptTypes();
     const speciesInfo = getSpecies(species);
     const apolloPrefix = speciesInfo.apolloName;
-    //add padding for SARS-Cov-2
-    if(species === 'NCBITaxon:2697049'){
-      const padding = 500;
-      fmin = (fmin - padding) > 1 ? fmin - padding : 1;
-      fmax = (fmax + padding);
-    }
     if (displayType === 'ISOFORM') {
       return {
         'locale': 'global',


### PR DESCRIPTION
Reverts alliance-genome/agr_ui#715

- [x] confirm yeast (sometimes weird chromosomes stuff), http://localhost:2992/gene/SGD:S000007259#sequence-feature-viewer + http://localhost:2992/gene/SGD:S000002812#sequence-feature-viewer
- [x] confirm COV-2 - ORF8
- [x] confirm  sox9b
- [x] confirm cd (for flybase)