### PR TITLE
AGR-2303 Change Allele category display name to Variant/Allele [DON'T MERGE YET!]

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,7 @@ export const CATEGORIES = [
   },
   {
     name: 'allele',
-    displayName: 'Allele',
+    displayName: 'Variant/Allele',
     displayFields: ['id','genes', 'synonyms','dnaChangeTypes','molecularConsequence', 'diseases'],
   },
   {

--- a/src/containers/search/resultsList.js
+++ b/src/containers/search/resultsList.js
@@ -100,20 +100,11 @@ class ResultsList extends Component {
     );
   }
 
-  renderDatasetEntry(d, i) {
-    let fields = CATEGORIES.find(cat => cat.name === d.category).displayFields;
-    return (
-      <div className={style.resultContainer} key={`sr${i}`}>
-        {this.renderHeader(d)}
-        {this.renderDetailFromFields(d, fields)}
-        {this.renderHighlightedValues(d.highlight, fields)}
-        {this.renderRelatedData(d)}
-        {this.renderMissingTerms(d)}
-      </div>
-    );
-  }
-
   renderEntry(d, i, fields) {
+    //need to handle variants within allele category slightly differently
+    if (d.category === 'allele' && d.alterationType && d.alterationType === 'variant') {
+      fields = ['genes', 'variantTypes', 'dnaChangeTypes'];
+    }
     return (
       <div className={style.resultContainer} key={`sr${i}`}>
         {this.renderHeader(d)}


### PR DESCRIPTION
plus basic results display config

I had thought this was in, but it's been sitting around since October. I don't think variants are actually available yet, so I'm not totally sure if this PR should go in yet or not. 

@gildossantos Does it make more sense to just hold on to this, so that if 4.0 goes out without variants, the category label stays as just Allele?  There's an argument to be made that MOD variants are represented within the Alleles, so maybe this should go in?  