### PR TITLE
gocam-viz changes: layout, complexes and gene panel

### DIFF
--- a/apps/main-app/src/components/pathway/pathwayWidget.js
+++ b/apps/main-app/src/components/pathway/pathwayWidget.js
@@ -481,7 +481,7 @@ class PathwayWidget extends Component {
             <div>
                 <wc-gocam-viz
                     id="gocam-1"
-                    repository="prod"
+                    repository="release"
                     gocam-id={this.state.cutils.getCurie(this.state.gocams.selected)}
                     show-go-cam-selector="false"
                     show-has-input="false"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@emotion/server": "11.0.0",
     "@emotion/styled": "11.1.5",
     "@geneontology/curie-util-es5": "^1.2.4",
-    "@geneontology/wc-gocam-viz": "0.0.45",
+    "@geneontology/wc-gocam-viz": "0.0.50-beta.12",
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
An updated gocam viz

Only the package version change as it is a component, so no other changes or side effects to agr-ui

As for the GO CAM VIZ changes

### Issues

- https://github.com/geneontology/wc-gocam-viz/issues/10
- https://github.com/geneontology/wc-gocam-viz/issues/9

### Added

- Linear Tree layout
- Gene Panel improvements
- Toggling protein complex view
- small molecules
- other adjustments

### Removed

- hover over effects (only clicks events)

### Todo

- the scrolling still lacking, but good enough, but the gene panel will be highlighted
- new decision tree including Constitutively Upstream, remove input for etc
- Group and contributor info


idk who to tag but tagging @kltm @chris-grove @dustine32 @vanaukenk @thomaspd 