### PR TITLE
Removed Unnecessary Load

### DIFF
--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -48,7 +48,6 @@ class GenomeFeatureWrapper extends Component {
     }
     else
     if(!isEqual(prevProps.allelesSelected,this.props.allelesSelected) && this.props.allelesSelected!==undefined) {
-      this.loadGenomeFeature();
       this.gfc.setSelectedAlleles(this.props.allelesSelected.map( a => a.id),`#${this.props.id}`);
     }
     else


### PR DESCRIPTION
Loading then highlighting was causing the genomeFeatureComponenent to 
not be ready for manipulation... and breaking the highlight.

