### PR TITLE
AGR-3053 Fixing non-unique transcripts (Rat)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,9 +1733,9 @@
       }
     },
     "agr_genomefeaturecomponent": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.21.tgz",
-      "integrity": "sha512-NP+NOl7f8sfgD3USi01aSAfoYkCmTy7qjzcRwsSFDnDve6JUCfY8WREIBnGCO/m/bvt7K1YHn/yicDwhYJY5SA==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.22.tgz",
+      "integrity": "sha512-czSNOL5/NB9FFNngb8cUB0r9q9oFBGN+ftZR5ZrLPOl2lXW5U06CZsESRbrypK52/lzSL0eu0nos/c6oKFmR2A==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "abortcontroller-polyfill": "^1.5.0",
-    "agr_genomefeaturecomponent": "^0.3.21",
+    "agr_genomefeaturecomponent": "^0.3.22",
     "bootstrap": "4.4.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^1.0.6",


### PR DESCRIPTION
Added in code for both isoform only and isoform/variant to filter out non-unique transcripts in the widget.  This can be removed once we are sure the GFF and Apollo return is only unique transcripts.  We are filtering on the apollo field ID which in the case of rat is something like rna1234.  If the browser gets to a transcript with an ID that its already seen it will skip it.

No UI codebase changes.