### PR TITLE
Add more config and styling for pathway widget update

### DIFF
--- a/src/components/pathway/pathwayWidget.js
+++ b/src/components/pathway/pathwayWidget.js
@@ -482,18 +482,10 @@ class PathwayWidget extends Component {
               <div>
                 <wc-gocam-viz
                   id="gocam-1"
-                  repository="release"
                   gocam-id={this.state.cutils.getCurie(this.state.gocams.selected)}
-                  show-go-cam-selector="false"
-                  show-has-input="false"
-                  show-has-output="false"
-                  show-gene-product="true"
-                  show-activity="false"
-                  show-isolated-activity="true"
-                  show-legend="false"
-                  style={{ "maxWidth": "1280px" }}
-                ></wc-gocam-viz>
-                <img src={gocamLegend} style={{"width" : "600px"}}/>
+                  show-legend="true"
+                  style={{ "maxWidth": "1280px" }}>
+                </wc-gocam-viz>
               </div>
             : <div>
                 <NoData/>

--- a/src/style.scss
+++ b/src/style.scss
@@ -125,3 +125,47 @@ wc-ribbon-cell.ribbon__subject--cell--no-annotation {
   --gocam-panel-h1-color: #2598C5;
   --gocam-panel-h1-weight: 400;
 }
+
+wc-gocam-viz {
+  --activity-background-active: #af732a;
+  --activity-color-active: #fff;
+  --button-background: #DDD;
+  --button-color: #000;
+  --button-background-hover: #BBB;
+  --button-border-width: 1px;
+  --button-border-color: #ccc;
+
+  // Panel
+  --panel-header-background:	#ececec;
+  --panel-border-color: #AAA;
+
+   // Process
+   --process-label-background:	#7a548d;
+   --process-label-color: #fff;
+
+  --process-label-padding: 0.5rem;
+  --activity-padding: 0.5rem;
+  --gene-product-padding: 0 0 0.5rem 0;
+  --function-label-padding: 0 0 0.5rem 0;
+
+  --graph-padding: 8px;
+
+--panel-header-padding: 8px;
+
+--panel-border-color: #CCC;
+
+--panel-border-width: 1px;
+--process-border-width: 1px;
+
+
+//Legend
+--legend-padding: 8px;
+--legend-header-padding: 8px;
+
+}
+
+
+.gocam-viz-legend-container {
+  padding: 0 1.2rem;
+  width: 800px;
+}


### PR DESCRIPTION
Additional changes made by @tmushayahama for the setup of the newer `wc-gocam-viz: 1.0.0` package for #1272.

The deleted attributes such as `show-has-input`, `show-activity`, and `repository` are not used.