### PR TITLE
update reverse proxy for mod-landing-pages 

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,7 @@ server {
 	}
 
 	location /members/ {
-		proxy_pass http://mod-landing-page.d2avs8zgrkjaup.amplifyapp.com/members/;
+		proxy_pass http://members.alliancegenome.org/members/;
 	}
 
 	error_page 404 =200 /index.html;


### PR DESCRIPTION
To hide the Amplify domain name, use a custom domain for the mod-landing-pages.

Update the upstream server for mod-landing-pages (ie. members.alliancegenome.org). So that /members/[something] is proxied to the same path under the subdomain.

