### PR TITLE
AGR-2637 alleleCategory filter name 

### DIFF
--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -128,6 +128,7 @@ const AlleleTable = ({geneId}) => {
       dataField: 'category',
       text: 'Category',
       headerStyle: {width: '140px'},
+      filterName: 'alleleCategory',
       filterable: getDistinctFieldValue(resolvedData, 'filter.alleleCategory'),
     },
     {


### PR DESCRIPTION
@cmpich is the alleleCategory filter refer to the non-detailed allele table on gene page? Here is the updated filter name, if I understand it correct.