### PR TITLE
AGR-2708 - just adding the type for the script tag

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
 
     <!-- In later version, Reactome would ideally provide NPM package so that the reactome pathway widget is lazy loaded when reaching the gene page -->
-    <script src="https://reactome.org/DiagramJs/diagram/diagram.nocache.js"></script>
+    <script type="text/javascript" src="https://reactome.org/DiagramJs/diagram/diagram.nocache.js"></script>
 
 </head>
 


### PR DESCRIPTION
Just in case, adding the proper type to the script tag.

Should issues come with that way of loading the reactome widget bundle from a CDN, other possibilites:

* https://www.newline.co/fullstack-react/articles/Declaratively_loading_JS_libraries/
* https://stackoverflow.com/a/60573185
