### PR TITLE
AGR-3081 allele buttons

### DIFF
--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -308,11 +308,19 @@ const AlleleTable = ({geneId}) => {
           selectRow={selectRow}
           sortOptions={sortOptions}
         />
-        {
-          hasAlleles ?
-            <Link className="btn btn-primary position-absolute d-block" style={{top: '2em'}} to={`/gene/${geneId}/allele-details`}>View all Alleles and Variants information</Link> :
-            null
-        }
+        <div className="d-flex flex-column align-items-center my-2 mx-auto">
+          {
+            hasAlleles ?
+              <>
+                <Link
+                  className="btn btn-primary"
+                  to={`/gene/${geneId}/allele-details`}
+                >View detailed Alleles/Variants information</Link>
+              </> :
+              null
+          }
+          <Link className="btn btn-link" to={'/downloads#variants-alleles'}>Download all Alleles/Variants for the species</Link>
+        </div>
       </div>
     </>
   );

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -49,6 +49,7 @@ const AlleleTable = ({geneId}) => {
   const [alleleIdsSelected, setAlleleIdsSelected] = useState([]);
 
   const hasAlleles = resolvedData && resolvedData.total > 0;
+  const hasManyAlleles = resolvedData && resolvedData.total > 20000;
 
   // filtered but not paginate list of alleles
   const allelesFiltered = useAllVariants(geneId, tableProps.tableState);
@@ -313,9 +314,16 @@ const AlleleTable = ({geneId}) => {
             hasAlleles ?
               <>
                 <Link
-                  className="btn btn-primary"
+                  className={'btn btn-primary ' + (hasManyAlleles ? 'disabled' : '')}
                   to={`/gene/${geneId}/allele-details`}
                 >View detailed Alleles/Variants information</Link>
+                {
+                  hasManyAlleles ?
+                    <NoData>
+                      Detailed information is disabled due to large number of variants. <br />
+                      Please refer to the download link below for more information.
+                    </NoData> : null
+                }
               </> :
               null
           }

--- a/src/containers/genePage/alleleTable.js
+++ b/src/containers/genePage/alleleTable.js
@@ -309,25 +309,25 @@ const AlleleTable = ({geneId}) => {
           selectRow={selectRow}
           sortOptions={sortOptions}
         />
-        <div className="d-flex flex-column align-items-center my-2 mx-auto">
+        <div className="d-flex flex-column align-items-start my-2 mx-auto">
           {
             hasAlleles ?
-              <>
+              <span>
                 <Link
                   className={'btn btn-primary ' + (hasManyAlleles ? 'disabled' : '')}
                   to={`/gene/${geneId}/allele-details`}
                 >View detailed Alleles/Variants information</Link>
                 {
                   hasManyAlleles ?
-                    <NoData>
-                      Detailed information is disabled due to large number of variants. <br />
+                    <NoData>{' '}
+                      Detailed information is disabled due to large number of variants.
                       Please refer to the download link below for more information.
                     </NoData> : null
                 }
-              </> :
+              </span> :
               null
           }
-          <Link className="btn btn-link" to={'/downloads#variants-alleles'}>Download all Alleles/Variants for the species</Link>
+          <Link className="btn btn-link" to={'/downloads#variants-alleles'}>Download all Alleles/Variants for all genes of the species</Link>
         </div>
       </div>
     </>


### PR DESCRIPTION
- display allele/variant details link below the summary table (instead of above)
- disable buttons when number of variants is large, and include a note to use the download page instead