### PR TITLE
AGR-2652 turn cursor to normal for a row

### DIFF
--- a/src/containers/genePage/TransgenicAlleleTable.js
+++ b/src/containers/genePage/TransgenicAlleleTable.js
@@ -142,7 +142,6 @@ const TransgenicAlleleTable = ({geneId}) => {
       columns={columns}
       data={data}
       downloadUrl={`/api/gene/${geneId}/transgenic-alleles/download`}
-      rowStyle={{cursor: 'pointer'}}
     />
   );
 };


### PR DESCRIPTION
Fixing a mistake that changed the same of the cursor when shouldn't. Click on the table shoe does nothing.