### PR TITLE
KANBAN-1163: fix genome viewer release race

### DIFF
--- a/src/containers/genePage/genomeFeatureWrapper.jsx
+++ b/src/containers/genePage/genomeFeatureWrapper.jsx
@@ -74,16 +74,28 @@ class GenomeFeatureWrapper extends Component {
   }
 
   componentDidMount() {
+    if (this.shouldWaitForReleaseVersion()) {
+      return;
+    }
+
     this.loadGenomeFeature();
   }
 
   componentDidUpdate(prevProps) {
     const visibleVariantsChanged = !isEqual(prevProps.visibleVariants, this.props.visibleVariants);
     const isoformFilterChanged = !isEqual(prevProps.isoformFilter, this.props.isoformFilter);
+    const releaseVersionChanged = this.props.releaseVersion !== prevProps.releaseVersion;
     const shouldReloadGenomeFeature =
-      this.props.primaryId !== prevProps.primaryId || visibleVariantsChanged || isoformFilterChanged;
+      this.props.primaryId !== prevProps.primaryId ||
+      visibleVariantsChanged ||
+      isoformFilterChanged ||
+      releaseVersionChanged;
 
     if (shouldReloadGenomeFeature) {
+      if (this.shouldWaitForReleaseVersion()) {
+        return;
+      }
+
       this.loadGenomeFeature();
       if (this.gfc) {
         this.gfc.setSelectedAlleles(
@@ -106,6 +118,10 @@ class GenomeFeatureWrapper extends Component {
     if (this.gfc && this.gfc.closeModal) {
       this.gfc.closeModal();
     }
+  }
+
+  shouldWaitForReleaseVersion() {
+    return !process.env.REACT_APP_JBROWSE_AGR_RELEASE && this.props.releaseIsLoading;
   }
 
   async generateJBrowseTrackData(fmin, fmax, chromosome, species, releaseVersion, displayType) {
@@ -541,6 +557,7 @@ GenomeFeatureWrapper.propTypes = {
   isoformFilter: PropTypes.array,
   primaryId: PropTypes.string,
   releaseVersion: PropTypes.string,
+  releaseIsLoading: PropTypes.bool,
   species: PropTypes.string.isRequired,
   strand: PropTypes.string,
   synonyms: PropTypes.array,
@@ -551,22 +568,13 @@ GenomeFeatureWrapper.propTypes = {
 
 // Functional wrapper to provide release version from context
 const GenomeFeatureWrapperWithRelease = (props) => {
-  const useGetReleaseVersion = () => {
-    const release = useRelease();
-
-    if (!release.isLoading && !release.isError) {
-      return release.data.releaseVersion;
-    } else {
-      return 'unknown';
-    }
-  };
-
-  const contextReleaseVersion = useGetReleaseVersion();
+  const release = useRelease();
+  const contextReleaseVersion = release.isLoading ? 'unknown' : release.isError ? undefined : release.data.releaseVersion;
   const releaseVersion = process.env.REACT_APP_JBROWSE_AGR_RELEASE || contextReleaseVersion;
 
   // Debug logging removed for production
 
-  return <GenomeFeatureWrapper {...props} releaseVersion={releaseVersion} />;
+  return <GenomeFeatureWrapper {...props} releaseIsLoading={release.isLoading} releaseVersion={releaseVersion} />;
 };
 
 export default GenomeFeatureWrapperWithRelease;

--- a/src/containers/genePage/genomeFeatureWrapper.jsx
+++ b/src/containers/genePage/genomeFeatureWrapper.jsx
@@ -569,7 +569,11 @@ GenomeFeatureWrapper.propTypes = {
 // Functional wrapper to provide release version from context
 const GenomeFeatureWrapperWithRelease = (props) => {
   const release = useRelease();
-  const contextReleaseVersion = release.isLoading ? 'unknown' : release.isError ? undefined : release.data.releaseVersion;
+  const contextReleaseVersion = release.isLoading
+    ? 'unknown'
+    : release.isError
+      ? undefined
+      : release.data.releaseVersion;
   const releaseVersion = process.env.REACT_APP_JBROWSE_AGR_RELEASE || contextReleaseVersion;
 
   // Debug logging removed for production

--- a/src/containers/genePage/tests/genomeFeatureWrapper.test.jsx
+++ b/src/containers/genePage/tests/genomeFeatureWrapper.test.jsx
@@ -194,25 +194,20 @@ describe('GenomeFeatureWrapper VCF Error Handling', () => {
     expect(errorAlert).toHaveTextContent('Variant data could not be loaded');
   });
 
-  test('should not attempt to load VCF when release version is unknown', async () => {
+  test('should wait to load genome feature data while release metadata is still loading', async () => {
     // Clear any environment variable that might override the release version
     const originalEnv = process.env.REACT_APP_JBROWSE_AGR_RELEASE;
     delete process.env.REACT_APP_JBROWSE_AGR_RELEASE;
 
-    // Set mock to return unknown release version
     mockUseRelease.mockReturnValue({
-      isLoading: false,
+      isLoading: true,
       isError: false,
-      data: { releaseVersion: 'unknown' },
+      data: undefined,
     });
 
     render(<GenomeFeatureWrapper {...defaultProps} />);
 
-    await waitFor(() => {
-      expect(fetchNCListData).toHaveBeenCalled();
-    });
-
-    // VCF loading should not be attempted
+    expect(fetchNCListData).not.toHaveBeenCalled();
     expect(fetchTabixVcfData).not.toHaveBeenCalled();
 
     // Should not show error alert
@@ -220,6 +215,73 @@ describe('GenomeFeatureWrapper VCF Error Handling', () => {
     expect(errorAlert).not.toBeInTheDocument();
 
     // Restore environment variable
+    if (originalEnv) {
+      process.env.REACT_APP_JBROWSE_AGR_RELEASE = originalEnv;
+    }
+  });
+
+  test('should fall back to the default release when release metadata fails to load', async () => {
+    const originalEnv = process.env.REACT_APP_JBROWSE_AGR_RELEASE;
+    delete process.env.REACT_APP_JBROWSE_AGR_RELEASE;
+
+    mockUseRelease.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      data: undefined,
+    });
+
+    render(<GenomeFeatureWrapper {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(fetchNCListData).toHaveBeenCalledTimes(1);
+    });
+
+    expect(fetchNCListData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        urlTemplate: expect.stringContaining('/8.2.0/'),
+      })
+    );
+
+    await waitFor(() => {
+      expect(GenomeFeatureViewer).toHaveBeenCalledTimes(1);
+    });
+
+    if (originalEnv) {
+      process.env.REACT_APP_JBROWSE_AGR_RELEASE = originalEnv;
+    }
+  });
+
+  test('should load genome feature data after release version changes from unknown to known', async () => {
+    const originalEnv = process.env.REACT_APP_JBROWSE_AGR_RELEASE;
+    delete process.env.REACT_APP_JBROWSE_AGR_RELEASE;
+
+    mockUseRelease.mockReturnValue({
+      isLoading: true,
+      isError: false,
+      data: undefined,
+    });
+
+    const { rerender } = render(<GenomeFeatureWrapper {...defaultProps} />);
+
+    expect(fetchNCListData).not.toHaveBeenCalled();
+    expect(GenomeFeatureViewer).not.toHaveBeenCalled();
+
+    mockUseRelease.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { releaseVersion: '8.2.0' },
+    });
+
+    rerender(<GenomeFeatureWrapper {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(fetchNCListData).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(GenomeFeatureViewer).toHaveBeenCalledTimes(1);
+    });
+
     if (originalEnv) {
       process.env.REACT_APP_JBROWSE_AGR_RELEASE = originalEnv;
     }
@@ -235,10 +297,10 @@ describe('GenomeFeatureWrapper VCF Error Handling', () => {
       expect(fetchNCListData).toHaveBeenCalled();
     });
 
-    // Should show the general error message, not the VCF-specific one
-    const generalError = screen.getByText('Unable to retrieve data');
-    expect(generalError).toBeInTheDocument();
-    expect(generalError).toHaveClass('text-danger');
+    await waitFor(() => {
+      const generalError = screen.getByText('Unable to retrieve data');
+      expect(generalError).toHaveClass('text-danger');
+    });
 
     // Should not show the VCF-specific alert
     const vcfAlert = container.querySelector('.alert.alert-warning');


### PR DESCRIPTION
## Summary
This follow-up fixes a sequence viewer regression that appeared on variant pages after the earlier KANBAN-1163 work. The viewer was trying to load JBrowse data before release metadata had resolved, which could suppress the viewer on stage; this change waits for release loading to finish, retries when the real release arrives, and preserves the existing default-release fallback when release metadata fails.

## Changes
- Updated `GenomeFeatureWrapper` to defer the initial genome feature load only while release metadata is still loading.
- Updated `GenomeFeatureWrapper` to reload when `releaseVersion` changes so the viewer initializes after the release context resolves.
- Preserved the existing default release fallback when `/api/releaseInfo` fails instead of leaving the viewer stuck on a spinner.
- Added regression coverage for the loading-to-loaded transition and the release-info error fallback in `genomeFeatureWrapper.test.jsx`.
- Kept the variant sequence viewer regression suite passing to confirm the earlier variant-data fallback still works.

## Testing
Ran `npx jest src/containers/genePage/tests/genomeFeatureWrapper.test.jsx --runInBand`.
Ran `npx jest src/containers/allelePage/VariantSequenceView.test.jsx --runInBand`.
