### PR TITLE
AGR-2330 : add error handling when data can not be fetched or ID is missing

### DIFF
--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -14,7 +14,7 @@ import LoadingSpinner from '../loadingSpinner';
 
 import { withRouter } from 'react-router';
 
-// import NoData from '../noData';
+import NoData from '../noData';
 
 
 const GO_API_URL = 'https://api.geneontology.org/api/';
@@ -229,12 +229,12 @@ class GeneOntologyRibbon extends Component {
                   error: false
                 }
               });
-            }).catch(err => {
-            this.setState({ loading: false, error : true });
-          });
-        }).catch(err => {
+            }).catch(() => {
+              this.setState({ loading: false, error : true });
+            });
+        }).catch(() => {
           this.setState({ loading: false, error : true });
-        })
+        });
         
 
       // regular group
@@ -251,9 +251,9 @@ class GeneOntologyRibbon extends Component {
               error: false
             }
           });
-        }).catch((err) => {
+        }).catch(() => {
           this.setState({ selected: { loading: false, error : true } } );
-        })
+        });
 
     }
 
@@ -276,7 +276,7 @@ class GeneOntologyRibbon extends Component {
           }
         });
 
-      }).catch((err) => {
+      }).catch(() => {
         this.setState({ loading: false, error : true });
       });
     });
@@ -508,7 +508,7 @@ class GeneOntologyRibbon extends Component {
   }
 
   renderError() {
-    return <div>No function available for that gene</div>
+    return <NoData>No function available for that gene</NoData>;
   }
 
   renderValid() {
@@ -517,7 +517,7 @@ class GeneOntologyRibbon extends Component {
         {this.state.loading ? <LoadingSpinner /> : this.renderRibbonStrips()}
         {this.state.selected.group ? this.state.selected.loading ? <LoadingSpinner/> : this.renderRibbonTable() : ''}
       </div>
-    )
+    );
   }
 
 }

--- a/src/components/geneOntologyRibbon/index.js
+++ b/src/components/geneOntologyRibbon/index.js
@@ -29,6 +29,7 @@ class GeneOntologyRibbon extends Component {
       compareOrthologs: false,
       applyingFilters: false,      // if ortholgs are loading or any other filtering is happening
       loading: true,               // if ribbon strips loading
+      error: false,                // if the ribbon encountered any error while loading (eg ID not present in mygene.info)
       subjectBaseURL: '/gene/',
       stringency: STRINGENCY_HIGH,
       selectedOrthologs: [],
@@ -42,7 +43,8 @@ class GeneOntologyRibbon extends Component {
         subject: null,
         group: null,
         data: null,
-        loading: false             // if ribbon table loading
+        loading: false,            // if ribbon table loading
+        error: false               // not used yet but follow the same logic as for the strips - can be used if errors occured while loading the table (should never happened)
       },
       search: ''
     };
@@ -183,7 +185,8 @@ class GeneOntologyRibbon extends Component {
         subject: subject,
         group: group,
         data: null,
-        loading: true
+        loading: true,
+        error: false
       }
     });
 
@@ -222,11 +225,17 @@ class GeneOntologyRibbon extends Component {
                   subject: subject,
                   group: group,
                   data: filtered, // assoc data from BioLink
-                  loading: false
+                  loading: false,
+                  error: false
                 }
               });
-            });
-        });
+            }).catch(err => {
+            this.setState({ loading: false, error : true });
+          });
+        }).catch(err => {
+          this.setState({ loading: false, error : true });
+        })
+        
 
       // regular group
     } else {
@@ -238,10 +247,14 @@ class GeneOntologyRibbon extends Component {
               subject: subject,
               group: group,
               data: filtered, // assoc data from BioLink
-              loading: false
+              loading: false,
+              error: false
             }
           });
-        });
+        }).catch((err) => {
+          this.setState({ selected: { loading: false, error : true } } );
+        })
+
     }
 
   }
@@ -255,6 +268,7 @@ class GeneOntologyRibbon extends Component {
         this.setState({
           applyingFilters: false,
           loading: false,
+          error: false,
           ribbon: data
         }, () => {
           if (this.state.selected.subject && !this.state.ribbon.subjects.some(sub => sub.id === this.state.selected.subject.id)) {
@@ -262,8 +276,8 @@ class GeneOntologyRibbon extends Component {
           }
         });
 
-      }).catch(() => {
-        this.setState({ loading: false });
+      }).catch((err) => {
+        this.setState({ loading: false, error : true });
       });
     });
   }
@@ -277,12 +291,11 @@ class GeneOntologyRibbon extends Component {
     this.setState({ 'onlyEXP': event.target.checked }, () => {
       this.fetchSummaryData(this.state.subset, this.getGeneIdList()).then(data => {
         data = this.ensureFocusGeneIsPopulated(data);
-        this.setState({ applyingFilters: false, loading: false, ribbon: data });
+        this.setState({ applyingFilters: false, loading: false, error : false, ribbon: data });
 
       }).catch(() => {
-        this.setState({ loading: false });
+        this.setState({ loading: false, error : true });
       });
-
     });
   }
 
@@ -488,12 +501,23 @@ class GeneOntologyRibbon extends Component {
 
         {this.renderControls()}
 
-        {this.state.loading ? <LoadingSpinner /> : this.renderRibbonStrips()}
-
-        {this.state.selected.group ? this.state.selected.loading ? <LoadingSpinner/> : this.renderRibbonTable() : ''}
+        {this.state.error ? this.renderError() : this.renderValid()}
 
       </div>
     );
+  }
+
+  renderError() {
+    return <div>No function available for that gene</div>
+  }
+
+  renderValid() {
+    return (
+      <div>
+        {this.state.loading ? <LoadingSpinner /> : this.renderRibbonStrips()}
+        {this.state.selected.group ? this.state.selected.loading ? <LoadingSpinner/> : this.renderRibbonTable() : ''}
+      </div>
+    )
   }
 
 }


### PR DESCRIPTION
Essentially, just use catch for fetch functions and add a state "error" to alter the rendering in case of issues.
https://agr-jira.atlassian.net/browse/AGR-2330

Tests:
	* HGNC with mapping
		/gene/HGNC:11998#function---go-annotations
		display correctly
	* HGNC without mapping
		/gene/HGNC:53833#function---go-annotations
		Show "No function available for that gene"
	* Regular gene
		/gene/ZFIN:ZDB-GENE-990415-270
		display correctly