### PR TITLE
KANBAN-1098-scottcain-remove-red-error-box

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "custom-event-polyfill": "^1.0.7",
     "d3-selection": "^3.0.0",
     "events": "^3.3.0",
-    "generic-sequence-panel": "^1.7.0",
+    "generic-sequence-panel": "^1.8.0",
     "genomefeatures": "github:alliance-genome/genomefeatures#a49427156f449ea11319ac2bd3069751d25ba4e5",
     "html-react-parser": "^5.2.3",
     "immutable": "^5.1.2",


### PR DESCRIPTION
The actual removing of the red box happens in the generic-sequence-panel that I just updated.