### PR TITLE
Added Xenbase to header & footer

### DIFF
--- a/apps/main-app/src/constants.js
+++ b/apps/main-app/src/constants.js
@@ -121,6 +121,11 @@ export const NAV_MENU = [
         route: '/members/wormbase'
       },
       {
+        label: 'Xenbase',
+        shortLabel: 'Xenbase',
+        route: 'https://www.xenbase.org/'
+      },
+      {
         label: 'Zebrafish Information Network',
         shortLabel: 'ZFIN',
         route: '/members/zfin'


### PR DESCRIPTION
Xenbase added to header and footer via the constants file.

No visible issues with css on both homepage and gene pages.  Both the header and footer are correctly showing the "link out" symbol for the href to xenbase home.  The ticket didn't specify if Xenbase had a longer form label (ex Mouse Genome Database vs MGD) so they are both the same right now. 