### PR TITLE
Expanded banner and title invisible bar

### DIFF
--- a/apps/main-app/src/containers/modLanding/style.scss
+++ b/apps/main-app/src/containers/modLanding/style.scss
@@ -5,7 +5,7 @@
 
 .titleBar {
   color: white;
-  bottom: 0;
+  bottom: 0px;
   padding-top: 10px;
   padding-bottom: 5px;
 }
@@ -51,7 +51,7 @@
   padding: 0;
   margin: 0;
   width: 100%;
-  height: 160px;
+  height: 370px;
 }
 
 .sectionTitle {
@@ -66,7 +66,8 @@
 
 .banner {
   background-size: cover;
-  height: 200px;
+  background-position: center center;
+  height: 440px;
 }
 
 .banner__DEFAULT {


### PR DESCRIPTION
Some changes on banner size, title bar position by increasing `titleBarEmptyRow`. They look quite nice now, with a couple of exceptions but I can modify the original pics to look nicer.

Just a suggestion, you can merge or delete the PR 