### PR TITLE
KANBAN-1182: Update agr_ui genomefeatures dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "custom-event-polyfill": "^1.0.7",
         "d3-selection": "^3.0.0",
         "events": "^3.3.0",
-        "generic-sequence-panel": "^1.7.0",
-        "genomefeatures": "github:alliance-genome/genomefeatures#a49427156f449ea11319ac2bd3069751d25ba4e5",
+        "generic-sequence-panel": "^1.8.0",
+        "genomefeatures": "github:alliance-genome/genomefeatures#37dc2289d9193aa39823a58ee221b3c14a6d3185",
         "html-react-parser": "^5.2.3",
         "immutable": "^5.1.2",
         "js-yaml": "^4.1.0",
@@ -8964,9 +8964,9 @@
       }
     },
     "node_modules/generic-sequence-panel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/generic-sequence-panel/-/generic-sequence-panel-1.7.0.tgz",
-      "integrity": "sha512-knh4aQqXX58FHxTdPwEs7XgqI5rnWmCXy0JrAk28eHQLcSB1BOlSzUSYxEe/UAfB/i1TBsV5SWzeGqyFsqSyGA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/generic-sequence-panel/-/generic-sequence-panel-1.8.0.tgz",
+      "integrity": "sha512-ZN2zL10DdH8GuQ7H9UNJaAvQcka5NT63gsXb6AeflmKDGerYXLqxKrJplgIv1ZpOQrnOVeuy9WZoQrx3r6yetQ==",
       "license": "MIT",
       "dependencies": {
         "@gmod/indexedfasta": "^3.0.1",
@@ -8988,8 +8988,8 @@
     },
     "node_modules/genomefeatures": {
       "version": "1.0.5",
-      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#a49427156f449ea11319ac2bd3069751d25ba4e5",
-      "integrity": "sha512-LZsgHUM5MN5O/rmchhZWtA0Pw5xa026kvpPvmbzhO4PZ2SWL3eqMqL8K/w1zi+hF0ULgP7qVQamvZnE38jtTuA==",
+      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#37dc2289d9193aa39823a58ee221b3c14a6d3185",
+      "integrity": "sha512-YQHeQDqCTmainQN89NLR/yTG4N++NbBMek95kmtmIA+A5X4TMkv8c79UsEI3E46nSaQV3UpTVO/Wio/b5Pmtbw==",
       "license": "MIT",
       "dependencies": {
         "@gmod/nclist": "^3.0.0",
@@ -14491,24 +14491,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "d3-selection": "^3.0.0",
     "events": "^3.3.0",
     "generic-sequence-panel": "^1.8.0",
-    "genomefeatures": "github:alliance-genome/genomefeatures#a49427156f449ea11319ac2bd3069751d25ba4e5",
+    "genomefeatures": "github:alliance-genome/genomefeatures#37dc2289d9193aa39823a58ee221b3c14a6d3185",
     "html-react-parser": "^5.2.3",
     "immutable": "^5.1.2",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Summary
The genomefeatures fix for the missing human NF1 gene model has already been merged, but agr_ui was still pinned to an older GitHub commit and would not install it automatically. This update moves agr_ui to the merged genomefeatures revision and refreshes the lockfile so deployments and local installs pick up the fix consistently.

## Changes
- Updated the `genomefeatures` dependency in `package.json` to point at the merged commit `37dc2289d9193aa39823a58ee221b3c14a6d3185`.
- Refreshed `package-lock.json` so it resolves the new `genomefeatures` commit.
- Refreshed the lockfile entry for `generic-sequence-panel` to `1.8.0`, matching the existing `package.json` declaration and fixing the prior `npm ci` sync error.

## Testing
- Ran `npm install` successfully in `alliance-genome/agr_ui` to regenerate the lockfile.
- Ran `npx jest src/containers/genePage/tests/genomefeatures-import.test.js src/containers/genePage/tests/genomeFeatureWrapper.test.jsx --runInBand` successfully.
