### PR TITLE
AGR-2500 Autocomplete falls back to name if name_key isn't available

### DIFF
--- a/src/containers/layout/searchBar/index.js
+++ b/src/containers/layout/searchBar/index.js
@@ -111,8 +111,9 @@ class SearchBarComponent extends Component {
         autocompleteGoToPageEvent(id);
         this.props.history.push({ pathname: url });
       } else {
-        this.setState({ value: item.suggestion.name_key });
-        let query = item.suggestion.name_key;
+        //use name if name_key isn't available
+        let query = item.suggestion.name_key ? item.suggestion.name_key : item.suggestion.name;
+        this.setState({ value: query });
         this.doQuery(query);
       }
     }
@@ -169,7 +170,7 @@ class SearchBarComponent extends Component {
   renderSuggestion(d) {
     return (
       <div className={style.autoListItem}>
-        <span>{d.name_key}</span>
+        <span>{d.name_key ? d.name_key : d.name }</span>
         <span className={style.catContainer}>
           <CategoryLabel category={d.category} />
         </span>


### PR DESCRIPTION
Hoping to get this into 3.2 as a patch, but leaving this as a draft until we decide to patch or not