### PR TITLE
add js warning to index.html

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -19,5 +19,6 @@
 <body>
     <div id="app"></div>
     <!-- html-webpack-plugin will append assets here -->
+    <noscript>You need to enable JavaScript to run this app.</noscript>
 </body>
 </html>


### PR DESCRIPTION
When JS is disabled in the end-users browser, AllianceGenome.org currently appears as if it's down.  :(