### PR TITLE
Adding HTP Variant View

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "agr_genomefeaturecomponent": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.13.tgz",
-      "integrity": "sha512-odSQZ1+jf2XVrTRdFgOzipSLgSOJ5XaqbbZotVw+TwQ76syMpjtehvijayuDktKaE1DUGTn753L1it64QSR1cQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.14.tgz",
+      "integrity": "sha512-9ay2uFE9JkM6W6X2Bw0FiZh/eyj1fuzVFKQIXiXGwjx9HmQIXOa++K3Qb0UPFXofUavBLXpRmAAZah3m/S6z+w==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "abortcontroller-polyfill": "^1.5.0",
-    "agr_genomefeaturecomponent": "^0.3.13",
+    "agr_genomefeaturecomponent": "^0.3.14",
     "bootstrap": "4.4.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^1.0.6",

--- a/src/containers/allelePage/VariantSequenceView.js
+++ b/src/containers/allelePage/VariantSequenceView.js
@@ -6,11 +6,8 @@ import getVariantGenomeLocation from './getVariantGenomeLocation';
 const VariantSequenceView = ({ variant }) => {
 
   const genomeLocation = getVariantGenomeLocation(variant);
-  let isoformFilter = [];
-  if(variant.transcriptList){
-    isoformFilter = variant.transcriptList.map(a => a.id.split(':').pop());
-  }
 
+  let htpVariant = `${variant.location.chromosome}:${variant.location.start}`;
   const fmin = Math.min(genomeLocation.start, variant.location.start);
   const fmax = Math.max(genomeLocation.end, variant.location.end);
   return (
@@ -18,14 +15,14 @@ const VariantSequenceView = ({ variant }) => {
       assembly={genomeLocation.assembly}
       biotype='gene'
       chromosome={genomeLocation.chromosome}
-      displayType='ISOFORM_AND_VARIANT'
+      displayType='ISOFORM'
       fmax={fmax}
       fmin={fmin}
-      geneSymbol={variant.symbol}
+      geneSymbol={variant.gene.symbol}
       genomeLocationList={[genomeLocation]}
       height='200px'
       id='genome-feature-location-id'
-      isoformFilter={isoformFilter}
+      htpVariant={htpVariant}
       primaryId={variant.id}
       species={variant.species && variant.species.taxonId}
       strand={genomeLocation.strand}

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -79,7 +79,7 @@ class GenomeFeatureWrapper extends Component {
       '&loc=' + encodeURIComponent(externalLocationString);
   }
 
-  generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, variantFilter, displayType,isoformFilter) {
+  generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, variantFilter, displayType,isoformFilter,htpVariant) {
     let transcriptTypes = getTranscriptTypes();
     const speciesInfo = getSpecies(species);
     const apolloPrefix = speciesInfo.apolloName;
@@ -95,6 +95,7 @@ class GenomeFeatureWrapper extends Component {
         'start': fmin,
         'end': fmax,
         'transcriptTypes': transcriptTypes,
+        'htpVariant': htpVariant ? htpVariant : '',
         'tracks': [
           {
             'id': 1,
@@ -146,7 +147,7 @@ class GenomeFeatureWrapper extends Component {
   }
 
   loadGenomeFeature() {
-    const {chromosome, fmin, fmax, species, id, primaryId, geneSymbol, displayType, synonyms = [], visibleVariants,isoformFilter} = this.props;
+    const {chromosome, fmin, fmax, species, id, primaryId, geneSymbol, displayType, synonyms = [], visibleVariants,isoformFilter,htpVariant} = this.props;
 
     // provide unique names
     let nameSuffix = [geneSymbol, ...synonyms, primaryId].filter((x, i, a) => a.indexOf(x) === i).map(x => encodeURI(x));
@@ -173,7 +174,7 @@ class GenomeFeatureWrapper extends Component {
     // [1] should be track name : ALL_Genes
     // [2] should be track name : name suffix string
     // const visibleVariants = allelesVisible && allelesVisible.length>0 ? allelesVisible.map( a => a.id ) : undefined;
-    const trackConfig = this.generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, visibleVariants, displayType,isoformFilter);
+    const trackConfig = this.generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, visibleVariants, displayType,isoformFilter,htpVariant);
     this.gfc = new GenomeFeatureViewer(trackConfig, `#${id}`, 900, undefined);
     this.setState({
       helpText: this.gfc.generateLegend()
@@ -246,6 +247,7 @@ GenomeFeatureWrapper.propTypes = {
   geneSymbol: PropTypes.string.isRequired,
   genomeLocationList: PropTypes.array,
   height: PropTypes.string,
+  htpVariant: PropTypes.string,
   id: PropTypes.string,
   isoformFilter: PropTypes.array,
   primaryId: PropTypes.string,


### PR DESCRIPTION
Adds browser version 0.3.14 that introduces an optional parameter in 
ISOFORM track views that renders a single SNP onto the viewer.

I've tested this on a few pages but its possible there are fringe cases that I haven't accounted for.  Assuming the variant object has a location parameter it should be passed onto the browser.  This does not make an additional call to apollo since we are currently only rendering the one variant.

