### PR TITLE
SCRUM-5854: filter to is_a-only ancestors for gene vs genome feature

### DIFF
--- a/src/containers/genePage/index.jsx
+++ b/src/containers/genePage/index.jsx
@@ -118,8 +118,7 @@ const GenePage = () => {
   const { speciesName, taxonId, geneSymbolText, dataProviderAbbr } = extractGeneFields(gene);
 
   const ancestorRelTypes = gene.geneType?.ancestors?.['SO:0000704'];
-  const isGeneType =
-    gene.geneType?.curie === 'SO:0000704' || (ancestorRelTypes?.length === 1 && ancestorRelTypes[0] === 'is_a');
+  const isGeneType = gene.geneType?.curie === 'SO:0000704' || ancestorRelTypes?.includes('is_a');
   const pageCategory = isGeneType ? GENE_CATEGORY : GENOME_FEATURE_CATEGORY;
 
   // Normalize genome locations

--- a/src/containers/genePage/index.jsx
+++ b/src/containers/genePage/index.jsx
@@ -110,7 +110,9 @@ const GenePage = () => {
   const gene = data.gene;
   const { speciesName, taxonId, geneSymbolText, dataProviderAbbr } = extractGeneFields(gene);
 
-  const isGeneType = gene.geneType?.curie === 'SO:0000704' || gene.geneType?.ancestors?.includes('SO:0000704');
+  const ancestorRelTypes = gene.geneType?.ancestors?.['SO:0000704'];
+  const isGeneType =
+    gene.geneType?.curie === 'SO:0000704' || (ancestorRelTypes?.length === 1 && ancestorRelTypes[0] === 'is_a');
   const pageCategory = isGeneType ? GENE_CATEGORY : GENOME_FEATURE_CATEGORY;
 
   // Normalize genome locations


### PR DESCRIPTION
## Summary
- Filter SO term ancestor check to only consider `is_a` relationships when classifying gene pages as "GENE" vs "GENOME FEATURE"
- Fixes three SO terms that were incorrectly showing as "GENE" because their path to SO:0000704 includes `part_of` relationships:
  - `promoter` (SO:0000167)
  - `CTCF_binding_site` (SO:0001974)
  - `intein_encoding_region` (SO:0002026)

Depends on curation PR: https://github.com/alliance-genome/agr_curation/pull/2624

## Test plan
- [ ] Navigate to [MGI:6857676](https://stage.alliancegenome.org/gene/MGI:6857676) (promoter) — should show "GENOME FEATURE"
- [ ] Navigate to [MGI:7021344](https://stage.alliancegenome.org/gene/MGI:7021344) (CTCF_binding_site) — should show "GENOME FEATURE"
- [ ] Navigate to [SGD:S000029636](https://stage.alliancegenome.org/gene/SGD:S000029636) (intein_encoding_region) — should show "GENOME FEATURE"
- [ ] Navigate to a regular gene page — should still show "GENE"

🤖 Generated with [Claude Code](https://claude.com/claude-code)