### PR TITLE
AGR-2228 AGR-2311 AGR-30587 Adding initialHighlight state and deletion support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,9 +1733,9 @@
       }
     },
     "agr_genomefeaturecomponent": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.17.tgz",
-      "integrity": "sha512-hP0LyAfonkND1O4PeLmHWaHtks0AEzXg1xQgzLO/WI7s9PKyW+GHNc3qWqk7Vj5szCUtn0H94qQjoeLJmlUqBA==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.19.tgz",
+      "integrity": "sha512-Y5EjqTv/BK+85BunU6o/GKytfijVujxacC0+Tk6NoTyQQPUBXrd78rY/y3Jake+/z6WMHAFm0C9ILloIxQ/KPQ==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "abortcontroller-polyfill": "^1.5.0",
-    "agr_genomefeaturecomponent": "^0.3.17",
+    "agr_genomefeaturecomponent": "^0.3.19",
     "bootstrap": "4.4.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^1.0.6",

--- a/src/containers/genePage/genomeFeatureWrapper.js
+++ b/src/containers/genePage/genomeFeatureWrapper.js
@@ -101,7 +101,7 @@ class GenomeFeatureWrapper extends Component {
       '&loc=' + encodeURIComponent(externalLocationString);
   }
 
-  generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, variantFilter, displayType,isoformFilter,htpVariant) {
+  generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, variantFilter, displayType,isoformFilter,htpVariant,allelesSelected) {
     let transcriptTypes = getTranscriptTypes();
     const speciesInfo = getSpecies(species);
     const apolloPrefix = speciesInfo.apolloName;
@@ -140,6 +140,7 @@ class GenomeFeatureWrapper extends Component {
         'showVariantLabel': false,
         'variantFilter': variantFilter ? variantFilter : [],
         'isoformFilter': isoformFilter ? isoformFilter : [],
+        'initialHighlight' : allelesSelected ? allelesSelected.map( a => a.id) : [],
         'visibleVariants': undefined,
         'binRatio': 0.01,
         'transcriptTypes': transcriptTypes,
@@ -169,7 +170,7 @@ class GenomeFeatureWrapper extends Component {
   }
 
   loadGenomeFeature() {
-    const {chromosome, fmin, fmax, species, id, primaryId, geneSymbol, displayType, synonyms = [], visibleVariants,isoformFilter,htpVariant} = this.props;
+    const {chromosome, fmin, fmax, species, id, primaryId, geneSymbol, displayType, synonyms = [], visibleVariants,isoformFilter,htpVariant,allelesSelected} = this.props;
 
     // provide unique names
     let nameSuffix = [geneSymbol, ...synonyms, primaryId].filter((x, i, a) => a.indexOf(x) === i).map(x => encodeURI(x));
@@ -196,7 +197,7 @@ class GenomeFeatureWrapper extends Component {
     // [1] should be track name : ALL_Genes
     // [2] should be track name : name suffix string
     // const visibleVariants = allelesVisible && allelesVisible.length>0 ? allelesVisible.map( a => a.id ) : undefined;
-    const trackConfig = this.generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, visibleVariants, displayType,isoformFilter,htpVariant);
+    const trackConfig = this.generateTrackConfig(fmin, fmax, chromosome, species, nameSuffixString, visibleVariants, displayType,isoformFilter,htpVariant,allelesSelected);
     this.gfc = new GenomeFeatureViewer(trackConfig, `#${id}`, 900, undefined);
     this.setState({
       helpText: this.gfc.generateLegend()


### PR DESCRIPTION
Adding the 0.3.19 browser which adds support for showing multiple rows 
of deletions and setting an initial highlighted state of the browser to keep the view in sync with the table.
Most code changes in the genomeFeatureComponent repo.
