### PR TITLE
AGR-2864 variant page (round 2)

### DIFF
--- a/src/components/dataTable/AlleleCell.js
+++ b/src/components/dataTable/AlleleCell.js
@@ -4,7 +4,9 @@ import {Link} from 'react-router-dom';
 import AlleleSymbol from '../../containers/allelePage/AlleleSymbol';
 
 const AlleleCell = ({allele}) => {
-  return allele.category === 'variant' ? allele.symbol : (
+  return allele.category === 'variant' ? (
+    <Link to={`/variant/${allele.id}`}>{allele.symbol}</Link>
+  ) : (
     <Link to={`/allele/${allele.id}`}>
       <AlleleSymbol allele={allele} wrap />
     </Link>

--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -169,7 +169,9 @@ const GeneAlleleDetailsTable = ({geneId}) => {
     {
       text: 'Molecular consequence',
       dataField: 'consequence.molecularConsequence',
-      formatter: VEPTextCell,
+      formatter: (molecularConsequences) => (
+        <span>{molecularConsequences.join(', ')}</span>
+      ),
       filterable: true,
       filterName: 'molecularConsequence',
       headerStyle: {width: '350px'},

--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -170,7 +170,7 @@ const GeneAlleleDetailsTable = ({geneId}) => {
       text: 'Molecular consequence',
       dataField: 'consequence.molecularConsequence',
       formatter: (molecularConsequences) => (
-        <span>{molecularConsequences.join(', ')}</span>
+        <span>{(molecularConsequences || []).join(', ')}</span>
       ),
       filterable: true,
       filterName: 'molecularConsequence',

--- a/src/containers/allelePage/VariantPage.js
+++ b/src/containers/allelePage/VariantPage.js
@@ -85,13 +85,15 @@ const VariantPage = ({ variantId }) => {
     return null;
   }
 
-  const title = `${data.displayName} | ${data.species && data.species.name} allele`;
+  const variantSymbol = data.symbol || data.displayName || data.id;
+
+  const title = `${variantSymbol} | ${data.species && data.species.name} allele`;
 
   return (
     <DataPage>
       <HeadMetaTags title={title}/>
       <PageNav sections={SECTIONS}>
-        <PageNavEntity entityName={data.displayName} icon={<SpeciesIcon inNav scale={0.5} species={data.species && data.species.name} />} truncateName>
+        <PageNavEntity entityName={variantSymbol} icon={<SpeciesIcon inNav scale={0.5} species={data.species && data.species.name} />} truncateName>
           <DataSourceLink reference={data.crossReferences.primary} />
           {data.gene && <div>Variant overlaps <Link to={`/gene/${data.gene.id}`}><GeneSymbol gene={data.gene} /></Link></div>}
           <SpeciesName>{data.species && data.species.name}</SpeciesName>
@@ -99,7 +101,7 @@ const VariantPage = ({ variantId }) => {
       </PageNav>
       <PageData>
         <PageCategoryLabel category='allele' />
-        <PageHeader>{data.displayName}</PageHeader>
+        <PageHeader>{variantSymbol}</PageHeader>
 
         <Subsection hideTitle title={SUMMARY}>
           <ErrorBoundary>

--- a/src/containers/allelePage/VariantSequenceView.js
+++ b/src/containers/allelePage/VariantSequenceView.js
@@ -1,19 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import GenomeFeatureWrapper from '../genePage/genomeFeatureWrapper';
+import getVariantGenomeLocation from './getVariantGenomeLocation';
 
 const VariantSequenceView = ({ variant }) => {
 
-  const genomeLocations = variant.gene && variant.gene.genomeLocations;
-  const genomeLocation = genomeLocations && genomeLocations.length > 0 ? 
-    genomeLocations[0] :
-    {
-      // in case not overlapping a gene
-      ...variant.location,
-      start: Math.max(1, variant.location.start - 500),
-      end: variant.location.end + 500,
-    };
-
+  const genomeLocation = getVariantGenomeLocation(variant);
   let isoformFilter = [];
   if(variant.transcriptList){
     isoformFilter = variant.transcriptList.map(a => a.id.split(':').pop());
@@ -30,7 +22,7 @@ const VariantSequenceView = ({ variant }) => {
       fmax={fmax}
       fmin={fmin}
       geneSymbol={variant.symbol}
-      genomeLocationList={genomeLocations || []}
+      genomeLocationList={[genomeLocation]}
       height='200px'
       id='genome-feature-location-id'
       isoformFilter={isoformFilter}

--- a/src/containers/allelePage/VariantSummary.js
+++ b/src/containers/allelePage/VariantSummary.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
-import { getSingleGenomeLocation } from '../../lib/utils';
 import {
   AttributeLabel,
   AttributeValue,
@@ -13,6 +12,7 @@ import ExternalLink from '../../components/ExternalLink';
 import DataSourceLink from '../../components/dataSourceLink';
 import { sectionAnchor } from './AlleleMolecularConsequences';
 import Sequence from './Sequence';
+import getVariantGenomeLocation from './getVariantGenomeLocation';
 
 function formatLocation(location) {
   const {chromosome = '', start = '', end = ''} = location || {};
@@ -38,7 +38,8 @@ const VariantSummary = ({variant}) => {
     notes,
   } = variant || {};
 
-  const geneLocation = overlap && overlap.genomeLocations && getSingleGenomeLocation(overlap.genomeLocations); // TODO
+  const genomeLocation = getVariantGenomeLocation(variant);
+
   return (
     <>
       <AttributeLabel>Symbol</AttributeLabel>
@@ -46,7 +47,7 @@ const VariantSummary = ({variant}) => {
         {
           location &&
           <VariantJBrowseLink
-            geneLocation={geneLocation}
+            geneLocation={genomeLocation}
             location={location}
             species={species && species.name}
             type={type && type.name}

--- a/src/containers/allelePage/VariantSummary.js
+++ b/src/containers/allelePage/VariantSummary.js
@@ -21,6 +21,8 @@ function formatLocation(location) {
 
 const VariantSummary = ({variant}) => {
   const {
+    id: variantId,
+    symbol,
     species, // TODO (not available in API yet)
     displayName,
     variantType: type,
@@ -49,7 +51,7 @@ const VariantSummary = ({variant}) => {
             species={species && species.name}
             type={type && type.name}
           >
-            <span className="text-break">{displayName}</span>
+            <span className="text-break">{symbol || displayName || variantId}</span>
           </VariantJBrowseLink>
         }
       </AttributeValue>

--- a/src/containers/allelePage/VariantToTranscriptTable.js
+++ b/src/containers/allelePage/VariantToTranscriptTable.js
@@ -25,7 +25,7 @@ const VariantToTranscriptTable = ({variant}) => {
         <div>{name}</div>
       ),
       headerStyle: {
-        width: 180,
+        width: 260,
       },
     },
     {

--- a/src/containers/allelePage/getVariantGenomeLocation.js
+++ b/src/containers/allelePage/getVariantGenomeLocation.js
@@ -1,0 +1,15 @@
+import { getSingleGenomeLocation } from '../../lib/utils';
+
+export default function getVariantGenomeLocation(variant) {
+  const { gene, location: variantLocation } = variant;
+  const { genomeLocations } = gene || {};
+
+  return genomeLocations ?
+    getSingleGenomeLocation(genomeLocations) :
+    variantLocation ? {
+      // in case not overlapping a gene
+      ...variantLocation,
+      start: Math.max(1, variantLocation.start - 500),
+      end: variantLocation.end + 500,
+    } : {};
+}


### PR DESCRIPTION
- fix Gene-Allele details page due to molecularConsequence type change
- variant symbol fallback to displayName and ID
- define variant genome window (for jbrowse and sequence feature viewer) based on gene location, and fallback to +/- 500 bp from the variant.
- increase the column width for feature name (some are really long). (e.g NC_005111.4:g.3276186C>A page)