### PR TITLE
generic-sequence-panel upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4366,9 +4366,9 @@
       "license": "MIT"
     },
     "node_modules/@mui/icons-material": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.4.5.tgz",
-      "integrity": "sha512-4A//t8Nrc+4u4pbVhGarIFU98zpuB5AV9hTNzgXx1ySZJ1tWtx+i/1SbQ8PtGJxWeXlljhwimZJNPQ3x0CiIFw==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.4.6.tgz",
+      "integrity": "sha512-rGJBvIQQbQAlyKYljHQ8wAQS/K2/uYwvemcpygnAmCizmCI4zSF9HQPuiG8Ql4YLZ6V/uKjA3WHIYmF/8sV+pQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0"
@@ -4381,7 +4381,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^6.4.5",
+        "@mui/material": "^6.4.6",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -4406,9 +4406,9 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.3.tgz",
-      "integrity": "sha512-jxHRHh3BqVXE9ABxDm+Tc3wlBooYz/4XPa0+4AI+iF38rV1/+btJmSUgG4shDtSWVs/I97aDn5jBCt6SF2Uq2A==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.6.tgz",
+      "integrity": "sha512-43nZeE1pJF2anGafNydUcYFPtHwAqiBiauRtaMvurdrZI3YrUjHkAu43RBsxef7OFtJMXGiHFvq43kb7lig0sA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -5123,9 +5123,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.27.0.tgz",
-      "integrity": "sha512-GOA+pvSpwL734yijTB8+LHesqPq3o/K6IaCrNoZybNVpe6lgVfvciDwPeP1XOj6JZpA/Lp8Uh3U9znoS8qgwOA==",
+      "version": "4.27.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.27.1.tgz",
+      "integrity": "sha512-wJ+U3yJ9xSrME1PheHh8DnZrgFhjTlvF54mkA0tzTDXYdrEAYXIEAAeWbXx3munYX2Lqj3oDBEDsbsJNxDkwzA==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -6991,9 +6991,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1000.3",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1000.3.tgz",
-      "integrity": "sha512-y0sU603gGWpVTwqDw9MKVHg3e1t49Mvve6t3YDOvjeKY195Vu6dgHlHjW4h8n1vX04r49NKfpoApG60V8sMbdw==",
+      "version": "2.1001.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1001.0.tgz",
+      "integrity": "sha512-Wp6fKNXcxBm+f8U1GkLV4gEgqq1pu5uwyDCMBg7ZB/6CtP+PsD/mPhuKyMULNWucDvYN8oy70XLOkMnxa3NWFw==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
@@ -7006,9 +7006,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.180.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.180.0.tgz",
-      "integrity": "sha512-ncYx3MGcLL397WAg6LOHV8G/5d0FkdoskiUscqFawLWioK75f0M6AIuif9kxrxLBvbMOncOfqhV8wIsCM1fquA==",
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.181.0.tgz",
+      "integrity": "sha512-W95HRgahebHQdXwGTIvJydc33JG4NBIKpzoNFS17pmfX3nauxa7o4YPTJHHjQwv7A5LNQotuF7QilpN5PlQFzg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -8176,9 +8176,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001700",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+      "version": "1.0.30001701",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9244,9 +9244,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.31.0.tgz",
-      "integrity": "sha512-zDGn1K/tfZwEnoGOcHc0H4XazqAAXAuDpcYw9mUnUjATjqljyCNGJv8uEvbvxGaGHaVshxMecyl6oc6uKzRfbw==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.31.1.tgz",
+      "integrity": "sha512-Hx5Mtb1+hnmAKaZZ/7zL1Y5HTFYOjdDswZy/jD+1WINRU8KVi1B7+vlHdsTwY+VCFucTreoyu1RDzQJ9u0d2Hw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -10250,9 +10250,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.104",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.104.tgz",
-      "integrity": "sha512-Us9M2L4cO/zMBqVkJtnj353nQhMju9slHm62NprKTmdF3HH8wYOtNvDFq/JB2+ZRoGLzdvYDiATlMHs98XBM1g==",
+      "version": "1.5.107",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.107.tgz",
+      "integrity": "sha512-dJr1o6yCntRkXElnhsHh1bAV19bo/hKyFf7tCcWgpXbuFIF0Lakjgqv5LRfSDaNzAII8Fnxg2tqgHkgCvxdbxw==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -11422,9 +11422,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -12037,9 +12037,9 @@
       }
     },
     "node_modules/generic-sequence-panel": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/generic-sequence-panel/-/generic-sequence-panel-1.6.1.tgz",
-      "integrity": "sha512-6JTfKPz0TTruK9Zj6ZcIS14SWuXyjMeBdUioqohi4heo8I4ZcJrNlkccAMZC0PqTP22CVE6avDtm5Vj7f9OBDg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/generic-sequence-panel/-/generic-sequence-panel-1.7.0.tgz",
+      "integrity": "sha512-knh4aQqXX58FHxTdPwEs7XgqI5rnWmCXy0JrAk28eHQLcSB1BOlSzUSYxEe/UAfB/i1TBsV5SWzeGqyFsqSyGA==",
       "license": "MIT",
       "dependencies": {
         "@gmod/indexedfasta": "^3.0.1",
@@ -12050,46 +12050,13 @@
         "mobx": "^6.13.5",
         "mobx-react": "^9.2.0",
         "mobx-state-tree": "^5.1.8",
-        "reactstrap": "^9.2.3",
+        "react-bootstrap": "^2.10.9",
         "rxjs": "^7.8.0",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17.0.1 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.1 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/generic-sequence-panel/node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/generic-sequence-panel/node_modules/reactstrap": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
-      "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@popperjs/core": "^2.6.0",
-        "classnames": "^2.2.3",
-        "prop-types": "^15.5.8",
-        "react-popper": "^2.2.4",
-        "react-transition-group": "^4.4.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/gensync": {
@@ -20825,9 +20792,9 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -22687,9 +22654,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
-      "integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.12.tgz",
+      "integrity": "sha512-jDLYqo7oF8tJIttjXO6jBY5Hk8p3A8W4ttih7cCEq64fQFWmgJ4VqAQjKr7WwIDlmXKEc6QeoRb5ecjZ+2afcg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -23224,9 +23191,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
Bumped all versions in the lockfile to include generic-sequence-panel `1.7.0`, which replaced usage of `reactstrap` with `bootstrap-react` to enable react 19 support (once all other dependencies have been updated to versions supporting react 19 as well).