### PR TITLE
Filtering Transcripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "agr_genomefeaturecomponent": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.9.tgz",
-      "integrity": "sha512-Ey039e+Vqlf5s3eyjUwY0Zn/1MZX4F8J0maKTaXGjhHmLAPUUciqUPJcxOvdEla08+LPXltgXYrnlt3WIvlaVg==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.11.tgz",
+      "integrity": "sha512-N4oHiqSH3rVtK8H8417xfYgoaHTFCbvMh6/HXk3UKk4U4mLHzUbl93wIy3aKAk0ZSALswOSzQ/IpCfzTVsyHSw==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "abortcontroller-polyfill": "^1.5.0",
-    "agr_genomefeaturecomponent": "^0.3.9",
+    "agr_genomefeaturecomponent": "^0.3.11",
     "bootstrap": "4.4.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^1.0.6",

--- a/src/containers/allelePage/AlleleSequenceView.js
+++ b/src/containers/allelePage/AlleleSequenceView.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import GenomeFeatureWrapper from '../genePage/genomeFeatureWrapper';
 import useAllAlleleVariants from '../../hooks/useAlleleVariants';
+import useDataTableQuery from '../../hooks/useDataTableQuery';
+
 
 
 function findFminFmax(genomeLocation, variants) {
@@ -22,6 +24,9 @@ function findFminFmax(genomeLocation, variants) {
 
 const AlleleSequenceView = ({ allele }) => {
   const variants = useAllAlleleVariants(allele.id);
+  let variantId = allele.variants[0].id;
+  const visibleTranscripts = useDataTableQuery(`/api/variant/${variantId}/transcripts`);
+  let isoformFilter = visibleTranscripts.data.map(a => a.id.split(":").pop());
 
   if (!allele.gene) {
     return null;
@@ -46,6 +51,7 @@ const AlleleSequenceView = ({ allele }) => {
       genomeLocationList={genomeLocations}
       height='200px'
       id='genome-feature-location-id'
+      isoformFilter={isoformFilter}
       primaryId={allele.id}
       species={allele.species.taxonId}
       strand={genomeLocation.strand}

--- a/src/containers/allelePage/AlleleSequenceView.js
+++ b/src/containers/allelePage/AlleleSequenceView.js
@@ -24,9 +24,7 @@ function findFminFmax(genomeLocation, variants) {
 
 const AlleleSequenceView = ({ allele }) => {
   const variants = useAllAlleleVariants(allele.id);
-  let variantId = allele.variants[0].id;
-  const visibleTranscripts = useDataTableQuery(`/api/variant/${variantId}/transcripts`);
-  let isoformFilter = visibleTranscripts.data.map(a => a.id.split(":").pop());
+  const visibleTranscripts = useDataTableQuery(`/api/allele/${allele.id}/variants`);
 
   if (!allele.gene) {
     return null;
@@ -34,9 +32,11 @@ const AlleleSequenceView = ({ allele }) => {
 
   const genomeLocations = allele.gene.genomeLocations;
   const genomeLocation = genomeLocations && genomeLocations.length > 0 ? genomeLocations[0] : null;
-  if (!genomeLocation || variants.isLoading || variants.isError || variants.data.length === 0) {
+  if (!genomeLocation || variants.isLoading || variants.isError || variants.data.length === 0 ||visibleTranscripts.data.length === 0) {
     return null;
   }
+
+  let isoformFilter = visibleTranscripts.data[0].transcriptList.map(a => a.id.split(':').pop());
 
   const { fmin, fmax } = findFminFmax(genomeLocation, variants);
   return (

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -79,7 +79,7 @@ class GenomeFeatureWrapper extends Component {
       '&loc=' + encodeURIComponent(externalLocationString);
   }
 
-  generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, variantFilter, displayType) {
+  generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, variantFilter, displayType,isoformFilter) {
     let transcriptTypes = getTranscriptTypes();
     const speciesInfo = getSpecies(species);
     const apolloPrefix = speciesInfo.apolloName;
@@ -116,6 +116,7 @@ class GenomeFeatureWrapper extends Component {
         'end': fmax,
         'showVariantLabel': false,
         'variantFilter': variantFilter ? variantFilter : [],
+        'isoformFilter': isoformFilter ? isoformFilter : [],
         'visibleVariants': undefined,
         'binRatio': 0.01,
         'transcriptTypes': transcriptTypes,
@@ -145,7 +146,7 @@ class GenomeFeatureWrapper extends Component {
   }
 
   loadGenomeFeature() {
-    const {chromosome, fmin, fmax, species, id, primaryId, geneSymbol, displayType, synonyms = [], visibleVariants} = this.props;
+    const {chromosome, fmin, fmax, species, id, primaryId, geneSymbol, displayType, synonyms = [], visibleVariants,isoformFilter} = this.props;
 
     // provide unique names
     let nameSuffix = [geneSymbol, ...synonyms, primaryId].filter((x, i, a) => a.indexOf(x) === i).map(x => encodeURI(x));
@@ -172,7 +173,7 @@ class GenomeFeatureWrapper extends Component {
     // [1] should be track name : ALL_Genes
     // [2] should be track name : name suffix string
     // const visibleVariants = allelesVisible && allelesVisible.length>0 ? allelesVisible.map( a => a.id ) : undefined;
-    const trackConfig = this.generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, visibleVariants, displayType);
+    const trackConfig = this.generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, visibleVariants, displayType,isoformFilter);
     this.gfc = new GenomeFeatureViewer(trackConfig, `#${id}`, 900, undefined);
     this.setState({
       helpText: this.gfc.generateLegend()
@@ -246,6 +247,7 @@ GenomeFeatureWrapper.propTypes = {
   genomeLocationList: PropTypes.array,
   height: PropTypes.string,
   id: PropTypes.string,
+  isoformFilter: PropTypes.array,
   primaryId: PropTypes.string,
   species: PropTypes.string.isRequired,
   strand: PropTypes.string,


### PR DESCRIPTION
On allele page filtering transcripts to only include those with 
consequences so that all can be seen.  Also updates widget version to 
0.3.11.

Making a draft until I can do a bit of testing to make sure we haven't introduced bugs.
Fixes bugs discussed in AGR-2483 and AGR-2216

