### PR TITLE
SCRUM-5854: require is_a-only ancestor relationship for gene type cla…

### DIFF
--- a/src/containers/genePage/index.jsx
+++ b/src/containers/genePage/index.jsx
@@ -96,7 +96,8 @@ const SECTIONS = [
 ];
 
 const GenePageCategoryLabel = ({ gene }) => {
-  const isGeneType = gene.geneType?.curie === 'SO:0000704' || !!gene.geneType?.ancestors?.['SO:0000704'];
+  const ancestorRels = gene.geneType?.ancestors?.['SO:0000704'];
+  const isGeneType = gene.geneType?.curie === 'SO:0000704' || (ancestorRels?.length === 1 && ancestorRels[0] === 'is_a');
   const pageLabel = isGeneType ? GENE_CATEGORY : 'genome_feature';
   return <PageCategoryLabel category={pageLabel} />;
 };
@@ -118,7 +119,7 @@ const GenePage = () => {
   const { speciesName, taxonId, geneSymbolText, dataProviderAbbr } = extractGeneFields(gene);
 
   const ancestorRelTypes = gene.geneType?.ancestors?.['SO:0000704'];
-  const isGeneType = gene.geneType?.curie === 'SO:0000704' || ancestorRelTypes?.includes('is_a');
+  const isGeneType = gene.geneType?.curie === 'SO:0000704' || (ancestorRelTypes?.length === 1 && ancestorRelTypes[0] === 'is_a');
   const pageCategory = isGeneType ? GENE_CATEGORY : GENOME_FEATURE_CATEGORY;
 
   // Normalize genome locations

--- a/src/containers/genePage/index.jsx
+++ b/src/containers/genePage/index.jsx
@@ -97,7 +97,8 @@ const SECTIONS = [
 
 const GenePageCategoryLabel = ({ gene }) => {
   const ancestorRels = gene.geneType?.ancestors?.['SO:0000704'];
-  const isGeneType = gene.geneType?.curie === 'SO:0000704' || (ancestorRels?.length === 1 && ancestorRels[0] === 'is_a');
+  const isGeneType =
+    gene.geneType?.curie === 'SO:0000704' || (ancestorRels?.length === 1 && ancestorRels[0] === 'is_a');
   const pageLabel = isGeneType ? GENE_CATEGORY : 'genome_feature';
   return <PageCategoryLabel category={pageLabel} />;
 };
@@ -119,7 +120,8 @@ const GenePage = () => {
   const { speciesName, taxonId, geneSymbolText, dataProviderAbbr } = extractGeneFields(gene);
 
   const ancestorRelTypes = gene.geneType?.ancestors?.['SO:0000704'];
-  const isGeneType = gene.geneType?.curie === 'SO:0000704' || (ancestorRelTypes?.length === 1 && ancestorRelTypes[0] === 'is_a');
+  const isGeneType =
+    gene.geneType?.curie === 'SO:0000704' || (ancestorRelTypes?.length === 1 && ancestorRelTypes[0] === 'is_a');
   const pageCategory = isGeneType ? GENE_CATEGORY : GENOME_FEATURE_CATEGORY;
 
   // Normalize genome locations


### PR DESCRIPTION
…ssification

Ensure SO:0000704 ancestor must have only "is_a" relationship (not "part_of") to classify as GENE. Fixes promoter, CTCF_binding_site, and intein_encoding_region incorrectly showing as "GENE" instead of "GENOME FEATURE".