### PR TITLE
SCRUM-1086 Search links are now h5 instead of normal links, because t…

### DIFF
--- a/apps/main-app/src/containers/modLanding/Search.js
+++ b/apps/main-app/src/containers/modLanding/Search.js
@@ -5,17 +5,17 @@ const Search = ({links, sectionStyle}) => {
   return (
     <div>
       <div className={`container ${style.containerExtra}`}>
-        <div data-testid={'resources_topdiv'} className={`${style.section} ${sectionStyle}`}>
-        <h2 data-testid={'resources_header'} className={style.sectionTitle}>Search Alliance</h2>
-          <div data-testid={'resources_link_div'} className={style.resourceDiv} >
+        <div data-testid={'search_topdiv'} className={`${style.section} ${sectionStyle}`}>
+        <h2 data-testid={'search_header'} className={style.sectionTitle}>Search Alliance</h2>
+          <div data-testid={'search_link_div'} className={style.searchiv} >
           { links && links.map((link, index) => {
                       return (
                         <div key={index}>
-                          <p>
-                            <a href={link[1]} data-testid={'href_resources_' + index} >
+                          <h5>
+                            <a href={link[1]} data-testid={'href_search_' + index} >
                             <span dangerouslySetInnerHTML={{__html: link[0]}} 
-                                  data-testid={'resources_label_' + index}/>
-                          </a></p>
+                                  data-testid={'search_label_' + index}/>
+                          </a></h5>
                         </div>
                       );
                     })}

--- a/apps/main-app/src/containers/modLanding/content.js
+++ b/apps/main-app/src/containers/modLanding/content.js
@@ -35,7 +35,7 @@ export const MODContent = {
     fetchNewsCount: 3,
     linkToNewsPage: 'https://blog.wormbase.org/',
     search: [
-      ['<i>C. elegans</i>', 'search?species=Caenorhabditis elegans'],
+      ['<i>C. elegans</i>', 'search?q=Caenorhabditis elegans'],
     ],
     resources: [
       ['WormBase Guidelines for Nomenclature',  'https://wormbase.org/about/userguide/nomenclature#gi9m5c264k8be0afldh71j3--10'],
@@ -95,7 +95,7 @@ export const MODContent = {
     fetchNewsCount: 3,
     linkToNewsPage: 'https://yeastgenomeblog.wordpress.com/',
     search: [
-      ['<i>S. cerevisiae</i>', 'search?species=Saccharomyces cerevisiae'],
+      ['<i>S. cerevisiae</i>', 'search?q=Saccharomyces cerevisiae'],
     ],
     resources: [
       ['Search SGD',                        'https://www.yeastgenome.org/search?q=&is_quick=true'],
@@ -150,7 +150,7 @@ export const MODContent = {
     zfinNewsAPI: 'https://zfin.org/action/api/wiki/news?limit=5&page=1',
     fetchNewsCount: 3,
     search: [
-      ['<i>D. rerio</i>', 'search?species=Danio rerio'],
+      ['<i>D. rerio</i>', 'search?q=Danio rerio'],
     ],
     resources: [
       ['Search and Retrieve Zebrafish Data',      'https://zfin.org/search?category=&q='],
@@ -201,7 +201,7 @@ export const MODContent = {
     newsURL: 'https://flybase.org/commentaries',
     linkToNewsPage: 'https://flybase.org/commentaries',
     search: [
-      ['<i>D. melanogaster</i>', 'search?species=Drosophila melanogaster'],
+      ['<i>D. melanogaster</i>', 'search?q=Drosophila melanogaster'],
     ],
     resources: [
       ['Search FlyBase',        'https://flybase.org/'],
@@ -242,7 +242,7 @@ export const MODContent = {
     hasNews: true,
     newsURL: 'https://rgd.mcw.edu/wg/news2/',
     search: [
-      ['<i>R. norvegicus</i>', 'search?species=Rattus norvegicus'],
+      ['<i>R. norvegicus</i>', 'search?q=Rattus norvegicus'],
     ],
     resources: [
       ['RGD Gene Search',                         'https://rgd.mcw.edu/rgdweb/search/genes.html'],
@@ -285,7 +285,7 @@ export const MODContent = {
     hasNews: true,
     newsURL: 'http://www.informatics.jax.org/mgihome/news/whatsnew.shtml',
     search: [
-      ['<i>M. musculus</i>', 'search?species=Mus musculus'],
+      ['<i>M. musculus</i>', 'search?q=Mus musculus'],
     ],
     resources: [
       ['Mouse Genes',                           'http://www.informatics.jax.org/genes.shtml'],


### PR DESCRIPTION
…he text was so tiny.  Paulo realized the species filter didn't work, Ceri changed the links to a search for the species instead of using a species link.