### PR TITLE
AGR-2178 Add transgenic alleles table to gene page

### DIFF
--- a/src/components/ConstructLink.js
+++ b/src/components/ConstructLink.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import DataSourceLink from './dataSourceLink';
+
+const ConstructLink = ({construct}) => {
+  return (
+    <DataSourceLink reference={construct.crossReferences.primary}>
+      <span dangerouslySetInnerHTML={{__html: construct.name}} />
+    </DataSourceLink>
+  );
+};
+
+ConstructLink.propTypes = {
+  construct: PropTypes.shape({
+    name: PropTypes.string,
+    crossReferences: PropTypes.shape({
+      primary: PropTypes.object,
+    }),
+  })
+};
+
+export default ConstructLink;

--- a/src/components/dataTable/BooleanLinkCell.js
+++ b/src/components/dataTable/BooleanLinkCell.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { HashLink as Link } from 'react-router-hash-link';
+
+const BooleanLinkCell = ({
+  to,
+  value,
+}) => {
+  if (!value) {
+    return null;
+  }
+  return (
+    <Link to={to}>Yes</Link>
+  );
+};
+
+BooleanLinkCell.propTypes = {
+  to: PropTypes.string,
+  value: PropTypes.any,
+};
+
+export default BooleanLinkCell;

