### PR TITLE
AGR-2649

### DIFF
--- a/src/lib/searchHelpers.js
+++ b/src/lib/searchHelpers.js
@@ -115,7 +115,7 @@ export function makeFieldDisplayName(unformattedName, category = '') {
   case 'symbolText':
     return 'Symbol';
   case 'alterationType':
-    return 'Category';
+    return 'Category\u00a0'; //non breaking whitespace char in order to avoid conflict with higher level category value
   default:
     //replace fix both camel case and underscores, capitalize the first letter
     return unformattedName


### PR DESCRIPTION
Changing the filter name to "Category" created a conflict with the higher-level "Category" name which resulted in the exclude link not working. I added a non-breaking unicode character to the name in order to differentiate between the two.