### PR TITLE
AGR-2708: make sure Reactome variable is also declared

### DIFF
--- a/src/components/pathway/pathwayWidget.js
+++ b/src/components/pathway/pathwayWidget.js
@@ -216,8 +216,8 @@ class PathwayWidget extends Component {
   loadReactomeDiagram(pathwayId) {
     if(!this.reactomePathwayDiagram) {
       (async() => {
-        // ensure the Reactome library has been loaded
-        while(!Reactome) {
+        // ensure the Reactome library has been loaded (typeof used to check if variable is even declared)
+        while(typeof Reactome != 'undefined' && !Reactome) {
           await new Promise(resolve => setTimeout(resolve, 1000));
         }
         this.reactomePathwayDiagram = Reactome.Diagram.create({


### PR DESCRIPTION
On very first load, I find that you might have an issue with the reactome library being loaded from the CDN. So I added an additional check if the Reactome variable is even declared (based on https://stackoverflow.com/a/138883/7608507).