--- a/src/components/dataTable/DataTable.js
+++ b/src/components/dataTable/DataTable.js
@@ -116,9 +116,10 @@ const DataTable = ({
   });
 
   columns.forEach(column => {
+    const filterField = column.filterName || column.dataField;
     const columnFilter = filters &&
-      filters[column.dataField] &&
-      filters[column.dataField].filterVal;
+      filters[filterField] &&
+      filters[filterField].filterVal;
     if (!column.headerFormatter) {
       column.headerFormatter = (column, _, {filterElement}) => (
         <ColumnHeader

--- a/src/components/dataTable/RotatedHeaderCell.js
+++ b/src/components/dataTable/RotatedHeaderCell.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import style from './RotatedHeaderCell.scss';
+
+const RotatedHeaderCell = ({children}) => {
+  return (
+    <div className={style.label}>
+      {children}
+    </div>
+  );
+};
+
+RotatedHeaderCell.propTypes = {
+  children: PropTypes.node,
+};
+
+export default RotatedHeaderCell;

--- a/src/components/dataTable/RotatedHeaderCell.scss
+++ b/src/components/dataTable/RotatedHeaderCell.scss
@@ -1,0 +1,5 @@
+.label {
+  transform: rotate(-45deg);
+  transform-origin: calc(0% + 0.5rem) calc(100% - 1rem);
+  white-space: nowrap;
+}

--- a/src/components/dataTable/RotatedHeaderCell.scss
+++ b/src/components/dataTable/RotatedHeaderCell.scss
@@ -2,4 +2,6 @@
   transform: rotate(-45deg);
   transform-origin: calc(0% + 0.5rem) calc(100% - 1rem);
   white-space: nowrap;
+  display: inline-flex;
+  width: 1.5rem
 }

--- a/src/components/dataTable/utils.js
+++ b/src/components/dataTable/utils.js
@@ -5,8 +5,9 @@ export const renderPaginationShowsTotal = (start, end, total) => {
   return <span>Showing { start } - { end } of { total.toLocaleString() } rows</span>;
 };
 
-export const getDistinctFieldValue = ({supplementalData = {}} = {}, field) => {
-  const {distinctFieldValues = {}} = supplementalData;
+export const getDistinctFieldValue = (response, field) => {
+  response = response || {};
+  const {distinctFieldValues = {}} = response.supplementalData || {};
   return (distinctFieldValues[field] || []).sort(compareAlphabeticalCaseInsensitive);
 };
 

--- a/src/containers/allelePage/AlleleTransgenicConstructs.js
+++ b/src/containers/allelePage/AlleleTransgenicConstructs.js
@@ -5,10 +5,10 @@ import {
   AttributeList,
   AttributeValue
 } from '../../components/attribute';
-import DataSourceLink from '../../components/dataSourceLink';
 import CommaSeparatedGeneList from './CommaSeparatedGeneList';
 import NoData from '../../components/noData';
 import {Link} from 'react-router-dom';
+import ConstructLink from '../../components/ConstructLink';
 
 const AlleleTransgenicConstructs = ({constructs}) => {
   if (!constructs || constructs.length === 0) {
@@ -25,9 +25,7 @@ const AlleleTransgenicConstructs = ({constructs}) => {
           <AttributeList className='mb-0'>
             <AttributeLabel>Symbol</AttributeLabel>
             <AttributeValue>
-              <DataSourceLink reference={construct.crossReferences.primary}>
-                <span dangerouslySetInnerHTML={{__html: construct.name}} />
-              </DataSourceLink>
+              <ConstructLink construct={construct} />
             </AttributeValue>
 
             <AttributeLabel>Expressed Components</AttributeLabel>

--- a/src/containers/genePage/TransgenicAlleleTable.js
+++ b/src/containers/genePage/TransgenicAlleleTable.js
@@ -1,0 +1,151 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AlleleCell, DataTable, SpeciesCell } from '../../components/dataTable';
+import SynonymList from '../../components/synonymList';
+import ConstructLink from '../../components/ConstructLink';
+import useDataTableQuery from '../../hooks/useDataTableQuery';
+import CommaSeparatedGeneList from '../allelePage/CommaSeparatedGeneList';
+import RotatedHeaderCell from '../../components/dataTable/RotatedHeaderCell';
+import BooleanLinkCell from '../../components/dataTable/BooleanLinkCell';
+
+const constructsRelatedGenesFormatter = constructRelatedGenes => (
+  constructRelatedGenes.map(({id, genes}) => (
+    <div key={id}>
+      <CommaSeparatedGeneList genes={genes} />
+    </div>
+  ))
+);
+
+const TransgenicAlleleTable = ({geneId}) => {
+  const {
+    data: results,
+    ...tableProps
+  } = useDataTableQuery(`/api/gene/${geneId}/transgenic-alleles`);
+
+  const data = results.map(result => ({
+    ...result,
+    constructExpressedGene: result.constructs.map(construct => ({
+      id: construct.id,
+      genes: construct.expressedGenes,
+    })),
+    constructTargetedGene: result.constructs.map(construct => ({
+      id: construct.id,
+      genes: construct.targetGenes,
+    })),
+    constructRegulatedGene: result.constructs.map(construct => ({
+      id: construct.id,
+      genes: construct.regulatedByGenes,
+    })),
+  }));
+
+  const columns = [
+    {
+      dataField: 'species',
+      text: 'Species',
+      headerNode: (
+        <>
+          Species
+          <br />
+          <span className='text-muted'>(Carrying the transgene)</span>
+        </>
+      ),
+      formatter: species => <SpeciesCell species={species} />,
+      filterable: true,
+      headerStyle: {width: '100px'},
+    },
+    {
+      dataField: 'symbol',
+      text: 'Allele symbol',
+      formatter: (_, allele) => <AlleleCell allele={allele} />,
+      headerStyle: {width: '185px'},
+      filterable: true,
+      filterName: 'allele',
+    },
+    {
+      dataField: 'synonyms',
+      text: 'Synonyms',
+      formatter: synonyms => <SynonymList synonyms={synonyms}/>,
+      headerStyle: {width: '165px'},
+      filterable: true,
+      filterName: 'synonym',
+    },
+    {
+      dataField: 'constructs',
+      text: 'Transgenic construct',
+      formatter: constructs => constructs.map(construct => (
+        <div key={construct.id}>
+          <ConstructLink construct={construct} />
+        </div>
+      )),
+      headerStyle: {width: '185px'},
+      filterable: true,
+      filterName: 'construct',
+    },
+    {
+      dataField: 'constructExpressedGene',
+      text: 'Expressed components',
+      formatter: constructsRelatedGenesFormatter,
+      headerStyle: {width: '120px'},
+      filterable: true,
+    },
+    {
+      dataField: 'constructTargetedGene',
+      text: 'Knock-down targets',
+      formatter: constructsRelatedGenesFormatter,
+      headerStyle: {width: '120px'},
+      filterable: true,
+    },
+    {
+      dataField: 'constructRegulatedGene',
+      text: 'Regulatory regions',
+      formatter: constructsRelatedGenesFormatter,
+      headerStyle: {width: '120px'},
+      filterable: true,
+    },
+    {
+      dataField: 'hasDisease',
+      text: 'Has Disease Annotations',
+      formatter: (hasDisease, allele) => (
+        <BooleanLinkCell
+          to={`/allele/${allele.id}#disease-associations`}
+          value={hasDisease}
+        />
+      ),
+      headerFormatter: column => <RotatedHeaderCell>{column.text}</RotatedHeaderCell>,
+      headerStyle: {
+        width: '40px',
+        height: '130px',
+      },
+    },
+    {
+      dataField: 'hasPhenotype',
+      text: 'Has Phenotype Annotations',
+      formatter: (hasPhenotype, allele) => (
+        <BooleanLinkCell
+          to={`/allele/${allele.id}#phenotypes`}
+          value={hasPhenotype}
+        />
+      ),
+      headerFormatter: column => <RotatedHeaderCell>{column.text}</RotatedHeaderCell>,
+      headerStyle: {
+        width: '40px',
+        height: '140px',
+      }
+    },
+  ];
+
+  return (
+    <DataTable
+      {...tableProps}
+      keyField='id'
+      columns={columns}
+      data={data}
+    />
+  );
+};
+
+TransgenicAlleleTable.propTypes = {
+  geneId: PropTypes.string.isRequired,
+};
+
+export default TransgenicAlleleTable;

--- a/src/containers/genePage/TransgenicAlleleTable.js
+++ b/src/containers/genePage/TransgenicAlleleTable.js
@@ -50,7 +50,7 @@ const TransgenicAlleleTable = ({geneId}) => {
         <>
           Species
           <br />
-          <span className='text-muted'>(Carrying the transgene)</span>
+          <small className='text-muted text-transform-none'>(carrying the transgene)</small>
         </>
       ),
       formatter: species => <SpeciesCell species={species} />,
@@ -115,11 +115,13 @@ const TransgenicAlleleTable = ({geneId}) => {
           value={hasDisease}
         />
       ),
-      headerFormatter: column => <RotatedHeaderCell>{column.text}</RotatedHeaderCell>,
+      headerNode: <RotatedHeaderCell>Has Disease Annotations</RotatedHeaderCell>,
       headerStyle: {
-        width: '40px',
+        width: '50px',
         height: '130px',
       },
+      filterable: ['true', 'false'],
+      filterFormatter: val => val === 'true' ? 'Yes' : 'No',
     },
     {
       dataField: 'hasPhenotype',
@@ -130,11 +132,13 @@ const TransgenicAlleleTable = ({geneId}) => {
           value={hasPhenotype}
         />
       ),
-      headerFormatter: column => <RotatedHeaderCell>{column.text}</RotatedHeaderCell>,
+      headerNode: <RotatedHeaderCell>Has Phenotype Annotations</RotatedHeaderCell>,
       headerStyle: {
-        width: '40px',
+        width: '50px',
         height: '140px',
-      }
+      },
+      filterable: ['true', 'false'],
+      filterFormatter: val => val === 'true' ? 'Yes' : 'No',
     },
   ];
 

--- a/src/containers/genePage/TransgenicAlleleTable.js
+++ b/src/containers/genePage/TransgenicAlleleTable.js
@@ -7,6 +7,9 @@ import useDataTableQuery from '../../hooks/useDataTableQuery';
 import CommaSeparatedGeneList from '../allelePage/CommaSeparatedGeneList';
 import RotatedHeaderCell from '../../components/dataTable/RotatedHeaderCell';
 import BooleanLinkCell from '../../components/dataTable/BooleanLinkCell';
+import { getDistinctFieldValue } from '../../components/dataTable/utils';
+import { compareByFixedOrder } from '../../lib/utils';
+import { SPECIES_NAME_ORDER } from '../../constants';
 
 const constructsRelatedGenesFormatter = constructRelatedGenes => (
   constructRelatedGenes.map(({id, genes}) => (
@@ -19,6 +22,7 @@ const constructsRelatedGenesFormatter = constructRelatedGenes => (
 const TransgenicAlleleTable = ({geneId}) => {
   const {
     data: results,
+    resolvedData,
     ...tableProps
   } = useDataTableQuery(`/api/gene/${geneId}/transgenic-alleles`);
 
@@ -50,7 +54,7 @@ const TransgenicAlleleTable = ({geneId}) => {
         </>
       ),
       formatter: species => <SpeciesCell species={species} />,
-      filterable: true,
+      filterable: getDistinctFieldValue(resolvedData, 'species').sort(compareByFixedOrder(SPECIES_NAME_ORDER)),
       headerStyle: {width: '100px'},
     },
     {
@@ -65,7 +69,7 @@ const TransgenicAlleleTable = ({geneId}) => {
       dataField: 'synonyms',
       text: 'Synonyms',
       formatter: synonyms => <SynonymList synonyms={synonyms}/>,
-      headerStyle: {width: '165px'},
+      headerStyle: {width: '200px'},
       filterable: true,
       filterName: 'synonym',
     },

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -27,6 +27,7 @@ import PageNavEntity from '../../components/dataPage/PageNavEntity';
 import PageCategoryLabel from '../../components/dataPage/PageCategoryLabel';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
 import { getSpecies } from '../../lib/utils';
+import TransgenicAlleleTable from './TransgenicAlleleTable';
 
 const SUMMARY = 'Summary';
 const SEQUENCE_FEATURE_VIEWER = 'Sequence Feature Viewer';
@@ -35,6 +36,7 @@ const ORTHOLOGY = 'Orthology';
 const DISEASE = 'Disease Associations';
 const EXPRESSION = 'Expression';
 const ALLELES = 'Alleles and Variants';
+const TG_ALLELES = 'Transgenic Alleles';
 const PHENOTYPES = 'Phenotypes';
 const INTERACTIONS = 'Molecular Interactions';
 const MODELS = 'Models';
@@ -46,6 +48,7 @@ const SECTIONS = [
   {name: PHENOTYPES},
   {name: DISEASE},
   {name: ALLELES},
+  {name: TG_ALLELES},
   {name: MODELS},
   {name: SEQUENCE_FEATURE_VIEWER},
   {name: EXPRESSION},
@@ -142,6 +145,10 @@ const GenePage = ({geneId}) => {
             geneSymbol={data.symbol}
             species={data.species.name}
           />
+        </Subsection>
+
+        <Subsection title={TG_ALLELES}>
+          <TransgenicAlleleTable geneId={data.id} />
         </Subsection>
 
         <Subsection title={MODELS}>


### PR DESCRIPTION
@sibyl229 this work contains two components (`RotatedHeaderCell` and `BooleanLinkCell`) that can also be used for the allele and variants table updates. 

The `filterFormatter` bit is something I'm tacking on to the react-bootstrap-table column definition in order to allow for custom formatting of the checkbox filter labels. Here it's being used to translate true/false (which is what the API wants) to Yes/No (which is what the UI needs). The implementation of `filterFormatter` is part of the disease NOT annotation work, but I'm using it here in anticipation that that work will be coming along soon.