### PR TITLE
AGR-2665 hide allele/variant details link when there is no alleles/variants

### DIFF
--- a/src/containers/allelePage/VariantEffectDetails.js
+++ b/src/containers/allelePage/VariantEffectDetails.js
@@ -96,7 +96,7 @@ const VariantEffectDetails = ({
       <AttributeLabel>Molecular Consequence</AttributeLabel>
       <AttributeValue>
         <CollapsibleList collapsedSize={5}>
-          {molecularConsequence.split(',').map(consequenceText => consequenceText.replace(/_/g, ' '))}
+          {(molecularConsequence || []).map(consequenceText => consequenceText.replace(/_/g, ' '))}
         </CollapsibleList>
       </AttributeValue>
 

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -287,7 +287,9 @@ const AlleleTable = ({geneId}) => {
           null :
           variantsSequenceViewerProps.hasVariants ?
             <VariantsSequenceViewer {...variantsSequenceViewerProps} /> :
-            <NoData>No mapped variant information available</NoData>
+            hasAlleles ?
+              <NoData>No mapped variant information available</NoData> :
+              null /* in this case, the whole section is empty, and default no data message kicks in */
       }
       <div className="position-relative">
         <DataTable

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -47,6 +47,8 @@ const AlleleTable = ({geneId}) => {
 
   const [alleleIdsSelected, setAlleleIdsSelected] = useState([]);
 
+  const hasAlleles = resolvedData && resolvedData.total > 0;
+
   // filtered but not paginate list of alleles
   const allelesFiltered = useAllVariants(geneId, tableProps.tableState); 
 
@@ -298,7 +300,11 @@ const AlleleTable = ({geneId}) => {
           selectRow={selectRow}
           sortOptions={sortOptions}
         />
-        <Link className="btn btn-primary position-absolute d-block" style={{top: '2em'}} to={`/gene/${geneId}/allele-details`}>View all Alleles and Variants information</Link>
+        {
+          hasAlleles ?
+            <Link className="btn btn-primary position-absolute d-block" style={{top: '2em'}} to={`/gene/${geneId}/allele-details`}>View all Alleles and Variants information</Link> :
+            null
+        }
       </div>
     </>
   );


### PR DESCRIPTION
Hide allele/variant details link when there are no alleles or variants.

In the code, the alleles is used to refer to both alleles and variants, ie whatever is returned by the /api/gene/ID/alleles endpoint. 

