### PR TITLE
JBrowse Link to Human Fix

### DIFF
--- a/apps/main-app/src/containers/genePage/VariantsSequenceViewer.js
+++ b/apps/main-app/src/containers/genePage/VariantsSequenceViewer.js
@@ -7,6 +7,7 @@ const VariantsSequenceViewer = ({ gene, fmin, fmax, allelesSelected, allelesVisi
 
   const genomeLocationList = gene.genomeLocations;
   const genomeLocation = getSingleGenomeLocation(genomeLocationList);
+  const displayType = gene.species.name == "Homo sapiens" ? 'ISOFORM' : 'ISOFORM_AND_VARIANT';
 
   // TODO: remove when onAllelesSelect is in use
   // onAllelesSelect is to be called with a list of allele IDs, when selecting alleles throw the viewer.
@@ -24,6 +25,7 @@ const VariantsSequenceViewer = ({ gene, fmin, fmax, allelesSelected, allelesVisi
       biotype={gene.soTermName}
       chromosome={genomeLocation.chromosome}
       displayType='ISOFORM_AND_VARIANT'
+      displayType={displayType}
       fmax={fmax}
       fmin={fmin}
       geneSymbol={gene.symbol}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20033,9 +20033,9 @@
       }
     },
     "agr_genomefeaturecomponent": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.22.tgz",
-      "integrity": "sha512-czSNOL5/NB9FFNngb8cUB0r9q9oFBGN+ftZR5ZrLPOl2lXW5U06CZsESRbrypK52/lzSL0eu0nos/c6oKFmR2A==",
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/agr_genomefeaturecomponent/-/agr_genomefeaturecomponent-0.3.23.tgz",
+      "integrity": "sha512-PHNIitzEnz5hfZpqQFQzf+HIM+0pZ+8EEZu3bgB67X2MLLWYvcm7Dk6bM8mKT4VmYT6titXcmpo6SuqOeQ6P0Q==",
       "requires": {
         "d3": "^5.7.0",
         "d3-tip": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "abortcontroller-polyfill": "^1.5.0",
-    "agr_genomefeaturecomponent": "^0.3.22",
+    "agr_genomefeaturecomponent": "^0.3.23",
     "bootstrap": "4.4.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^1.0.6",


### PR DESCRIPTION
Fixing link to human jbrowse within browser window and loading error on 
human browser window when variants are requested.

The issue described in KANBAN-33 was due to the "source" for human data being labeled as RGD.  We were building the JBrowse link based on this data.  It now looks at a track level variable to determine which genome to link.  This pull also fixes an issue with the human browser where it was requesting variants from apollo where none exist and failing to load.  Now it does not request these variants and loads fine.  

Also I don't really know who to request reviews for on these sorts of things.... so feel free to redirect this to others.