### PR TITLE
KANBAN-1182: fix variant sequence viewer gene targeting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "custom-event-polyfill": "^1.0.7",
         "d3-selection": "^3.0.0",
         "events": "^3.3.0",
-        "generic-sequence-panel": "^1.7.0",
-        "genomefeatures": "github:alliance-genome/genomefeatures#a49427156f449ea11319ac2bd3069751d25ba4e5",
+        "generic-sequence-panel": "^1.8.0",
+        "genomefeatures": "github:alliance-genome/genomefeatures#37dc2289d9193aa39823a58ee221b3c14a6d3185",
         "html-react-parser": "^5.2.3",
         "immutable": "^5.1.2",
         "js-yaml": "^4.1.0",
@@ -8964,9 +8964,9 @@
       }
     },
     "node_modules/generic-sequence-panel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/generic-sequence-panel/-/generic-sequence-panel-1.7.0.tgz",
-      "integrity": "sha512-knh4aQqXX58FHxTdPwEs7XgqI5rnWmCXy0JrAk28eHQLcSB1BOlSzUSYxEe/UAfB/i1TBsV5SWzeGqyFsqSyGA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/generic-sequence-panel/-/generic-sequence-panel-1.8.0.tgz",
+      "integrity": "sha512-ZN2zL10DdH8GuQ7H9UNJaAvQcka5NT63gsXb6AeflmKDGerYXLqxKrJplgIv1ZpOQrnOVeuy9WZoQrx3r6yetQ==",
       "license": "MIT",
       "dependencies": {
         "@gmod/indexedfasta": "^3.0.1",
@@ -8988,8 +8988,8 @@
     },
     "node_modules/genomefeatures": {
       "version": "1.0.5",
-      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#a49427156f449ea11319ac2bd3069751d25ba4e5",
-      "integrity": "sha512-LZsgHUM5MN5O/rmchhZWtA0Pw5xa026kvpPvmbzhO4PZ2SWL3eqMqL8K/w1zi+hF0ULgP7qVQamvZnE38jtTuA==",
+      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#37dc2289d9193aa39823a58ee221b3c14a6d3185",
+      "integrity": "sha512-YQHeQDqCTmainQN89NLR/yTG4N++NbBMek95kmtmIA+A5X4TMkv8c79UsEI3E46nSaQV3UpTVO/Wio/b5Pmtbw==",
       "license": "MIT",
       "dependencies": {
         "@gmod/nclist": "^3.0.0",
@@ -14491,24 +14491,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "d3-selection": "^3.0.0",
     "events": "^3.3.0",
     "generic-sequence-panel": "^1.8.0",
-    "genomefeatures": "github:alliance-genome/genomefeatures#a49427156f449ea11319ac2bd3069751d25ba4e5",
+    "genomefeatures": "github:alliance-genome/genomefeatures#37dc2289d9193aa39823a58ee221b3c14a6d3185",
     "html-react-parser": "^5.2.3",
     "immutable": "^5.1.2",
     "js-yaml": "^4.1.0",

--- a/src/containers/allelePage/VariantSequenceView.jsx
+++ b/src/containers/allelePage/VariantSequenceView.jsx
@@ -3,13 +3,33 @@ import PropTypes from 'prop-types';
 import GenomeFeatureWrapper from '../genePage/genomeFeatureWrapper.jsx';
 import getVariantGenomeLocation from './getVariantGenomeLocation';
 
-const VariantSequenceView = ({ variant: variantData }) => {
-  const genomeLocation = getVariantGenomeLocation(variantData);
+function getTargetGene(variantData, cvgla) {
+  return cvgla?.overlapGenes?.[0] || variantData?.gene || null;
+}
 
+function getTargetGeneLocation(targetGene) {
+  const geneLocationAssociation = targetGene?.geneGenomicLocationAssociations?.[0];
+  if (geneLocationAssociation) {
+    return {
+      chromosome: geneLocationAssociation.geneGenomicLocationAssociationObject?.name,
+      start: geneLocationAssociation.start,
+      end: geneLocationAssociation.end,
+      strand: geneLocationAssociation.strand,
+      assembly: targetGene?.taxon?.species?.assembly_curie,
+    };
+  }
+
+  return targetGene?.genomeLocations?.[0] || null;
+}
+
+const VariantSequenceView = ({ variant: variantData }) => {
   // Build location from new API data structure
   const variant = variantData?.variants && variantData.variants[0];
   const cvgla = variant?.curatedVariantGenomicLocations && variant.curatedVariantGenomicLocations[0];
   const variantLocationObj = cvgla?.variantGenomicLocationAssociationObject;
+  const targetGene = getTargetGene(variantData, cvgla);
+  const targetGeneLocation = getTargetGeneLocation(targetGene);
+  const genomeLocation = targetGeneLocation || getVariantGenomeLocation(variantData);
 
   const location = {
     chromosome: variantLocationObj?.name,
@@ -17,11 +37,16 @@ const VariantSequenceView = ({ variant: variantData }) => {
     end: cvgla?.end,
   };
 
-  let htpVariant = `${location.chromosome}:${location.start}`;
+  if (!genomeLocation?.chromosome || location.start == null || location.end == null) {
+    return null;
+  }
+
+  const htpVariant = `${location.chromosome}:${location.start}`;
   const fmin = Math.min(genomeLocation.start, location.start);
   const fmax = Math.max(genomeLocation.end, location.end);
-  // Extract species from new data structure
-  const species = variant?.taxon;
+  const species = variant?.taxon?.curie || targetGene?.taxon?.curie;
+  const targetGeneId = targetGene?.curie || targetGene?.primaryExternalId || targetGene?.modEntityId;
+  const targetGeneSymbol = targetGene?.geneSymbol?.displayText || targetGene?.symbol;
 
   return (
     <GenomeFeatureWrapper
@@ -31,13 +56,13 @@ const VariantSequenceView = ({ variant: variantData }) => {
       displayType="ISOFORM"
       fmax={fmax}
       fmin={fmin}
-      geneSymbol={variantData.gene?.symbol}
+      geneSymbol={targetGeneSymbol}
       genomeLocationList={[genomeLocation]}
       height="200px"
       id="genome-feature-location-id"
       htpVariant={htpVariant}
-      primaryId={variantData.id || variant?.id}
-      species={species?.curie}
+      primaryId={targetGeneId || variantData.id || variant?.id}
+      species={species}
       strand={genomeLocation.strand}
       synonyms={variantData.synonyms}
       visibleVariants={[variantData.id || variant?.id]}

--- a/src/containers/allelePage/VariantSequenceView.test.jsx
+++ b/src/containers/allelePage/VariantSequenceView.test.jsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VariantSequenceView from './VariantSequenceView.jsx';
+
+const mockGenomeFeatureWrapper = jest.fn(() => <div data-testid="genome-feature-wrapper" />);
+
+jest.mock('../genePage/genomeFeatureWrapper.jsx', () => (props) => mockGenomeFeatureWrapper(props));
+
+describe('VariantSequenceView', () => {
+  beforeEach(() => {
+    mockGenomeFeatureWrapper.mockClear();
+  });
+
+  test('passes overlapping gene metadata to GenomeFeatureWrapper', () => {
+    const variantData = {
+      id: 'NC_003279.8:g.10765226C>T',
+      synonyms: ['variant-synonym'],
+      variants: [
+        {
+          id: 'VAR:123',
+          taxon: {
+            curie: 'NCBITaxon:9606',
+          },
+          curatedVariantGenomicLocations: [
+            {
+              start: 10765226,
+              end: 10765226,
+              overlapGenes: [
+                {
+                  curie: 'HGNC:7765',
+                  geneSymbol: {
+                    displayText: 'NF1',
+                  },
+                  geneGenomicLocationAssociations: [
+                    {
+                      start: 31094927,
+                      end: 31382116,
+                      strand: '-',
+                      geneGenomicLocationAssociationObject: {
+                        name: '17',
+                      },
+                    },
+                  ],
+                  taxon: {
+                    species: {
+                      assembly_curie: 'GRCh38',
+                    },
+                  },
+                },
+              ],
+              variantGenomicLocationAssociationObject: {
+                name: '17',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<VariantSequenceView variant={variantData} />);
+
+    expect(mockGenomeFeatureWrapper).toHaveBeenCalledTimes(1);
+    const props = mockGenomeFeatureWrapper.mock.calls[0][0];
+    expect(props).toEqual(
+      expect.objectContaining({
+        chromosome: '17',
+        geneSymbol: 'NF1',
+        primaryId: 'HGNC:7765',
+        species: 'NCBITaxon:9606',
+        fmin: 10765226,
+        fmax: 31382116,
+        genomeLocationList: [
+          expect.objectContaining({
+            chromosome: '17',
+            start: 31094927,
+            end: 31382116,
+          }),
+        ],
+      })
+    );
+  });
+
+  test('falls back to legacy gene data when overlapGenes are absent', () => {
+    const variantData = {
+      id: 'VAR:456',
+      gene: {
+        modEntityId: 'HGNC:7',
+        symbol: 'A2M',
+        genomeLocations: [
+          {
+            chromosome: '12',
+            start: 9067664,
+            end: 9116229,
+            strand: '+',
+            assembly: 'GRCh38',
+          },
+        ],
+      },
+      variants: [
+        {
+          id: 'VARIANT:456',
+          taxon: {
+            curie: 'NCBITaxon:9606',
+          },
+          curatedVariantGenomicLocations: [
+            {
+              start: 9070000,
+              end: 9070001,
+              variantGenomicLocationAssociationObject: {
+                name: '12',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<VariantSequenceView variant={variantData} />);
+
+    expect(mockGenomeFeatureWrapper).toHaveBeenCalledTimes(1);
+    const props = mockGenomeFeatureWrapper.mock.calls[0][0];
+    expect(props).toEqual(
+      expect.objectContaining({
+        geneSymbol: 'A2M',
+        primaryId: 'HGNC:7',
+        genomeLocationList: [
+          expect.objectContaining({
+            chromosome: '12',
+            start: 9067664,
+            end: 9116229,
+          }),
+        ],
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This updates the variant sequence viewer so human variant pages can target the overlapping gene model instead of filtering isoforms against the variant ID. It also syncs the agr_ui dependency state with the merged genomefeatures fix so stage can install cleanly and render the corrected NF1-style viewer behavior.

## Changes
- Updated the variant sequence viewer to resolve the target gene from the variant payload, prefer that gene's genomic span, and pass the target gene ID and symbol into GenomeFeatureWrapper.
- Added regression tests covering both the overlapGenes payload path and the legacy fallback path for variant sequence viewer props.
- Updated the pinned genomefeatures commit and regenerated package-lock.json so npm ci is back in sync with generic-sequence-panel 1.8.0 and the merged genomefeatures fix.

## Testing
- Ran `npm test -- --runInBand src/containers/allelePage/VariantSequenceView.test.jsx`.
- Ran `npm test -- --runInBand src/containers/genePage/tests/genomeFeatureWrapper.test.jsx`.
- Ran `npm ci --ignore-scripts`.
