### PR TITLE
error handling for variant details page

### DIFF
--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -12,6 +12,7 @@ import useDataTableQuery from '../../hooks/useDataTableQuery';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
 import { getSingleGenomeLocation, findFminFmax } from '../../lib/utils';
 import VariantsSequenceViewer from '../genePage/VariantsSequenceViewer';
+import ErrorBoundary from '../../components/errorBoundary';
 
 const GeneAlleleDetailsTable = ({geneId}) => {
   const { isLoading: isLoadingGene, isError: isErrorGene, data: gene } = usePageLoadingQuery(`/api/gene/${geneId}`);
@@ -201,18 +202,22 @@ const GeneAlleleDetailsTable = ({geneId}) => {
 
   return (
     <>
-      {
-        isLoading || isLoadingGene ?
-          null :
-          variantsSequenceViewerProps.hasVariants ?
-            <VariantsSequenceViewer {...variantsSequenceViewerProps} /> :
-            <NoData>No mapped variant information available</NoData>
-      }
-      <DataTable
-        {...tableQuery}
-        columns={columns}
-        keyField='id'
-      />
+      <ErrorBoundary>
+        {
+          isLoading || isLoadingGene ?
+            null :
+            variantsSequenceViewerProps.hasVariants ?
+              <VariantsSequenceViewer {...variantsSequenceViewerProps} /> :
+              <NoData>No mapped variant information available</NoData>
+        }
+      </ErrorBoundary>
+      <ErrorBoundary>
+        <DataTable
+          {...tableQuery}
+          columns={columns}
+          keyField='id'
+        />
+      </ErrorBoundary>
     </>
   );
 };

--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -6,6 +6,7 @@ import {
   DataTable,
   VEPTextCell,
 } from '../../components/dataTable';
+import NoData from '../../components/noData';
 import VariantJBrowseLink from '../../components/variant/VariantJBrowseLink';
 import useDataTableQuery from '../../hooks/useDataTableQuery';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';


### PR DESCRIPTION
**fix missing import of NoData component**

An import statement was missing and somehow the linter didn't catch it.  Without the import statement, the UI would through an error when the API response contains no mapped variant.

**Separate error boundary for viewer and table**

So error in either of the component doesn't break another.

