### PR TITLE
addresses https://agr-jira.atlassian.net/browse/KANBAN-318

### DIFF
--- a/libs/app-shell/src/lib/sitemap.js
+++ b/libs/app-shell/src/lib/sitemap.js
@@ -24,7 +24,7 @@ const sitemap = [
       },
       {
         label: 'JBrowse',
-        route: '/jbrowse/?data=data%2FHomo%20sapiens',
+        route: '/jbrowse/index.html?data=data%2FHomo%20sapiens',
       }
     ],
   },


### PR DESCRIPTION
Removed #1112 because I was merging into master rather than main. Fixed here. Adds explicit "index.html" to the JBrowse link in the data and tools section