### PR TITLE
AGR-2667 release version number

### DIFF
--- a/src/containers/downloadsPage/index.js
+++ b/src/containers/downloadsPage/index.js
@@ -13,6 +13,7 @@ import DownloadFileRow from './DownloadFileRow';
 import PageNavEntity from '../../components/dataPage/PageNavEntity';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
 import SpeciesName from '../../components/SpeciesName';
+import { useRelease } from '../../hooks/ReleaseContextProvider';
 
 const DISEASE = 'Disease';
 const EXPRESSION = 'Expression';
@@ -54,11 +55,18 @@ const TAXON_SUBTYPES = [
 
 const DownloadsPage = () => {
   const {
+    data: dataRelease,
+    isLoading: isLoadingRelease,
+  } = useRelease();
+
+  const { releaseVersion } = dataRelease || {};
+
+  const {
     data: files,
     isLoading,
-  } = usePageLoadingQuery( `https://fms.alliancegenome.org/api/datafile/by/release/${process.env.ALLIANCE_RELEASE}?latest=true`);
+  } = usePageLoadingQuery( `https://fms.alliancegenome.org/api/datafile/by/release/${releaseVersion}?latest=true`);
 
-  if (isLoading) {
+  if (isLoadingRelease || isLoading) {
     return null;
   }
 

--- a/src/containers/layout/ReleaseBanner.js
+++ b/src/containers/layout/ReleaseBanner.js
@@ -10,7 +10,8 @@ const ReleaseBanner = () => {
     isError,
   } = useRelease();
 
-  const { releaseVersion, releaseDate } = data || {};
+  const { releaseInfo } = data || {};
+  const { releaseVersion, releaseDate } = releaseInfo || {};
 
   return isLoading ? <LoadingSpinner /> : 
     (

--- a/src/containers/layout/ReleaseBanner.js
+++ b/src/containers/layout/ReleaseBanner.js
@@ -15,8 +15,8 @@ const ReleaseBanner = () => {
   return isLoading ? <LoadingSpinner /> : 
     (
       <small className="text-secondary">
-        Version: {isError ? 'Unknown' : releaseVersion}.
-        <span className="d-none d-md-inline-block mx-1">
+        Version: {isError ? 'Unknown' : releaseVersion}
+        <span className="d-none d-md-block">
           Released on {releaseDate ? new Date(releaseDate).toLocaleDateString('en-US', {dateStyle: 'medium'}) : 'Unknown'}
         </span>
       </small>

--- a/src/containers/layout/ReleaseBanner.js
+++ b/src/containers/layout/ReleaseBanner.js
@@ -11,15 +11,12 @@ const ReleaseBanner = () => {
   } = useRelease();
 
   const { releaseInfo } = data || {};
-  const { releaseVersion, releaseDate } = releaseInfo || {};
+  const { releaseVersion } = releaseInfo || {};
 
   return isLoading ? <LoadingSpinner /> : 
     (
       <small className="text-secondary">
         Version: {isError ? 'Unknown' : releaseVersion}
-        <span className="d-none d-md-block">
-          Released on {releaseDate ? new Date(releaseDate).toLocaleDateString('en-US', {dateStyle: 'medium'}) : 'Unknown'}
-        </span>
       </small>
     );
 };

--- a/src/containers/layout/ReleaseBanner.js
+++ b/src/containers/layout/ReleaseBanner.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useQuery } from 'react-query';
+import fetchData from '../../lib/fetchData';
+import LoadingSpinner from '../../components/loadingSpinner';
+
+const ReleaseBanner = () => {
+  const devServerAPIHostname = process.env.NODE_ENV === 'production' ? '' :
+    (process.env.API_URL || '').replace(/https?:\/\//, '');
+  const [host] = (devServerAPIHostname || window.location.hostname).split('.');
+  const releaseUrl = `https://fms.alliancegenome.org/api/releaseversion/current?host=${host}`;
+
+  const {
+    data,
+    isLoading,
+    isError,
+  } = useQuery([releaseUrl], () => {
+    return fetchData(releaseUrl);
+  });
+
+  const { releaseVersion, releaseDate } = data || {};
+
+  return isLoading ? <LoadingSpinner /> : 
+    (
+      <small className="text-secondary">
+        Version: {releaseVersion}.{' '}
+        <span className="d-none d-md-inline-block mx-1">Released on {releaseDate && new Date(releaseDate).toLocaleDateString('en-US', {dateStyle: 'medium'})}</span>    
+      </small>      
+    );
+};
+
+export default ReleaseBanner;
+

--- a/src/containers/layout/ReleaseBanner.js
+++ b/src/containers/layout/ReleaseBanner.js
@@ -22,9 +22,11 @@ const ReleaseBanner = () => {
   return isLoading ? <LoadingSpinner /> : 
     (
       <small className="text-secondary">
-        Version: {releaseVersion}.{' '}
-        <span className="d-none d-md-inline-block mx-1">Released on {releaseDate && new Date(releaseDate).toLocaleDateString('en-US', {dateStyle: 'medium'})}</span>    
-      </small>      
+        Version: {isError ? 'Unknown' : releaseVersion}.
+        <span className="d-none d-md-inline-block mx-1">
+          Released on {releaseDate ? new Date(releaseDate).toLocaleDateString('en-US', {dateStyle: 'medium'}) : 'Unknown'}
+        </span>
+      </small>
     );
 };
 

--- a/src/containers/layout/ReleaseBanner.js
+++ b/src/containers/layout/ReleaseBanner.js
@@ -1,21 +1,14 @@
 import React from 'react';
-import { useQuery } from 'react-query';
-import fetchData from '../../lib/fetchData';
 import LoadingSpinner from '../../components/loadingSpinner';
+import { useRelease } from '../../hooks/ReleaseContextProvider';
 
 const ReleaseBanner = () => {
-  const devServerAPIHostname = process.env.NODE_ENV === 'production' ? '' :
-    (process.env.API_URL || '').replace(/https?:\/\//, '');
-  const [host] = (devServerAPIHostname || window.location.hostname).split('.');
-  const releaseUrl = `https://fms.alliancegenome.org/api/releaseversion/current?host=${host}`;
 
   const {
     data,
     isLoading,
     isError,
-  } = useQuery([releaseUrl], () => {
-    return fetchData(releaseUrl);
-  });
+  } = useRelease();
 
   const { releaseVersion, releaseDate } = data || {};
 

--- a/src/containers/layout/index.js
+++ b/src/containers/layout/index.js
@@ -8,6 +8,7 @@ import Loader from './loader/index';
 import logo from './agrLogo.png';
 import SearchBar from './searchBar';
 import { MenuItems } from './navigation';
+import ReleaseBanner from './ReleaseBanner';
 import { selectPageLoading } from '../../selectors/loadingSelector';
 import Footer from './Footer';
 
@@ -60,7 +61,7 @@ class Layout extends Component {
                 <Link to='/'>
                   <img className={`img-fluid ${style.agrLogo}`} src={logo} />
                 </Link>
-                <span className={style.version}>Release {process.env.ALLIANCE_RELEASE}</span>
+                <ReleaseBanner />
               </div>
               <button className="navbar-toggler d-md-none" onClick={() => this.setState({menuOpen: !menuOpen})} type="button">
                 <i className='fa fa-fw fa-bars' />

--- a/src/containers/layout/index.js
+++ b/src/containers/layout/index.js
@@ -59,7 +59,7 @@ class Layout extends Component {
             <div className='col-md d-flex justify-content-between'>
               <div className='navbar-brand d-flex align-items-end'>
                 <Link to='/'>
-                  <img className={`img-fluid ${style.agrLogo}`} src={logo} />
+                  <img className={style.agrLogo} width="200" src={logo} />
                 </Link>
                 <ReleaseBanner />
               </div>

--- a/src/hooks/ReleaseContextProvider.js
+++ b/src/hooks/ReleaseContextProvider.js
@@ -1,0 +1,47 @@
+import React, { createContext, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useQuery } from 'react-query';
+import fetchData from '../lib/fetchData';
+
+const ReleaseContext = createContext();
+
+const ReleaseContextProvider = ({children}) => {
+  const devServerAPIHostname = process.env.NODE_ENV === 'production' ? '' :
+    (process.env.API_URL || '').replace(/https?:\/\//, '');
+  const [host] = (devServerAPIHostname || window.location.hostname).split('.');
+  const releaseUrl = `https://fms.alliancegenome.org/api/releaseversion/current?host=${host}`;
+
+  const {
+    data,
+    isLoading,
+    isError,
+  } = useQuery([releaseUrl], () => {
+    return fetchData(releaseUrl);
+  });
+
+  const value = useMemo(() => ({
+    data,
+    isLoading,
+    isError,
+  }), [data, isLoading, isError]);
+
+  return (
+    <ReleaseContext.Provider value={value}>
+      {children}
+    </ReleaseContext.Provider>
+  );
+};
+
+ReleaseContextProvider.propTypes = {
+  children: PropTypes.any,
+};
+
+export default ReleaseContextProvider;
+
+export function useRelease() {
+  const context = React.useContext(ReleaseContext);
+  if (context === undefined) {
+    throw new Error('useCount must be used within a CountProvider');
+  }
+  return context;
+}

--- a/src/hooks/ReleaseContextProvider.js
+++ b/src/hooks/ReleaseContextProvider.js
@@ -6,16 +6,35 @@ import fetchData from '../lib/fetchData';
 const ReleaseContext = createContext();
 
 const ReleaseContextProvider = ({children}) => {
-  const devServerAPIHostname = process.env.NODE_ENV === 'production' ? '' :
-    (process.env.API_URL || '').replace(/https?:\/\//, '');
-  const [host] = (devServerAPIHostname || window.location.hostname).split('.');
-  const releaseUrl = `https://fms.alliancegenome.org/api/releaseversion/current?host=${host}`;
+  const releaseUrl = '/api/releaseInfo/summary';
 
   const {
     data,
     isLoading,
     isError,
   } = useQuery([releaseUrl], () => {
+  /*
+    return {
+      'releaseInfo': {
+        'releaseDate': null,
+        'releaseVersion': '4.1.0',
+        'snapShotDate': null
+      },
+      'metaData': [
+        {
+          'date_produced': null,
+          'mod': 'TAGS',
+          'release': 'NotSpecified',
+          'type': 'HTP'
+        },
+        {
+          'date_produced': null,
+          'mod': 'SGD',
+          'release': 'SGD 1.0.1.4 2021-01-21',
+          'type': 'BGI'
+        },
+      ]
+    }; */
     return fetchData(releaseUrl);
   });
 

--- a/src/reactApplication.js
+++ b/src/reactApplication.js
@@ -8,6 +8,7 @@ import RouteListener from './components/routeListener';
 import routes from './routes';
 import { ScrollContext } from 'react-router-scroll-4';
 import { ReactQueryConfigProvider } from 'react-query';
+import ReleaseContextProvider from './hooks/ReleaseContextProvider';
 
 const isBrowser = (typeof window !== 'undefined');
 const store = configureStore();
@@ -26,17 +27,19 @@ class ReactApp extends Component {
     return (
       <Provider store={store}>
         <ReactQueryConfigProvider config={queryConfig}>
-          <Router>
-            {
-              isBrowser ?
-                <ScrollContext>
-                  <RouteListener onRouteChange={logPageView}>
-                    {routes}
-                  </RouteListener>
-                </ScrollContext> :
-                routes
-            }
-          </Router>
+          <ReleaseContextProvider>
+            <Router>
+              {
+                isBrowser ?
+                  <ScrollContext>
+                    <RouteListener onRouteChange={logPageView}>
+                      {routes}
+                    </RouteListener>
+                  </ScrollContext> :
+                  routes
+              }
+            </Router>
+          </ReleaseContextProvider>
         </ReactQueryConfigProvider>
       </Provider>
     );

--- a/src/tests/application.test.js
+++ b/src/tests/application.test.js
@@ -7,6 +7,11 @@ import ReactApp from '../reactApplication';
 
 describe('ReactApp', () => {
   it('should be able to render to an HTML string', () => {
+    global.window = {
+      location: {
+        hostname: 'www.alliancegenome.org'
+      }
+    };
     let htmlString = renderToString(
       <ReactApp router={MemoryRouter} />
     );

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -77,7 +77,6 @@ const plugins = [
     title: 'Alliance of Genome Resources'
   }),
   new webpack.EnvironmentPlugin({
-    API_URL: '',
   }),
   new MiniCssExtractPlugin({
     filename: '[name].[hash].css',

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -77,7 +77,6 @@ const plugins = [
     title: 'Alliance of Genome Resources'
   }),
   new webpack.EnvironmentPlugin({
-    ALLIANCE_RELEASE: '[dev]',
     API_URL: '',
   }),
   new MiniCssExtractPlugin({

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -78,6 +78,7 @@ const plugins = [
   }),
   new webpack.EnvironmentPlugin({
     ALLIANCE_RELEASE: '[dev]',
+    API_URL: '',
   }),
   new MiniCssExtractPlugin({
     filename: '[name].[hash].css',


### PR DESCRIPTION
Use the FMS API to obtain the release version number, which is used to populate both 1) the release number in the website header and 2) the API call for the download page.

ALLIANCE_RELEASE environment variable is no longer in use and is retired.