### PR TITLE
Updated to gocam-viz@0.0.51

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@emotion/server": "11.0.0",
     "@emotion/styled": "11.1.5",
     "@geneontology/curie-util-es5": "^1.2.4",
-    "@geneontology/wc-gocam-viz": "0.0.50-beta.12",
+    "@geneontology/wc-gocam-viz": "0.0.51",
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
[Package Update Commit](https://github.com/geneontology/wc-gocam-viz/commit/629c02a9aaea7fd8c2086172f2695ca18df6a250)

### Changed
- Fix linkouts to MGI 

### Removed
- The purple linkouts no more (quick temp solution), to check the GO term linkouts use the inner box
![image](https://user-images.githubusercontent.com/2273929/230170966-3541416e-ac51-45d8-9665-c4a201d4be62.png)

tagging @oblodgett @dustine32 @chris-grove @kltm 
Thanks @chris-grove @dustine32 for feedback and testing it 