### PR TITLE
KANBAN-1163: Fix variant sequence viewer gene fallback

### DIFF
--- a/src/containers/allelePage/VariantSequenceView.jsx
+++ b/src/containers/allelePage/VariantSequenceView.jsx
@@ -21,8 +21,7 @@ function getTargetGeneLocation(targetGene, variantLocationObj) {
       start: geneLocationAssociation.start,
       end: geneLocationAssociation.end,
       strand: geneLocationAssociation.strand,
-      assembly:
-        targetGene?.taxon?.species?.assembly_curie || variantLocationObj?.genomeAssembly?.primaryExternalId,
+      assembly: targetGene?.taxon?.species?.assembly_curie || variantLocationObj?.genomeAssembly?.primaryExternalId,
     };
   }
 

--- a/src/containers/allelePage/VariantSequenceView.jsx
+++ b/src/containers/allelePage/VariantSequenceView.jsx
@@ -4,18 +4,25 @@ import GenomeFeatureWrapper from '../genePage/genomeFeatureWrapper.jsx';
 import getVariantGenomeLocation from './getVariantGenomeLocation';
 
 function getTargetGene(variantData, cvgla) {
-  return cvgla?.overlapGenes?.[0] || variantData?.gene || null;
+  const consequenceGene =
+    cvgla?.predictedVariantConsequences
+      ?.flatMap((consequence) => consequence?.variantTranscript?.transcriptGeneAssociations || [])
+      .map((association) => association?.transcriptGeneAssociationObject)
+      .find(Boolean) || null;
+
+  return cvgla?.overlapGenes?.[0] || variantData?.gene || consequenceGene;
 }
 
-function getTargetGeneLocation(targetGene) {
+function getTargetGeneLocation(targetGene, variantLocationObj) {
   const geneLocationAssociation = targetGene?.geneGenomicLocationAssociations?.[0];
   if (geneLocationAssociation) {
     return {
-      chromosome: geneLocationAssociation.geneGenomicLocationAssociationObject?.name,
+      chromosome: geneLocationAssociation.geneGenomicLocationAssociationObject?.name || variantLocationObj?.name,
       start: geneLocationAssociation.start,
       end: geneLocationAssociation.end,
       strand: geneLocationAssociation.strand,
-      assembly: targetGene?.taxon?.species?.assembly_curie,
+      assembly:
+        targetGene?.taxon?.species?.assembly_curie || variantLocationObj?.genomeAssembly?.primaryExternalId,
     };
   }
 
@@ -28,7 +35,7 @@ const VariantSequenceView = ({ variant: variantData }) => {
   const cvgla = variant?.curatedVariantGenomicLocations && variant.curatedVariantGenomicLocations[0];
   const variantLocationObj = cvgla?.variantGenomicLocationAssociationObject;
   const targetGene = getTargetGene(variantData, cvgla);
-  const targetGeneLocation = getTargetGeneLocation(targetGene);
+  const targetGeneLocation = getTargetGeneLocation(targetGene, variantLocationObj);
   const genomeLocation = targetGeneLocation || getVariantGenomeLocation(variantData);
 
   const location = {

--- a/src/containers/allelePage/VariantSequenceView.test.jsx
+++ b/src/containers/allelePage/VariantSequenceView.test.jsx
@@ -134,4 +134,74 @@ describe('VariantSequenceView', () => {
       })
     );
   });
+
+  test('derives target gene metadata from predicted variant consequences when overlap genes are absent', () => {
+    const variantData = {
+      symbol: 'NC_003279.8:g.10765226C>T',
+      variantList: [
+        {
+          taxon: {
+            curie: 'NCBITaxon:6239',
+          },
+          curatedVariantGenomicLocations: [
+            {
+              start: 10765226,
+              end: 10765226,
+              variantGenomicLocationAssociationObject: {
+                name: 'I',
+                genomeAssembly: {
+                  primaryExternalId: 'WBcel235',
+                },
+              },
+              predictedVariantConsequences: [
+                {
+                  variantTranscript: {
+                    transcriptGeneAssociations: [
+                      {
+                        transcriptGeneAssociationObject: {
+                          curie: 'WB:WBGene00000912',
+                          geneSymbol: {
+                            displayText: 'daf-16',
+                          },
+                          geneGenomicLocationAssociations: [
+                            {
+                              start: 10750498,
+                              end: 10776703,
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<VariantSequenceView variant={variantData} />);
+
+    expect(mockGenomeFeatureWrapper).toHaveBeenCalledTimes(1);
+    const props = mockGenomeFeatureWrapper.mock.calls[0][0];
+    expect(props).toEqual(
+      expect.objectContaining({
+        chromosome: 'I',
+        geneSymbol: 'daf-16',
+        primaryId: 'WB:WBGene00000912',
+        species: 'NCBITaxon:6239',
+        fmin: 10750498,
+        fmax: 10776703,
+        genomeLocationList: [
+          expect.objectContaining({
+            chromosome: 'I',
+            start: 10750498,
+            end: 10776703,
+            assembly: 'WBcel235',
+          }),
+        ],
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Summary
The variant sequence viewer was still assuming older variant payload fields, which caused it to miss the target gene on newer responses and show the non-coding fallback message on protein-coding examples. This update teaches the viewer to derive gene metadata from predicted variant consequences so affected variant pages render the expected gene model again.

## Changes
- Updated `VariantSequenceView` to fall back from `overlapGenes` and legacy `variant.gene` fields to gene metadata embedded in `predictedVariantConsequences`.
- Filled in missing chromosome and assembly values from the variant genomic location when the nested gene location is only partially populated.
- Added a regression test covering the current API shape where the target gene is only available through transcript gene associations.

## Testing
- Ran `npx jest src/containers/allelePage/VariantSequenceView.test.jsx --runInBand`.
- Validated the fix logic against the live stage variant API payload shape for the reopened ticket examples.
