### PR TITLE
SCRUM-5924 Fix missing amino acid variant for synonymous variants in …

### DIFF
--- a/src/containers/allelePage/VariantToTranscriptTable.jsx
+++ b/src/containers/allelePage/VariantToTranscriptTable.jsx
@@ -208,7 +208,7 @@ const VariantToTranscriptTable = ({ variant, variantHgvs, variantType }) => {
         {
           molecularConsequences: (item.vepConsequences || []).map((c) => c.name),
           aminoAcidReference: item.aminoAcidReference || '',
-          aminoAcidVariation: item.aminoAcidVariant || '',
+          aminoAcidVariation: item.aminoAcidVariant || item.aminoAcidReference || '',
           proteinStartPosition: item.calculatedProteinStart,
           proteinEndPosition: item.calculatedProteinEnd,
           codonReference: item.codonReference || '',


### PR DESCRIPTION
…molecular consequences widget

Fall back to aminoAcidReference when aminoAcidVariant is absent from the API response, ensuring the codon change section renders correctly for synonymous variants.