### PR TITLE
Port missing features from test branch to stage

### DIFF
--- a/src/containers/alzheimersPage/DiseasePortalSection.jsx
+++ b/src/containers/alzheimersPage/DiseasePortalSection.jsx
@@ -3,9 +3,15 @@ import style from './style.module.scss';
 // import SearchBarComponent from '../layout/searchBar';
 // import SearchExample from './SearchExample';
 import EntityButton from './EntityButton.jsx';
+import { useEntityButtonCounts } from './useEntityButtonCounts.jsx';
 // import {Link} from 'react-router-dom';
 
 const DiseasePortalSection = () => {
+  const url = '/api/disease/DOID:10652/';
+  const geneCount = useEntityButtonCounts(url + 'genes', 5000);
+  const modelCount = useEntityButtonCounts(url + 'models', 5000);
+  const alleleCount = useEntityButtonCounts(url + 'alleles', 5000);
+
   return (
     <section className={`${style.section} ${style.searchBackground} shadow`}>
       <div className={style.contentContainer}>
@@ -28,13 +34,11 @@ const DiseasePortalSection = () => {
             to="/disease/DOID:10652#associated-models"
             tooltip="View all associated models"
           >
-            213
-            <br />
+            <div>{modelCount ?? '213'}</div>
             Models
           </EntityButton>
           <EntityButton id="entity-genes" to="/disease/DOID:10652#associated-genes" tooltip="View all associated genes">
-            2,939
-            <br />
+            <div>{geneCount ?? '2,939'}</div>
             Genes
           </EntityButton>
           <EntityButton
@@ -42,8 +46,7 @@ const DiseasePortalSection = () => {
             to="/disease/DOID:10652#associated-alleles"
             tooltip="View all associated alleles"
           >
-            268
-            <br />
+            <div>{alleleCount ?? '268'}</div>
             Alleles
           </EntityButton>
           <EntityButton id="entity-publications" to="/disease-portal/alzheimers-disease">

--- a/src/containers/alzheimersPage/ResourcesSection.jsx
+++ b/src/containers/alzheimersPage/ResourcesSection.jsx
@@ -21,7 +21,7 @@ const ResourcesSection = () => {
       <div className={style.contentContainer}>
         <div className="row">
           <div className="col-lg-12">
-            <h2>Community Resoures</h2>
+            <h2>Community Resources</h2>
             <div>
               {resourceLinks.map((resourceLink, index) => {
                 return (

--- a/src/containers/alzheimersPage/ResourcesSection.jsx
+++ b/src/containers/alzheimersPage/ResourcesSection.jsx
@@ -11,6 +11,7 @@ const resourceLinks = [
   },
   { title: "Alzheimer's Foundation of America", url: 'https://alzfdn.org/' },
   { title: 'National Institute on Aging', url: 'https://www.nia.nih.gov/' },
+  { title: 'NIAGADS', url: 'https://www.niagads.org/' },
   { title: 'OMIM', url: 'https://omim.org/entry/104300' },
 ];
 

--- a/src/containers/alzheimersPage/useEntityButtonCounts.jsx
+++ b/src/containers/alzheimersPage/useEntityButtonCounts.jsx
@@ -1,0 +1,56 @@
+import {useEffect, useState} from 'react';
+
+export function useEntityButtonCounts(url, limit) {
+  const [counts, setCounts] = useState();
+
+  useEffect(() => {
+    if (!limit || limit <= 0) return;
+
+    let cancelled = false;
+
+    async function fetchCount() {
+      try {
+        const response = await fetch(`${url}?limit=${limit}`);
+        if (!response.ok) throw new Error(response.status);
+        const json = await response.json();
+        if (!cancelled) {
+          setCounts(filterData(json.results));
+        }
+      } catch {
+        if (!cancelled) {
+          setCounts(undefined);
+        }
+      }
+    }
+
+    fetchCount();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url, limit]);
+
+  function filterData(items) {
+    const set = new Set();
+    for (const each of items) {
+      const subject = each.subject;
+      const symbol = subject.geneSymbol?.displayText
+        ? subject.geneSymbol?.displayText
+          : subject.name
+            ? subject.name
+              : subject.alleleSymbol?.displayText
+      const type = each.generatedRelationString;
+
+      if (symbol && !set.has(symbol) && !isWrongType(type)) {
+        set.add(symbol);
+      }
+    }
+
+    return set.size;
+    function isWrongType(type) {
+      return type === 'is_not_implicated_in' || type === 'does_not_model'
+    }
+  }
+
+  return counts;
+}

--- a/src/containers/alzheimersPage/useEntityButtonCounts.jsx
+++ b/src/containers/alzheimersPage/useEntityButtonCounts.jsx
@@ -11,7 +11,7 @@ export function useEntityButtonCounts(url, limit) {
     async function fetchCount() {
       try {
         const response = await fetch(`${url}?limit=${limit}`);
-        if (!response.ok) throw new Error(response.status);
+        if (!response.ok) throw new Error(`Failed to fetch entity counts from ${url}: HTTP ${response.status}`);
         const json = await response.json();
         if (!cancelled) {
           setCounts(filterData(json.results));
@@ -31,6 +31,10 @@ export function useEntityButtonCounts(url, limit) {
   }, [url, limit]);
 
   function filterData(items) {
+    const isWrongType = (type) => {
+      return type === 'is_not_implicated_in' || type === 'does_not_model';
+    };
+
     const set = new Set();
     for (const each of items) {
       const subject = each.subject;
@@ -47,9 +51,6 @@ export function useEntityButtonCounts(url, limit) {
     }
 
     return set.size;
-    function isWrongType(type) {
-      return type === 'is_not_implicated_in' || type === 'does_not_model';
-    }
   }
 
   return counts;

--- a/src/containers/alzheimersPage/useEntityButtonCounts.jsx
+++ b/src/containers/alzheimersPage/useEntityButtonCounts.jsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from 'react';
 
 export function useEntityButtonCounts(url, limit) {
   const [counts, setCounts] = useState();
@@ -36,9 +36,9 @@ export function useEntityButtonCounts(url, limit) {
       const subject = each.subject;
       const symbol = subject.geneSymbol?.displayText
         ? subject.geneSymbol?.displayText
-          : subject.name
-            ? subject.name
-              : subject.alleleSymbol?.displayText
+        : subject.name
+          ? subject.name
+          : subject.alleleSymbol?.displayText;
       const type = each.generatedRelationString;
 
       if (symbol && !set.has(symbol) && !isWrongType(type)) {
@@ -48,7 +48,7 @@ export function useEntityButtonCounts(url, limit) {
 
     return set.size;
     function isWrongType(type) {
-      return type === 'is_not_implicated_in' || type === 'does_not_model'
+      return type === 'is_not_implicated_in' || type === 'does_not_model';
     }
   }
 


### PR DESCRIPTION
## Summary
This PR ports user-facing features that were completed in the test branch (June 2025) but never made it to stage due to branch divergence after the major refactoring.

## Features Ported
- **KANBAN-428**: Display model counts
- **KANBAN-429**: Display gene counts  
- **KANBAN-430**: Display allele counts
- **KANBAN-655**: Add NIAGADS URL to Alzheimer's Disease landing page

## Changes
✅ Created `useEntityButtonCounts.jsx` hook for fetching entity counts dynamically
✅ Updated `DiseasePortalSection.jsx` to display live counts instead of hardcoded values
✅ Added NIAGADS resource URL to `ResourcesSection.jsx`
✅ Fixed typo: "Community Resoures" → "Community Resources"

## Context
These features were stuck in the test branch after Seth's major refactoring that renamed all `.js` files to `.jsx`. Due to the extensive file changes (553 files), a regular merge wasn't feasible, so these features were manually ported over.

## Testing Checklist
- [ ] Verify entity counts display correctly on Alzheimer's Disease portal
- [ ] Verify counts fall back to static values if API fails
- [ ] Verify NIAGADS link appears in resources section
- [ ] Ensure no regression in existing functionality

## Implementation Details
The dynamic counts fetch from:
- Gene counts: `/api/disease/DOID:10652/genes`
- Model counts: `/api/disease/DOID:10652/models`  
- Allele counts: `/api/disease/DOID:10652/alleles`

Fallback values (213 models, 2,939 genes, 268 alleles) display if API calls fail, maintaining the current user experience.

## Files Changed
- `src/containers/alzheimersPage/useEntityButtonCounts.jsx` (new file - 56 lines)
- `src/containers/alzheimersPage/DiseasePortalSection.jsx` (modified)
- `src/containers/alzheimersPage/ResourcesSection.jsx` (modified)
