### PR TITLE
Fix jbrowse covid

### DIFF
--- a/src/components/orthology/orthologyJBrowseLinkPanel.js
+++ b/src/components/orthology/orthologyJBrowseLinkPanel.js
@@ -15,7 +15,7 @@ const geneLocationIsInvalid = (geneLocation) => {
 
 const OrthologyJBrowseLinkPanel = ({geneLocation, taxonid}) => {
   return (
-    geneLocationIsInvalid(geneLocation) ? null :
+    (geneLocationIsInvalid(geneLocation) || taxonid === 'NCBITaxon:2697049') ? null :
     <div id='orthologyJBrowseLinkPanel'>
         <span>Links to orthology data in JBrowse by filter level: </span>
 	<OrthologyJBrowseLink

--- a/src/constants.js
+++ b/src/constants.js
@@ -409,6 +409,7 @@ export const SPECIES = [
     jBrowseurltemplate: 'tracks/All Genes/{refseq}/trackData.jsonz',
     jBrowsefastaurl: 'https://s3.amazonaws.com/agrjbrowse/fasta/GCF_000001405.40_GRCh38.p14_genomic.fna.gz',
     jBrowsetracks: '_all_genes',
+    jBrowseOrthologyTracks:'',
     suppressFlatten: true,
     vertebrate: false,
     enableSingleCellExpressionAtlasLink: false,


### PR DESCRIPTION
This fixed the pink error box for SARS-CoV-2 and suppresses the jbrowse orthology link panel (the thing that says 'links to jbrowse orthology tracks' at the bottom of the orthology panel) for SARS-CoV-2 since there isn't any tracks like that available.