### PR TITLE
Bump wc-gocam-viz version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@geneontology/curie-util-es5": "^1.2.4",
-    "@geneontology/wc-gocam-viz": "0.0.51",
+    "@geneontology/wc-gocam-viz": "1.0.0",
     "@geneontology/wc-ribbon-strips": "0.0.37",
     "@geneontology/wc-ribbon-table": "0.0.57",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
For https://github.com/geneontology/wc-gocam-viz/issues/34.

This change should result in the GO-CAM pathway viewer on an Alliance gene page now displaying "Has Input" and "Has Output" relation symbols in the legend.

Thanks @oblodgett!