### PR TITLE
Adding multi-variant track to jbrowse link

### DIFF
--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -67,7 +67,7 @@ class GenomeFeatureWrapper extends Component {
     const bufferedMax = Math.round(this.props.fmax + (linkLength * LINK_BUFFER / 2.0));
     const externalLocationString = this.props.chromosome + ':' + bufferedMin + '..' + bufferedMax;
     // TODO: handle bufferedMax exceeding chromosome length, though I think it has a good default.
-    const tracks = ['Variants', 'All Genes'];
+    const tracks = ['Variants', 'All Genes','Multiple-Variant Alleles'];
     return externalJBrowsePrefix +
       '&tracks=' + encodeURIComponent(tracks.join(',')) +
       '&highlight=' + geneSymbolUrl +


### PR DESCRIPTION
I don't have a test instance to verify that this change works, but it's pretty simple, so I imagine it will.  It should just add the multiple variant allele track to the "Genome location" jbrowse link.

