### PR TITLE
Fix Amplify production build with NODE_ENV=production

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -8,10 +8,10 @@ frontend:
         - nvm use
         - node -v
         - npm -v
-        - npm install -g typescript
         - rm -f package-lock.json
         - rm -rf node_modules
         - npm install
+        - npm install --no-save typescript vite @vitejs/plugin-react
     build:
       commands:
         - npm run build


### PR DESCRIPTION
When NODE_ENV=production, npm skips devDependencies which includes TypeScript, Vite, and other build tools. This causes the build to fail.

This fix uses 'npm install --no-save' to install the minimal required build dependencies locally without modifying package.json, allowing the build to complete while maintaining NODE_ENV=production for runtime.

Required packages:
- typescript (for tsc compilation)
- vite (build tool)
- @vitejs/plugin-react (vite plugin for React)

These are installed after the main npm install to ensure they're available for the build phase.