### PR TITLE
Fix Amplify production build by installing TypeScript globally

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -8,6 +8,7 @@ frontend:
         - nvm use
         - node -v
         - npm -v
+        - npm install -g typescript
         - rm -f package-lock.json
         - rm -rf node_modules
         - npm install


### PR DESCRIPTION
The production Amplify app has NODE_ENV=production which causes npm to skip devDependencies in Node.js 22/npm 10. Since TypeScript is a devDependency, it's not installed and the build fails with 'tsc: command not found'.

This fix explicitly installs TypeScript globally during the build phase, ensuring tsc is available regardless of NODE_ENV setting.

Fixes the build error:
sh: line 1: tsc: command not found
!!! Build failed
!!! Error: Command failed with exit code 127