### PR TITLE
GenomeFeatureComponent version bump and padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@geneontology/wc-ribbon-table": "0.0.51",
     "@geneontology/wc-ribbon-strips": "0.0.34",
     "abortcontroller-polyfill": "^1.5.0",
-    "agr_genomefeaturecomponent": "^0.3.8",
+    "agr_genomefeaturecomponent": "^0.3.9",
     "bootstrap": "4.4.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^1.0.6",

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -80,6 +80,11 @@ class GenomeFeatureWrapper extends Component {
     let transcriptTypes = getTranscriptTypes();
     const speciesInfo = getSpecies(species);
     const apolloPrefix = speciesInfo.apolloName;
+    if(species === 'NCBITaxon:2697049'){
+      const padding = (fmax-fmin)*0.2;
+      fmin = (fmin - padding) > 1 ? fmin - padding : 1;
+      fmax = (fmax + padding);
+    }
     if (displayType === 'ISOFORM') {
       return {
         'locale': 'global',


### PR DESCRIPTION
Adding in the new version(0.3.9) of the widget and adding a 20% padding for CoV-2 viewer windows.

This update should fix both the axis issue and center the feature.  The layout changes for the widget apply to all isoform viewers (w/o variants) but I can address this in a future update for the other if that would help.

