### PR TITLE
SCRUM-5980 Show HGVS name and remove Category Type from variant search

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -67,14 +67,7 @@ export const CATEGORIES = [
   {
     name: VARIANT_CATEGORY,
     displayName: 'HTP Variant',
-    displayFields: [
-      'primaryKey',
-      'name',
-      'variantType',
-      'alterationType',
-      'crossReferences',
-      'molecularConsequence',
-    ],
+    displayFields: ['primaryKey', 'name', 'variantType', 'alterationType', 'crossReferences', 'molecularConsequence'],
   },
 ];
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -69,8 +69,8 @@ export const CATEGORIES = [
     displayName: 'HTP Variant',
     displayFields: [
       'primaryKey',
+      'name',
       'variantType',
-      'categoryType',
       'alterationType',
       'crossReferences',
       'molecularConsequence',


### PR DESCRIPTION
## Summary
- Add `name` (HGVS name) to HTP Variant search result display fields
- Remove `categoryType` from HTP Variant search result display fields

## Test plan
- [ ] Search for a variant on stage, verify HGVS name appears in results
- [ ] Verify "Category Type" field no longer shows in variant search results