### PR TITLE
AGR-2271

### DIFF
--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -13,6 +13,7 @@ import RotatedHeaderCell from '../../components/dataTable/RotatedHeaderCell';
 import BooleanLinkCell from '../../components/dataTable/BooleanLinkCell';
 import VariantsSequenceViewer from './VariantsSequenceViewer';
 import useDataTableQuery from '../../hooks/useDataTableQuery';
+import useAllVariants from '../../hooks/useAllVariants';
 
 const AlleleTable = ({gene, geneId, geneSymbol, geneLocation = {}, species, geneDataProvider}) => {
   const {

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -35,6 +35,15 @@ const AlleleTable = ({gene, geneId, geneSymbol, geneLocation = {}, species, gene
 
   const [alleleIdsSelected, setAlleleIdsSelected] = useState([]);
 
+  //Sequence Viewer Specific Call
+  const viewerVariants = useAllVariants(geneId, tableProps.tableState);
+  const variantDisplayData = useMemo(() => {
+    return viewerVariants.data && viewerVariants.data.results.map(allele => ({
+      ...allele,
+    }));
+  }, [viewerVariants.data]);
+
+
   const variantsSequenceViewerProps = useMemo(() => {
     /*
        Warning!
@@ -48,11 +57,11 @@ const AlleleTable = ({gene, geneId, geneSymbol, geneLocation = {}, species, gene
     );
     return {
       allelesSelected: alleleIdsSelected.map(formatAllele),
-      allelesVisible: data && data.map(({id}) => formatAllele(id)),
+      allelesVisible: variantDisplayData ? variantDisplayData && variantDisplayData.map(({id}) => formatAllele(id)) : [],
       onAllelesSelect: setAlleleIdsSelected,
       tableState: tableProps.tableState
     };
-  }, [data, alleleIdsSelected, setAlleleIdsSelected, tableProps.tableState]);
+  }, [variantDisplayData, alleleIdsSelected, setAlleleIdsSelected, tableProps.tableState]);
 
   const selectRow = useMemo(() => ({
     mode: 'checkbox',

--- a/src/hooks/useAllVariants.js
+++ b/src/hooks/useAllVariants.js
@@ -11,7 +11,7 @@ function getFullUrl(baseUrl, tableState) {
 }
 
 export default function useAllVariants(geneId, tableState) {
-  const url = `/api/gene/${geneId}/alleles?`
+  const url = `/api/gene/${geneId}/alleles?`;
   return useQuery ([url, tableState], () => {
     return fetchData(getFullUrl(url,tableState));
   });

--- a/src/hooks/useAllVariants.js
+++ b/src/hooks/useAllVariants.js
@@ -1,0 +1,18 @@
+import { useQuery } from 'react-query';
+import fetchData from '../lib/fetchData';
+import {buildTableQueryString} from '../lib/utils';
+
+function getFullUrl(baseUrl, tableState) {
+  if (!baseUrl) {
+    return null;
+  }
+  const separator = baseUrl.indexOf('?') < 0 ? '?' : '&';
+  return baseUrl + separator + buildTableQueryString({page: tableState.page, sizePerPage:1000, filters: tableState.filters});
+}
+
+export default function useAllVariants(geneId, tableState) {
+  const url = `/api/gene/${geneId}/alleles?`
+  return useQuery ([url, tableState], () => {
+    return fetchData(getFullUrl(url,tableState));
+  });
+}


### PR DESCRIPTION
Fixes AGR 2271 by displaying all variants regardless of pagination.  Uses a separate API call in useAllVariants that ignores the table pagination but uses the filters on the page.  Hopefully this code is consistent with the other react query code... I'm not all that familiar with it yet so this may not be the most concise way to do it.