### PR TITLE
KANBAN-1163: Bump genomefeatures dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "d3-selection": "^3.0.0",
         "events": "^3.3.0",
         "generic-sequence-panel": "^1.8.0",
-        "genomefeatures": "github:alliance-genome/genomefeatures#37dc2289d9193aa39823a58ee221b3c14a6d3185",
+        "genomefeatures": "github:alliance-genome/genomefeatures#981eb9659be8ad7f0dd3bb213c41a6e98702adc4",
         "html-react-parser": "^5.2.3",
         "immutable": "^5.1.2",
         "js-yaml": "^4.1.0",
@@ -8988,8 +8988,8 @@
     },
     "node_modules/genomefeatures": {
       "version": "1.0.5",
-      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#37dc2289d9193aa39823a58ee221b3c14a6d3185",
-      "integrity": "sha512-YQHeQDqCTmainQN89NLR/yTG4N++NbBMek95kmtmIA+A5X4TMkv8c79UsEI3E46nSaQV3UpTVO/Wio/b5Pmtbw==",
+      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#981eb9659be8ad7f0dd3bb213c41a6e98702adc4",
+      "integrity": "sha512-upuoWrHQsz2NwDKkz2cJnZ1srtZLTULeu0oa2M3ivC8R4pdxZ4REYOZ7zP0Co027+Zmysz9a+BB6Qef91OzUrg==",
       "license": "MIT",
       "dependencies": {
         "@gmod/nclist": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "d3-selection": "^3.0.0",
     "events": "^3.3.0",
     "generic-sequence-panel": "^1.8.0",
-    "genomefeatures": "github:alliance-genome/genomefeatures#37dc2289d9193aa39823a58ee221b3c14a6d3185",
+    "genomefeatures": "github:alliance-genome/genomefeatures#981eb9659be8ad7f0dd3bb213c41a6e98702adc4",
     "html-react-parser": "^5.2.3",
     "immutable": "^5.1.2",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Summary
This updates `agr_ui` to consume the merged `genomefeatures` changes for KANBAN-1163 so the UI actually picks up the fixed target-gene matching behavior from the widget library. Without this dependency bump, `agr_ui` would remain pinned to the older genomefeatures commit and would not receive the regression coverage and matching fix that was merged upstream.

## Changes
- Updated the `genomefeatures` dependency in `package.json` from commit `37dc2289d9193aa39823a58ee221b3c14a6d3185` to commit `981eb9659be8ad7f0dd3bb213c41a6e98702adc4`.
- Refreshed `package-lock.json` so the installed git dependency resolves to the merged `genomefeatures` commit.

## Testing
- Ran `npx jest src/containers/genePage/tests/genomeFeatureWrapper.test.jsx src/containers/allelePage/VariantSequenceView.test.jsx src/containers/genePage/tests/genomefeatures-import.test.js --runInBand`.
