### PR TITLE
SCRUM-1219

### DIFF
--- a/apps/main-app/src/components/orthology/constants.js
+++ b/apps/main-app/src/components/orthology/constants.js
@@ -17,7 +17,7 @@ const ALL_METHODS = {
   },
   PhylomeDB: {
   },
-  sonicParanoid: {
+  SonicParanoid: {
   },
   ZFIN: {
   }

--- a/apps/main-app/src/components/orthology/orthologyUserGuide.js
+++ b/apps/main-app/src/components/orthology/orthologyUserGuide.js
@@ -18,7 +18,7 @@ const OrthologyUserGuide = () => (
       (DIOPT). DIOPT integrates a number of existing methods including
       those used by the Alliance: Ensembl Compara, HGNC, Hieranoid,
       InParanoid, OMA, OrthoFinder, OrthoInspector, PANTHER, PhylomeDB,
-      sonicParanoid, and ZFIN. See the <ExternalLink href='https://fgr.hms.harvard.edu/diopt-documentation'>
+      SonicParanoid, and ZFIN. See the <ExternalLink href='https://fgr.hms.harvard.edu/diopt-documentation'>
       DIOPT documentation</ExternalLink> for additional information and
       references related to the included methods. DIOPT assigns a
       score/count based on the number of methods that call a specific


### PR DESCRIPTION
Reverting the temporary UI changes as we've fixed the spelling of "sonicParanoid" -> "SonicParanoid" in the source data.