### PR TITLE
AGR-2612 details page interactive highlight

### DIFF
--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -58,6 +58,10 @@ const GeneAlleleDetailsTable = ({geneId}) => {
     sizePerPage: 25,
   });
   const { isLoading } = tableQuery;
+  const data = tableQuery.data.map((row) => ({
+    ...row,
+    key: `${row.allele.id}-${row.consequence && row.consequence.transcriptID}`,
+  }));
   const columns = [
     {
       text: 'Allele / Variant Symbol',
@@ -279,12 +283,36 @@ const GeneAlleleDetailsTable = ({geneId}) => {
       fmin: fmin,
       fmax: fmax,
       hasVariants: isLoading ? undefined : Boolean(variants && variants.length),
-      allelesSelected: [],
+      allelesSelected: alleleIdsSelected.map(formatAllele),
       allelesVisible: allelesFiltered.data ? allelesFiltered.data.results.map(({allele}) => formatAllele(allele.id)) : [],
       onAllelesSelect: setAlleleIdsSelected,
     };
   }, [isLoading, allelesFiltered.data, alleleIdsSelected, setAlleleIdsSelected]);
 
+  const selectRow = useMemo(() => {
+    const rowsSelected = data.filter(row => alleleIdsSelected.indexOf(row.allele.id) > -1);
+    return ({
+      mode: 'checkbox',
+      clickToSelect: true,
+      hideSelectColumn: true,
+      selected: rowsSelected.map(row => row.key),
+      onSelect: (row) => {
+        const alleleIdRow = row.allele.id;
+        setAlleleIdsSelected(alleleIdsSelectedPrev => {
+          if (alleleIdsSelectedPrev.includes(alleleIdRow)) {
+            const indexAlleleId = alleleIdsSelectedPrev.indexOf(alleleIdRow);
+            return [
+              ...alleleIdsSelectedPrev.slice(0, indexAlleleId),
+              ...alleleIdsSelectedPrev.slice(indexAlleleId + 1)
+            ];
+          } else {
+            return [...alleleIdsSelectedPrev, alleleIdRow];
+          }
+        });
+      },
+      style: { backgroundColor: '#ffffd4' },
+    });
+  }, [data, alleleIdsSelected, setAlleleIdsSelected]);
 
   return (
     <>
@@ -301,10 +329,12 @@ const GeneAlleleDetailsTable = ({geneId}) => {
       <ErrorBoundary>
         <DataTable
           {...tableQuery}
+          data={data}
           columns={columns}
           downloadUrl={`/api/gene/${geneId}/allele-variant-detail/download`}
+          selectRow={selectRow}
           sortOptions={sortOptions}
-          keyField='id'
+          keyField='key'
         />
       </ErrorBoundary>
     </>

--- a/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
+++ b/src/containers/GeneAlleleDetailsPage/GeneAlleleDetailsTable.js
@@ -251,7 +251,8 @@ const GeneAlleleDetailsTable = ({geneId}) => {
     sizePerPage: 1000,
   }), [tableQuery.tableState]);
   const allelesFiltered = useQuery([baseUrl, tableStateAlleleFiltered], () => {
-    return fetchData(getTableUrl(baseUrl, tableStateAlleleFiltered));
+    const nonHTPCategories = ['allele', 'allele with multiple associated variants', 'allele with one associated variant'];
+    return fetchData(getTableUrl(`${baseUrl}?filter.alleleCategory=${encodeURIComponent(nonHTPCategories.join('|'))}`, tableStateAlleleFiltered));
   });
   const variantsSequenceViewerProps = useMemo(() => {
 


### PR DESCRIPTION
Interactive highlight for the details page, such as /gene/ZFIN:ZDB-GENE-070112-172/allele-details

This change enables highlighting in the viewer when rows in the table are clicked on.

`onAllelesSelect` prop is passed to the viewer, which can be called at the time of your choice, to highlight the table rows when variant is selected in the viewer.