### PR TITLE
Fix AGR-2626 and AGR-2581

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1290,9 +1290,9 @@
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
     "@geneontology/dbxrefs": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@geneontology/dbxrefs/-/dbxrefs-1.0.15.tgz",
-      "integrity": "sha512-SCKCF9yv9unkzCDWPXZIczgW2QZp7FPMdpr/nHLwVqeveT9wxljG1PCagjzz7vp1kYoPsHrcJixbewsYbDLuCA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@geneontology/dbxrefs/-/dbxrefs-1.0.16.tgz",
+      "integrity": "sha512-zKvbcfs+LU4ZnUo00A5ae0V+FVMIM4ftxcfKtJWmtnLKwWy1sOn2y36HGcz/rEmLwd2zBApKJ0ojmgBH416Q5Q==",
       "requires": {
         "axios": "^0.21.1",
         "js-yaml": "^4.0.0"
@@ -1314,19 +1314,19 @@
       }
     },
     "@geneontology/wc-ribbon-strips": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.36.tgz",
-      "integrity": "sha512-RsWulLkxkZ9edur/ceyBSe7GtHaJ508ACUp8Qg4B5TTAj/rITwdE8hYBv0MDZZbQwntympV0HOxC3PvAo4T0qw==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-strips/-/wc-ribbon-strips-0.0.37.tgz",
+      "integrity": "sha512-b7+YIMdEBwRMUV6IF5WJ1jrgSLeNb7yuwsqMin9bBEinDp4U+JAK6HZK/I2blOK2TTWTpsuJiyeHQ2P9ZvDJAQ==",
       "requires": {
         "@geneontology/wc-spinner": "0.0.2"
       }
     },
     "@geneontology/wc-ribbon-table": {
-      "version": "0.0.55",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-table/-/wc-ribbon-table-0.0.55.tgz",
-      "integrity": "sha512-O99kouVuEIos+BweiZLtaB0R9rTUgKQulV0Zj9KVzPX23uXNdDUEMGaXMpV57PYg2z/pvF4BNBP8c0xCelem/A==",
+      "version": "0.0.56",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-ribbon-table/-/wc-ribbon-table-0.0.56.tgz",
+      "integrity": "sha512-M/59pKfY1TGlm8yp64Cof3TaJieSDuZda+9nzz7qHZixuO0P1wUCnOFPs9MArRU08aW2vgaieSTsPuSg870uAQ==",
       "requires": {
-        "@geneontology/dbxrefs": "^1.0.15"
+        "@geneontology/dbxrefs": "^1.0.16"
       }
     },
     "@geneontology/wc-spinner": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "private": true,
   "dependencies": {
+    "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.56",
-    "@geneontology/wc-ribbon-strips": "0.0.36",
     "abortcontroller-polyfill": "^1.5.0",
     "agr_genomefeaturecomponent": "^0.3.9",
     "bootstrap": "4.4.1",

--- a/src/components/disease/diseaseComparisonRibbon.js
+++ b/src/components/disease/diseaseComparisonRibbon.js
@@ -115,6 +115,7 @@ const DiseaseComparisonRibbon = ({geneId, geneTaxon, history}) => {
             subject-base-url='/gene/'
             subject-open-new-tab={false}
             subject-position={compareOrthologs ? '1' : '0'}
+            update-on-subject-change={false}
           />
         </div>
         <div className='ribbon-loading-overlay'>{summary.isLoading && <LoadingSpinner />}</div>

--- a/src/components/expression/expressionComparisonRibbon.js
+++ b/src/components/expression/expressionComparisonRibbon.js
@@ -105,6 +105,7 @@ const ExpressionComparisonRibbon = ({
             subject-base-url='/gene/'
             subject-open-new-tab={false}
             subject-position={compareOrthologs ? '1' : '0'}
+            update-on-subject-change={false}
           />
         </div>
         <div className='ribbon-loading-overlay'>{summary.isLoading && <LoadingSpinner />}</div>


### PR DESCRIPTION
Yesterday PR on the release branch had two issues:

1. for some reason, the package-lock was using a wrong version of the dbxrefs, which prevented the table to work:
![Screen Shot 2021-03-02 at 10 56 30 AM](https://user-images.githubusercontent.com/24249870/109705807-07e3cd00-7b4d-11eb-90ae-f0fc790dee8b.png)

2. end of january, we introduced an auto reload of the ribbon upon subject change (https://github.com/geneontology/wc-ribbon/commit/4e38f384d0be8712c9e633bf2b506acf56fe27e4). So whenever the disease or expression ribbons where updating the list of genes, the ribbon was fetching data from GO, removing the current data. This was fixed by the addition of a new parameter (update-on-subject-change) to prevent those auto reload on subject change: https://github.com/geneontology/wc-ribbon/commit/46bbb2793ecf6d8548c257019940494f3167aa17

Tested locally + run npm tests.
