### PR TITLE
SCRUM-5854: Fix gene vs genome feature page type detection

### DIFF
--- a/src/containers/genePage/index.jsx
+++ b/src/containers/genePage/index.jsx
@@ -96,9 +96,12 @@ const SECTIONS = [
 ];
 
 const GenePageCategoryLabel = ({ gene }) => {
-  const ancestorRels = gene.geneType?.ancestors?.['SO:0000704'];
   const isGeneType =
-    gene.geneType?.curie === 'SO:0000704' || (ancestorRels?.length === 1 && ancestorRels[0] === 'is_a');
+    gene.geneType?.curie === 'SO:0000704' ||
+    gene.geneType?.ancestors?.some(entry => {
+      const rels = entry['SO:0000704'];
+      return rels?.length === 1 && rels[0] === 'is_a';
+    });
   const pageLabel = isGeneType ? GENE_CATEGORY : 'genome_feature';
   return <PageCategoryLabel category={pageLabel} />;
 };

--- a/src/containers/genePage/index.jsx
+++ b/src/containers/genePage/index.jsx
@@ -98,7 +98,7 @@ const SECTIONS = [
 const GenePageCategoryLabel = ({ gene }) => {
   const isGeneType =
     gene.geneType?.curie === 'SO:0000704' ||
-    gene.geneType?.ancestors?.some(entry => {
+    gene.geneType?.ancestors?.some((entry) => {
       const rels = entry['SO:0000704'];
       return rels?.length === 1 && rels[0] === 'is_a';
     });


### PR DESCRIPTION
## Summary
- Fixed gene type detection logic in `GenePageCategoryLabel` to correctly handle the `ancestors` data structure (array of objects, not a single object)
- Iterates ancestor entries with `.some()` to find `SO:0000704` where the only relationship is `is_a`, properly distinguishing genes from genome features
- Genes related to `SO:0000704` only via `part_of` (e.g. promoter, CTCF_binding_site, intein_encoding_region) now correctly render as `GENOME_FEATURE`

## Test plan
- [x] FB:FBgn0000153 (protein_coding_gene) → GENE
- [x] MGI:6835783 (TF_binding_site) → GENOME_FEATURE
- [x] MGI:6857676 (promoter) → GENOME_FEATURE
- [x] MGI:7021344 (CTCF_binding_site) → GENOME_FEATURE
- [x] SGD:S000029636 (intein_encoding_region) → GENOME_FEATURE
- [x] MGI:7855984 (enhancer) → GENOME_FEATURE (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)