### PR TITLE
Switch xyz to GO API for geneontology/go-fastapi#114

### DIFF
--- a/src/components/pathway/pathwayWidget.js
+++ b/src/components/pathway/pathwayWidget.js
@@ -149,20 +149,10 @@ class PathwayWidget extends Component {
           geneId = uniprotIds[0];
         }
       }
-      let iri = curieUtils.getIri(geneId);
       this.setState({ "cutils" : curieUtils})
-      return iri;
-
-    }).then(iri => {
-
-      // This should be a temporary fix, but MGI:MGI: has been a long standing issue that need to be fixed
-      // at the server level but also at the dbxrefs.yaml & equivalent e.g. http://identifiers.org/mgi/MGI:88177
-      if(iri.includes("mgi") && !iri.includes("MGI:")) {
-        iri = iri.replace("/mgi/", "/mgi/MGI:");
-      }
 
       // new query parameter to indicate we want models with at least 2 causal MFs
-      let gocams = "https://api.geneontology.xyz/gp/" + encodeURIComponent(iri) + "/models?causalmf=2"
+      let gocams = "https://api.geneontology.org/api/gp/" + geneId + "/models?causalmf=2"
       fetch(gocams)
       .then(data => {
         return data.json();


### PR DESCRIPTION
This is for geneontology/go-fastapi#114. See also https://github.com/geneontology/api-gorest-2023/issues/3#issuecomment-2777095671.

This change should result in same behavior/results that `.xyz` is delivering but, in the future, we plan on maintaining only the GO API and deprecating the `api.geneontology.xyz` endpoint. @vanaukenk and @kltm can fill in more details if needed.

I tested this change by running a local server instance and confirming models are returned on gene page pathway widget GO-CAM tab for genes [Ern1 Mmu](https://www.alliancegenome.org/gene/MGI:1930134) and [dkf-2 Cel](https://www.alliancegenome.org/gene/WB:WBGene00012019).
![image](https://github.com/user-attachments/assets/79992dbe-99ad-4d55-8082-21f4f9dcde29)