### PR TITLE
AGR-2535 A series of small fixes for Allele/Variant Details

### DIFF
--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -280,6 +280,7 @@ const GeneAlleleDetailsTable = ({geneId}) => {
               <NoData>No mapped variant information available</NoData>
         }
       </ErrorBoundary>
+      <hr />
       <ErrorBoundary>
         <DataTable
           {...tableQuery}

--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -7,6 +7,7 @@ import {
   GeneCell,
   VEPTextCell,
 } from '../../components/dataTable';
+import SynonymList from '../../components/synonymList';
 import NoData from '../../components/noData';
 import VariantJBrowseLink from '../../components/variant/VariantJBrowseLink';
 import useDataTableQuery from '../../hooks/useDataTableQuery';
@@ -66,7 +67,7 @@ const GeneAlleleDetailsTable = ({geneId}) => {
     {
       text: 'Allele / Variant Synonyms',
       dataField: 'allele.synonyms',
-      formatter: synonyms => (synonyms || []).join(', '),
+      formatter: synonyms => <SynonymList synonyms={synonyms} />,
       filterable: true,
       filterName: 'synonyms',
       headerStyle: {width: '200px'},

--- a/src/containers/GeneAlleleDetailsPage/index.js
+++ b/src/containers/GeneAlleleDetailsPage/index.js
@@ -15,7 +15,7 @@ const GeneAlleleDetailsPage = ({geneId}) => {
     return <NotFound />;
   }
 
-  const pageTitle = 'Alleles or Variants Details';
+  const pageTitle = 'Alleles and Variants Details';
 
   return (
     <div>
@@ -29,7 +29,7 @@ const GeneAlleleDetailsPage = ({geneId}) => {
             <li className="breadcrumb-item active" aria-current="page">{pageTitle}</li>
           </ol>
         </nav>
-        <PageHeader>{pageTitle} ({gene.symbol})</PageHeader>
+        <PageHeader>{pageTitle} for <Link to={`/gene/${geneId}`}>{gene.symbol}</Link></PageHeader>
         <ErrorBoundary>
           <div style={{width: '100%', overflowX: 'scroll'}}>
             <GeneAlleleDetailsTable geneId={geneId} />

--- a/src/containers/allelePage/VariantSummry.js
+++ b/src/containers/allelePage/VariantSummry.js
@@ -10,6 +10,7 @@ import {
 import { CollapsibleList } from '../../components/collapsibleList';
 import { DownloadButton } from '../../components/dataTable';
 import Subsection from '../../components/subsection';
+import NoData from '../../components/noData';
 import useAllAlleleVariants from '../../hooks/useAlleleVariants';
 import { VariantJBrowseLink } from '../../components/variant';
 import ExternalLink from '../../components/ExternalLink';
@@ -206,11 +207,12 @@ const VariantSummary = ({allele, alleleId}) => {
         })
       }
       {
-
-        <div className='mb-5'>
-          <DownloadButton downloadUrl={`/api/allele/${alleleId}/variants/download`} text='Download Variants Data' />
-        </div>
-
+        data && data.length ?
+          (
+            <div className='mb-5'>
+              <DownloadButton downloadUrl={`/api/allele/${alleleId}/variants/download`} text='Download Variants Data' />
+            </div>
+          ) : <NoData />
       }
     </>
   );

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -45,13 +45,14 @@ const AlleleTable = ({geneId}) => {
   }, [resolvedData]);
 
   const [alleleIdsSelected, setAlleleIdsSelected] = useState([]);
-  const variantsSequenceViewerProps = useMemo(() => {
-
-    const variants = resolvedData ?
+  const variants = useMemo(() => (
+    resolvedData ?
       resolvedData.results.flatMap(
         allele => (allele && allele.variants) || []
       ) :
-      [];
+      []
+  ), [resolvedData]);
+  const variantsSequenceViewerProps = useMemo(() => {
     const variantLocations = variants.map(variant => variant && variant.location);
     const { fmin, fmax } = findFminFmax([geneLocation, ...variantLocations]);
 
@@ -74,7 +75,7 @@ const AlleleTable = ({geneId}) => {
       allelesVisible: resolvedData ? resolvedData.results.map(allele => formatAllele(allele && allele.id)) : [],
       onAllelesSelect: setAlleleIdsSelected,
     };
-  }, [resolvedData, alleleIdsSelected, setAlleleIdsSelected]);
+  }, [resolvedData, variants, alleleIdsSelected, setAlleleIdsSelected]);
 
   const selectRow = useMemo(() => ({
     mode: 'checkbox',
@@ -294,7 +295,11 @@ const AlleleTable = ({geneId}) => {
           selectRow={selectRow}
           sortOptions={sortOptions}
         />
-        <Link className="btn btn-primary position-absolute" style={{top: '1em'}} to={`/gene/${geneId}/allele-details`}>View all Alleles and Variants information</Link>
+        {
+          variants && variants.length ?
+            <Link className="btn btn-primary position-absolute" style={{top: '1em'}} to={`/gene/${geneId}/allele-details`}>View all Alleles and Variants information</Link> :
+            null
+        }
       </div>
     </>
   );


### PR DESCRIPTION
- Bug in synonym display https://agr-jira.atlassian.net/browse/AGR-2622 
- Title of the details page: "Alleles and Variants details for [gene]"
    - Show ‘and’ instead of ‘or’
    - Instead of showing the gene in parentheses, show “for”
- The gene could/should link back to the gene page
- Between the sequence viewer and the table, add space or line, currently, it looks like this legend title is the header of the table.
- When there is no data, the details page should be suppressed
- When there is no data, the download on the “genomic variant” section on the Allele page should be suppressed


