### PR TITLE
SCRUM-5957: use dataProviderCrossReference for gene page side panel link

### DIFF
--- a/src/containers/genePage/index.jsx
+++ b/src/containers/genePage/index.jsx
@@ -124,7 +124,16 @@ const GenePage = () => {
   const genomeLocation = getSingleGenomeLocation(genomeLocations);
 
   // Build cross-reference map from flat array
-  const crossReferenceMap = buildCrossReferenceMap(gene.crossReferences, gene.primaryExternalId);
+  const crossReferenceMap = buildCrossReferenceMap(gene.crossReferences);
+
+  let primaryCrossReference;
+  if (taxonId === 'NCBITaxon:9606') {
+    primaryCrossReference = gene.crossReferences?.find(
+      (ref) => ref.resourceDescriptorPage?.name === 'default' && ref.referencedCurie === gene.primaryExternalId
+    );
+  } else {
+    primaryCrossReference = gene.dataProviderCrossReference;
+  }
 
   // manufacture a single cell atlas cross reference since this isn't stored
   // in the database (see AGR-1406)
@@ -156,7 +165,9 @@ const GenePage = () => {
           truncateName
         >
           <SpeciesName>{speciesName}</SpeciesName>
-          <DataSourceLinkCuration reference={crossReferenceMap.primary} />
+          <DataSourceLinkCuration reference={primaryCrossReference}>
+            {primaryCrossReference?.referencedCurie}
+          </DataSourceLinkCuration>
         </PageNavEntity>
       </PageNav>
       <PageData>

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -205,7 +205,7 @@ export function buildUrlFromTemplate(crossReference) {
 
 // Fix up species name with yeast correction
 
-export function buildCrossReferenceMap(crossReferences, primaryExternalId) {
+export function buildCrossReferenceMap(crossReferences) {
   if (!crossReferences) return {};
 
   const findByPage = (pageName) => crossReferences.find((ref) => ref.resourceDescriptorPage?.name === pageName);
@@ -218,16 +218,6 @@ export function buildCrossReferenceMap(crossReferences, primaryExternalId) {
 
   const map = {};
   map.primary = addUrl(findByPage('gene'));
-
-  // Fallback for species (like human) that don't have a "gene" page entry:
-  // use the "default" entry matching the gene's primary ID
-  let primaryFallbackRef;
-  if (!map.primary && primaryExternalId) {
-    primaryFallbackRef = crossReferences.find(
-      (ref) => ref.resourceDescriptorPage?.name === 'default' && ref.referencedCurie === primaryExternalId
-    );
-    map.primary = addUrl(primaryFallbackRef);
-  }
 
   const pantherRefs = findByPrefix('PANTHER:');
   map.panther = pantherRefs.length > 0 ? addUrl(pantherRefs[0]) : undefined;
@@ -249,14 +239,9 @@ export function buildCrossReferenceMap(crossReferences, primaryExternalId) {
       findByPage('gene/MODinteractions_molecular')
   );
 
-  // "other" = "default" page entries excluding PANTHER and the primary fallback
+  // "other" = "default" page entries excluding PANTHER
   map.other = crossReferences
-    .filter(
-      (ref) =>
-        ref.resourceDescriptorPage?.name === 'default' &&
-        !ref.referencedCurie?.startsWith('PANTHER:') &&
-        ref !== primaryFallbackRef
-    )
+    .filter((ref) => ref.resourceDescriptorPage?.name === 'default' && !ref.referencedCurie?.startsWith('PANTHER:'))
     .map(addUrl);
 
   return map;


### PR DESCRIPTION
For human genes, fall back to the HGNC cross reference since the data provider is RGD.