### PR TITLE
KANBAN-1163 fix production gene viewer regressions

### DIFF
--- a/initializeGOLibraryWebComponents.js
+++ b/initializeGOLibraryWebComponents.js
@@ -24,6 +24,8 @@ const initializeGOLibraryWebComponents_PRODUCTION = () => {
   head.appendChild(ribbonTableScriptElement);
 
   const goCamVizScriptElement = document.createElement('script');
+  // GO-CAM viz is shipped as an ES module bundle in production.
+  goCamVizScriptElement.type = 'module';
   goCamVizScriptElement.src = '/assets/wc-gocam-viz/wc-gocam-viz.esm.js';
   head.appendChild(goCamVizScriptElement);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "d3-selection": "^3.0.0",
         "events": "^3.3.0",
         "generic-sequence-panel": "^1.8.0",
-        "genomefeatures": "github:alliance-genome/genomefeatures#981eb9659be8ad7f0dd3bb213c41a6e98702adc4",
+        "genomefeatures": "github:alliance-genome/genomefeatures#2b6a4949aeb1795d52b8cbf05cfcdea4d0819b05",
         "html-react-parser": "^5.2.3",
         "immutable": "^5.1.2",
         "js-yaml": "^4.1.0",
@@ -8988,8 +8988,8 @@
     },
     "node_modules/genomefeatures": {
       "version": "1.0.5",
-      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#981eb9659be8ad7f0dd3bb213c41a6e98702adc4",
-      "integrity": "sha512-upuoWrHQsz2NwDKkz2cJnZ1srtZLTULeu0oa2M3ivC8R4pdxZ4REYOZ7zP0Co027+Zmysz9a+BB6Qef91OzUrg==",
+      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#2b6a4949aeb1795d52b8cbf05cfcdea4d0819b05",
+      "integrity": "sha512-cLowOyUUBeJ9R5/r/THvxUfmQiMeCitxkUB2IQKSGUzjp8+UAXSlzohtEgx9fziOMbDQetcrSYlG3Hi336foxA==",
       "license": "MIT",
       "dependencies": {
         "@gmod/nclist": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "d3-selection": "^3.0.0",
         "events": "^3.3.0",
         "generic-sequence-panel": "^1.8.0",
-        "genomefeatures": "github:alliance-genome/genomefeatures#2b6a4949aeb1795d52b8cbf05cfcdea4d0819b05",
+        "genomefeatures": "github:alliance-genome/genomefeatures#e9a83e5b63b8664e0de1b471932a5818353b3ae7",
         "html-react-parser": "^5.2.3",
         "immutable": "^5.1.2",
         "js-yaml": "^4.1.0",
@@ -8988,7 +8988,7 @@
     },
     "node_modules/genomefeatures": {
       "version": "1.0.5",
-      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#2b6a4949aeb1795d52b8cbf05cfcdea4d0819b05",
+      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#e9a83e5b63b8664e0de1b471932a5818353b3ae7",
       "integrity": "sha512-cLowOyUUBeJ9R5/r/THvxUfmQiMeCitxkUB2IQKSGUzjp8+UAXSlzohtEgx9fziOMbDQetcrSYlG3Hi336foxA==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "d3-selection": "^3.0.0",
     "events": "^3.3.0",
     "generic-sequence-panel": "^1.8.0",
-    "genomefeatures": "github:alliance-genome/genomefeatures#2b6a4949aeb1795d52b8cbf05cfcdea4d0819b05",
+    "genomefeatures": "github:alliance-genome/genomefeatures#e9a83e5b63b8664e0de1b471932a5818353b3ae7",
     "html-react-parser": "^5.2.3",
     "immutable": "^5.1.2",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "d3-selection": "^3.0.0",
     "events": "^3.3.0",
     "generic-sequence-panel": "^1.8.0",
-    "genomefeatures": "github:alliance-genome/genomefeatures#981eb9659be8ad7f0dd3bb213c41a6e98702adc4",
+    "genomefeatures": "github:alliance-genome/genomefeatures#2b6a4949aeb1795d52b8cbf05cfcdea4d0819b05",
     "html-react-parser": "^5.2.3",
     "immutable": "^5.1.2",
     "js-yaml": "^4.1.0",

--- a/src/tests/initializeGOLibraryWebComponents.test.js
+++ b/src/tests/initializeGOLibraryWebComponents.test.js
@@ -1,0 +1,28 @@
+import initializeGOLibraryWebComponents from '../../initializeGOLibraryWebComponents.js';
+
+describe('initializeGOLibraryWebComponents', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    document.head.innerHTML = '';
+  });
+
+  test('loads GO-CAM viz as a module script in production', () => {
+    process.env.NODE_ENV = 'production';
+
+    initializeGOLibraryWebComponents();
+
+    const scripts = Array.from(document.head.querySelectorAll('script'));
+    const goCamVizScript = scripts.find(
+      (script) => script.getAttribute('src') === '/assets/wc-gocam-viz/wc-gocam-viz.esm.js'
+    );
+
+    expect(goCamVizScript).toBeTruthy();
+    expect(goCamVizScript.type).toBe('module');
+  });
+});


### PR DESCRIPTION
## Summary
- load the GO-CAM production bundle as an ES module
- bump genomefeatures to the alias-normalization fix commit
- add a regression test for the production web component initialization path

## Testing
- npm test -- --watchAll=false src/tests/initializeGOLibraryWebComponents.test.js
- npm run build
- local production preview checks for yeast, frog, and variant pages
