### PR TITLE
AGR-2676 have viewer share same filter state as table but not pagination state

### DIFF
--- a/src/containers/genePage/VariantsSequenceViewer.js
+++ b/src/containers/genePage/VariantsSequenceViewer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import GenomeFeatureWrapper from './genomeFeatureWrapper';
 import { getSingleGenomeLocation } from '../../lib/utils';
 
-const VariantsSequenceViewer = ({ gene, fmin, fmax, allelesSelected }) => {
+const VariantsSequenceViewer = ({ gene, fmin, fmax, allelesSelected, allelesVisible }) => {
 
   const genomeLocationList = gene.genomeLocations;
   const genomeLocation = getSingleGenomeLocation(genomeLocationList);
@@ -34,6 +34,7 @@ const VariantsSequenceViewer = ({ gene, fmin, fmax, allelesSelected }) => {
       species={gene.species.taxonId}
       strand={genomeLocation.strand}
       synonyms={gene.synonyms}
+      visibleVariants={allelesVisible.map(a => a.id)}
       width='600px'
     />
   );

--- a/src/hooks/useAllVariants.js
+++ b/src/hooks/useAllVariants.js
@@ -7,12 +7,16 @@ function getFullUrl(baseUrl, tableState) {
     return null;
   }
   const separator = baseUrl.indexOf('?') < 0 ? '?' : '&';
-  return baseUrl + separator + buildTableQueryString({page: tableState.page, sizePerPage:1000, filters: tableState.filters});
+  return baseUrl + separator + buildTableQueryString(tableState);
 }
 
 export default function useAllVariants(geneId, tableState) {
   const url = `/api/gene/${geneId}/alleles?`;
   return useQuery ([url, tableState], () => {
-    return fetchData(getFullUrl(url,tableState));
+    return fetchData(getFullUrl(url, {
+      ...tableState,
+      page: 1,
+      sizePerPage:1000,
+    }));
   });
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -71,6 +71,15 @@ export function buildTableQueryString(options) {
   });
 }
 
+export function getTableUrl(baseUrl, tableState) {
+  if (!baseUrl) {
+    return null;
+  }
+  const separator = baseUrl.indexOf('?') < 0 ? '?' : '&';
+  return baseUrl + separator + buildTableQueryString(tableState);
+}
+
+
 function isHighStringency(orthology) {
   return orthology.stringencyFilter === 'stringent';
 }


### PR DESCRIPTION
For gene page and allele-details page for gene.

Forward to viewer via the `allelesVisible` prop up to 1000 alleles based on filtered but not paginated table state.