### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "custom-event-polyfill": "^1.0.6",
     "d3-selection": "2.0.0",
     "document-register-element": "1.13.1",
-    "generic-sequence-panel": "^1.2.5",
+    "generic-sequence-panel": "^1.3.0",
     "html-react-parser": "^0.10.0",
     "immutable": "^3.8.1",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
Fixes https://agr-jira.atlassian.net/browse/KANBAN-390
When genes were longer than 500kb, the sequence details panel barfed and showed a red error message. A fix to the npm package should fix that.