### PR TITLE
Fixes AGR-2341

### DIFF
--- a/src/containers/genePage/VariantsSequenceViewer.js
+++ b/src/containers/genePage/VariantsSequenceViewer.js
@@ -25,7 +25,7 @@ export function findFminFmax(genomeLocation, variants) {
   return { fmin, fmax };
 }
 
-const VariantsSequenceViewer = ({ alleles, allelesSelected, allelesVisible, tableState, gene, genomeLocation }) => {
+const VariantsSequenceViewer = ({ alleles, allelesSelected, allelesVisible, tableState, gene, genomeLocation,genomeLocationList }) => {
   if (!alleles || alleles.length === 0 || !genomeLocation.chromosome) {
     return null;
   }
@@ -50,6 +50,7 @@ const VariantsSequenceViewer = ({ alleles, allelesSelected, allelesVisible, tabl
       fmax={fmax}
       fmin={fmin}
       geneSymbol={gene.symbol}
+      genomeLocationList={genomeLocationList}
       height='200px'
       id='genome-feature-allele-location-id'
       primaryId={gene.id}
@@ -82,6 +83,7 @@ VariantsSequenceViewer.propTypes = {
     chromosome: PropTypes.string,
     strand: PropTypes.string,
   }),
+  genomeLocationList: PropTypes.array,
   onAllelesSelect: PropTypes.func.isRequired,
   tableState: PropTypes.object.isRequired,  // TODO: have type checking based on what this component actually uses
 };

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -15,7 +15,7 @@ import VariantsSequenceViewer from './VariantsSequenceViewer';
 import useDataTableQuery from '../../hooks/useDataTableQuery';
 import useAllVariants from '../../hooks/useAllVariants';
 
-const AlleleTable = ({gene, geneId, geneSymbol, geneLocation = {}, species, geneDataProvider}) => {
+const AlleleTable = ({gene, geneId, geneSymbol, geneLocation = {}, species, geneDataProvider, genomeLocationList}) => {
   const {
     resolvedData,
     ...tableProps
@@ -269,6 +269,7 @@ const AlleleTable = ({gene, geneId, geneSymbol, geneLocation = {}, species, gene
         gene={gene}
         genomeLocation={geneLocation}
         {...variantsSequenceViewerProps}
+        genomeLocationList={genomeLocationList}
       />
       <DataTable
         {...tableProps}
@@ -295,6 +296,7 @@ AlleleTable.propTypes = {
     chromosome: PropTypes.string,
   }),
   geneSymbol: PropTypes.string.isRequired,
+  genomeLocationList: PropTypes.array,
   species: PropTypes.string.isRequired,
 };
 

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -175,20 +175,23 @@ class GenomeFeatureWrapper extends Component {
 
   render() {
     const {assembly, id, displayType,genomeLocationList} = this.props;
-    const coordinates = [];
-    genomeLocationList.forEach(location => coordinates.push(
-      <span>
-        <ExternalLink href={this.generateJBrowseLink(location.chromosome,location.start,location.end)}>
-          {location.chromosome.toLowerCase().startsWith('chr') ? location.chromosome : 'Chr' + location.chromosome}:{location.start}...{location.end}
-        </ExternalLink> {location.strand} ({numeral((location.end - location.start) / 1000.0).format('0,0.00')} kb)
-      </span>
-    ));
+    const coordinates = genomeLocationList.map(location => {
+      return(
+        <span key={location.chromosome+location.start+location.end}>
+          <ExternalLink href={this.generateJBrowseLink(location.chromosome,location.start,location.end)}>
+            {location.chromosome.toLowerCase().startsWith('chr') ? location.chromosome : 'Chr' + location.chromosome}:{location.start}...{location.end}
+          </ExternalLink> {location.strand} ({numeral((location.end - location.start) / 1000.0).format('0,0.00')} kb)
+        </span>
+      );
+    });
 
     return (
       <div id='genomeViewer'>
         <AttributeList>
           <AttributeLabel>Genome location</AttributeLabel>
-          <AttributeValue><CommaSeparatedList>{coordinates}</CommaSeparatedList></AttributeValue>
+          <AttributeValue>
+            <CommaSeparatedList>{coordinates}</CommaSeparatedList>
+          </AttributeValue>
           <AttributeLabel>Assembly version</AttributeLabel>
           <AttributeValue>{assembly}
           </AttributeValue>

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -14,6 +14,7 @@ import '../../style.scss';
 import HorizontalScroll from '../../components/horizontalScroll';
 import HelpPopup from '../../components/helpPopup';
 import isEqual from 'lodash.isequal';
+import CommaSeparatedList from '../../components/commaSeparatedList';
 
 import style from './style.scss';
 import {getSpecies} from '../../lib/utils';
@@ -58,14 +59,14 @@ class GenomeFeatureWrapper extends Component {
     this.gfc.closeModal();
   }
 
-  generateJBrowseLink() {
+  generateJBrowseLink(chr, start, end) {
     const geneSymbolUrl = '&lookupSymbol=' + this.props.geneSymbol;
     const externalJBrowsePrefix = '/jbrowse/?' + 'data=data%2F' + encodeURIComponent(getSpecies(this.props.species).fullName);
-    const linkLength = this.props.fmax - this.props.fmin;
-    let bufferedMin = Math.round(this.props.fmin - (linkLength * LINK_BUFFER / 2.0));
+    const linkLength = end - start;
+    let bufferedMin = Math.round(start - (linkLength * LINK_BUFFER / 2.0));
     bufferedMin = bufferedMin < 0 ? 0 : bufferedMin;
-    const bufferedMax = Math.round(this.props.fmax + (linkLength * LINK_BUFFER / 2.0));
-    const externalLocationString = this.props.chromosome + ':' + bufferedMin + '..' + bufferedMax;
+    const bufferedMax = Math.round(end + (linkLength * LINK_BUFFER / 2.0));
+    const externalLocationString = chr + ':' + bufferedMin + '..' + bufferedMax;
     // TODO: handle bufferedMax exceeding chromosome length, though I think it has a good default.
     const tracks = ['Variants', 'All Genes','Multiple-Variant Alleles'];
     return externalJBrowsePrefix +
@@ -173,20 +174,21 @@ class GenomeFeatureWrapper extends Component {
   }
 
   render() {
-    const {assembly, chromosome, fmin, fmax, id, strand, displayType} = this.props;
-    const lengthValue = numeral((fmax - fmin) / 1000.0).format('0,0.00');
-    const jbrowseUrl = this.generateJBrowseLink();
+    const {assembly, id, displayType,genomeLocationList} = this.props;
+    const coordinates = [];
+    genomeLocationList.forEach(location => coordinates.push(
+      <span>
+        <ExternalLink href={this.generateJBrowseLink(location.chromosome,location.start,location.end)}>
+          {location.chromosome.toLowerCase().startsWith('chr') ? location.chromosome : 'Chr' + location.chromosome}:{location.start}...{location.end}
+        </ExternalLink> {location.strand} ({numeral((location.end - location.start) / 1000.0).format('0,0.00')} kb)
+      </span>
+    ));
 
     return (
       <div id='genomeViewer'>
         <AttributeList>
           <AttributeLabel>Genome location</AttributeLabel>
-          <AttributeValue>
-            <ExternalLink href={jbrowseUrl}>
-              {chromosome.toLowerCase().startsWith('chr') ? chromosome : 'Chr' + chromosome}:{fmin}...{fmax}
-            </ExternalLink> {strand} ({lengthValue} kb)
-          </AttributeValue>
-
+          <AttributeValue><CommaSeparatedList>{coordinates}</CommaSeparatedList></AttributeValue>
           <AttributeLabel>Assembly version</AttributeLabel>
           <AttributeValue>{assembly}
           </AttributeValue>
@@ -229,6 +231,7 @@ GenomeFeatureWrapper.propTypes = {
   fmax: PropTypes.number,
   fmin: PropTypes.number,
   geneSymbol: PropTypes.string.isRequired,
+  genomeLocationList: PropTypes.array,
   height: PropTypes.string,
   id: PropTypes.string,
   primaryId: PropTypes.string,
@@ -237,6 +240,7 @@ GenomeFeatureWrapper.propTypes = {
   synonyms: PropTypes.array,
   visibleVariants: PropTypes.array,
   width: PropTypes.string,
+
 };
 
 export default GenomeFeatureWrapper;

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -158,6 +158,7 @@ const GenePage = ({geneId}) => {
             geneId={data.id}
             geneLocation={genomeLocation}
             geneSymbol={data.symbol}
+            genomeLocationList={data.genomeLocations}
             species={data.species.name}
           />
         </Subsection>
@@ -182,6 +183,7 @@ const GenePage = ({geneId}) => {
             fmax={genomeLocation.end}
             fmin={genomeLocation.start}
             geneSymbol={data.symbol}
+            genomeLocationList={data.genomeLocations}
             height='200px'
             id='genome-feature-location-id'
             primaryId={data.id}


### PR DESCRIPTION
Added in an array prop that holds all of the locations for a specific gene.  This gets propagated down to both genome browser windows.  For examples of this look to HGNC:7082 and HGNC:750.

I'm not sure that I'm using the CommaSeperatedList component exactly correctly.  Things are working but I'm getting a warning about using keys in lists from that specific component. 

