### PR TITLE
AGR-2679 AGR-2538 bugfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "agr_genomefeaturecomponent": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.12.tgz",
-      "integrity": "sha512-fJU6j3nBzr/KM/kmLjYKXpjIuhtSlPPbvjU7RGbbqEHc2bSYWZhbWlJ2oJ/xahtxM9StZrKCWHkdebsBmtJuTg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.13.tgz",
+      "integrity": "sha512-odSQZ1+jf2XVrTRdFgOzipSLgSOJ5XaqbbZotVw+TwQ76syMpjtehvijayuDktKaE1DUGTn753L1it64QSR1cQ==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "agr_genomefeaturecomponent": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.11.tgz",
-      "integrity": "sha512-N4oHiqSH3rVtK8H8417xfYgoaHTFCbvMh6/HXk3UKk4U4mLHzUbl93wIy3aKAk0ZSALswOSzQ/IpCfzTVsyHSw==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.12.tgz",
+      "integrity": "sha512-fJU6j3nBzr/KM/kmLjYKXpjIuhtSlPPbvjU7RGbbqEHc2bSYWZhbWlJ2oJ/xahtxM9StZrKCWHkdebsBmtJuTg==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "abortcontroller-polyfill": "^1.5.0",
-    "agr_genomefeaturecomponent": "^0.3.11",
+    "agr_genomefeaturecomponent": "^0.3.12",
     "bootstrap": "4.4.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "abortcontroller-polyfill": "^1.5.0",
-    "agr_genomefeaturecomponent": "^0.3.12",
+    "agr_genomefeaturecomponent": "^0.3.13",
     "bootstrap": "4.4.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^1.0.6",

--- a/src/containers/allelePage/AlleleSequenceView.js
+++ b/src/containers/allelePage/AlleleSequenceView.js
@@ -36,7 +36,11 @@ const AlleleSequenceView = ({ allele }) => {
     return null;
   }
 
-  let isoformFilter = visibleTranscripts.data[0].transcriptList.map(a => a.id.split(':').pop());
+  let isoformFilter = [];
+  if(visibleTranscripts.data[0].transcriptList){
+    isoformFilter = visibleTranscripts.data[0].transcriptList.map(a => a.id.split(':').pop());
+  }
+
 
   const { fmin, fmax } = findFminFmax(genomeLocation, variants);
   return (


### PR DESCRIPTION
Fixes 2649.  Needs the latest browser version.  Also fixes an error that we get when an allele has an associated gene but no associated transcripts.