### PR TITLE
adding use of NoData when there isn't a refseq

### DIFF
--- a/src/containers/genePage/sequencePanelWrapper.jsx
+++ b/src/containers/genePage/sequencePanelWrapper.jsx
@@ -7,6 +7,8 @@ import { Buffer } from 'buffer';
 
 import { useRelease } from '../../hooks/ReleaseContextProvider.jsx';
 
+import NoData from '../../components/noData.jsx';
+
 window.Buffer = Buffer;
 
 const SequencePanel = ({ species, gene, refseq, start, end }) => {
@@ -30,7 +32,7 @@ const SequencePanel = ({ species, gene, refseq, start, end }) => {
 
   if (!refseq) {
     console.warn('SequencePanel: refseq is undefined, skipping sequence panel rendering');
-    return null;
+    return <NoData />;
   }
 
   if (species === 'NCBITaxon:559292' && !refseq.startsWith('chr') && !refseq.toLowerCase().startsWith('scaffold')) {


### PR DESCRIPTION
Super minor change to use the NoData component when there isn't a refseq