### PR TITLE
sift and polyphen display in allele details table

### DIFF
--- a/src/components/dataTable/DropdownCheckboxFilter.js
+++ b/src/components/dataTable/DropdownCheckboxFilter.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
 
 const DropdownCheckboxFilter = ({
-  formatter,
+  formatter = (value) => value && value.replace(/_/g, ' '),
   onChange,
   options,
   value = [],

--- a/src/components/dataTable/utils.js
+++ b/src/components/dataTable/utils.js
@@ -8,6 +8,10 @@ export const renderPaginationShowsTotal = (start, end, total) => {
 export const getDistinctFieldValue = (response, field) => {
   response = response || {};
   const {distinctFieldValues = {}} = response.supplementalData || {};
-  return (distinctFieldValues[field] || []).sort(compareAlphabeticalCaseInsensitive);
+  return (distinctFieldValues[field] || [])
+    .sort(compareAlphabeticalCaseInsensitive)
+    .filter((value) => (
+      value && value.trim()
+    ));
 };
 

--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -15,6 +15,34 @@ import { getSingleGenomeLocation, findFminFmax } from '../../lib/utils';
 import VariantsSequenceViewer from '../genePage/VariantsSequenceViewer';
 import ErrorBoundary from '../../components/errorBoundary';
 
+const getSiftStyle = (sift) => {
+  switch (sift && sift.toLowerCase()) {
+  case 'tolerated':
+    return 'text-success';
+  case 'tolerated_low_confidence':
+    return 'text-success';
+  case 'deleterious_low_confidence':
+    return 'text-warning';
+  case 'deleterious':
+    return 'text-danger';
+  default:
+    return 'text-muted';
+  }
+};
+
+const getPolyphenStyle = (polyphen) => {
+  switch (polyphen && polyphen.toLowerCase()) {
+  case 'benign':
+    return 'text-success';
+  case 'possibly_damaging':
+    return 'text-warning';
+  case 'probably_damaging':
+    return 'text-danger';
+  default:
+    return 'text-muted';
+  }
+};
+
 const GeneAlleleDetailsTable = ({geneId}) => {
   const { isLoading: isLoadingGene, isError: isErrorGene, data: gene } = usePageLoadingQuery(`/api/gene/${geneId}`);
   if (isLoadingGene || isErrorGene) {
@@ -105,7 +133,7 @@ const GeneAlleleDetailsTable = ({geneId}) => {
     {
       text: 'Sequence feature',
       dataField: 'consequence.transcriptName',
-      headerStyle: {width: '150px'},
+      headerStyle: {width: '250px'},
     },
     {
       text: 'Sequence feature type',
@@ -146,7 +174,9 @@ const GeneAlleleDetailsTable = ({geneId}) => {
     {
       text: 'SIFT prediction',
       dataField: 'consequence.siftPrediction',
-      formatter: VEPTextCell,
+      formatter: (siftPrediction) => (
+        <span className={getSiftStyle(siftPrediction)}>{siftPrediction && siftPrediction.replace(/_/g, ' ')}</span>
+      ),
       filterable: true,
       filterName: 'variantSift',
       headerStyle: {width: '200px'},
@@ -154,12 +184,17 @@ const GeneAlleleDetailsTable = ({geneId}) => {
     {
       text: 'SIFT score',
       dataField: 'consequence.siftScore',
+      formatter: (siftScore, { consequence }) => (
+        <span className={getSiftStyle(consequence && consequence.siftPrediction)}>{siftScore}</span>
+      ),
       headerStyle: {width: '100px'},
     },
     {
       text: 'PolyPhen prediction',
       dataField: 'consequence.polyphenPrediction',
-      formatter: VEPTextCell,
+      formatter: (polyphenPrediction) => (
+        <span className={getPolyphenStyle(polyphenPrediction)}>{polyphenPrediction && polyphenPrediction.replace(/_/g, ' ')}</span>
+      ),
       filterable: true,
       filterName: 'variantPolyphen',
       headerStyle: {width: '180px'},
@@ -167,6 +202,9 @@ const GeneAlleleDetailsTable = ({geneId}) => {
     {
       text: 'PolyPhen score',
       dataField: 'consequence.polyphenScore',
+      formatter: (polyphenScore, { consequence }) => (
+        <span className={getPolyphenStyle(consequence && consequence.polyphenPrediction)}>{polyphenScore}</span>
+      ),
       headerStyle: {width: '150px'},
     },
   ];


### PR DESCRIPTION
- color code sift and polyphen prediction and score
- add default formatter for column header checkbox
- remove empty value from distinct filter values

@cmpich the empty filter value might concern you, if you intended it to be a feature. But the API doesn't appear to work in that regard. ie. when siftPrediction filter is set to empty value, the response still include those with siftPrediction https://build.alliancegenome.org/api/gene/ZFIN:ZDB-GENE-001212-1/allele-variant-detail?filter.variantSift=&page=1&limit=100&sortBy= . I am omitting the empty values as possible filter values for now. It's likely not very interesting to know what variant has no sift prediction.