### PR TITLE
Partial fix for gocam mouse over

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@geneontology/wc-gocam-viz": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@geneontology/wc-gocam-viz/-/wc-gocam-viz-0.0.43.tgz",
-      "integrity": "sha512-edzdVGSAtsj7lx4PfkNdGjxKImPYj6SGzS4KxhVwjQVri2R9TQLrxAg9vu8GDhxEjyHhxmbZwZeCTeM/vVpfaw==",
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-gocam-viz/-/wc-gocam-viz-0.0.44.tgz",
+      "integrity": "sha512-FVcRO4pgt63CxCUmT0ChIAuvGT/sI7IVm0vzmdWNSreRf1KTseCp6k1TySM/BYApAhtvQ2hDQUJD9l069Vdipg==",
       "requires": {
         "@geneontology/dbxrefs": "^1.0.16",
         "@geneontology/wc-light-modal": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "dependencies": {
     "@geneontology/curie-util-es5": "^1.2.4",
-    "@geneontology/wc-gocam-viz": "0.0.43",
+    "@geneontology/wc-gocam-viz": "0.0.44",
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "abortcontroller-polyfill": "^1.5.0",

--- a/src/components/pathway/pathwayWidget.js
+++ b/src/components/pathway/pathwayWidget.js
@@ -5,12 +5,7 @@ import PropTypes from 'prop-types';
 import HorizontalScroll from '../horizontalScroll';
 
 import { STRINGENCY_HIGH } from '../orthology/constants';
-import ControlsContainer from '../controlsContainer';
-import OrthologPicker from '../OrthologPicker';
-import { getOrthologId } from '../orthology';
 import fetchData from '../../lib/fetchData';
-
-import LoadingSpinner from '../loadingSpinner';
 
 import { withRouter } from 'react-router-dom';
 
@@ -88,7 +83,6 @@ class PathwayWidget extends Component {
     //   this.setState({ uniprot : { loaded : true, error : true, id : undefined } });
     // })
   }
-
 
   /**
    * Dynamically load the reactome library the first time the component is mount
@@ -209,9 +203,10 @@ class PathwayWidget extends Component {
 
     this.setState({loading: false});
 
-    if(this.state.reactomePathways.selected) {
-      this.loadReactomeDiagram(this.state.reactomePathways.selected);
-    }
+    this.selectReactomePathway();
+    // if(this.state.reactomePathways.selected) {
+    //   this.loadReactomeDiagram(this.state.reactomePathways.selected);
+    // }
   }
 
   /**
@@ -321,7 +316,33 @@ class PathwayWidget extends Component {
   }
 
   selectMODPathway() {
-    this.setState({ selectedTab: "MODPathways" })
+    this.setState({ selectedTab: "MODPathways" });
+
+    // The following is to handle the autofocus method on the gocam widget
+    // Needs to over 3s or to click on the widget to get wheel focus
+    setTimeout(() => {
+      let elt = document.getElementById("gocam-1");
+      if(elt) {
+        elt.setAutoFocus(false);
+
+        elt.addEventListener("click", (e) => {
+          elt.setAutoFocus(true);
+        })
+
+        let isOvering = false;
+        elt.addEventListener("mouseenter", (e) => {
+          isOvering = true,
+          setTimeout(() => {
+            elt.setAutoFocus(true);
+          }, 3000)
+        })
+
+        elt.addEventListener("mouseleave", (e) => {
+          elt.setAutoFocus(false);
+          isOvering = false;
+        })
+      }
+    }, 5000)
   }
 
   isHumanGene() {

--- a/src/components/pathway/pathwayWidget.js
+++ b/src/components/pathway/pathwayWidget.js
@@ -222,7 +222,7 @@ class PathwayWidget extends Component {
         }
         this.reactomePathwayDiagram = Reactome.Diagram.create({
           "placeHolder": "reactomePathwayHolder",
-          "width": 1280,
+          "width": 1130,
           "height": 600
         })
         this.reactomePathwayDiagram.loadDiagram(pathwayId);


### PR DESCRIPTION
I was able to introduce a flexible strategy for the GO-CAM viewer. Currently the viewer will take focus:
* after a user stays more than 3s on the component (can be adjusted but 3s sounds a good balance)
* when a user click on the component

I have tried to hijack mouse events for the reactome pathway in different ways, but unfortunately wasn't able to prevent the default behavior. So this will require more discussion with reactome. However, double checking the current behavior, they don't automatically capture the mouse wheel either, they probably even require 3-5s to capture it, so it should not bother the casual scroll of the page.