### PR TITLE
SCRUM-5829 do not show gene/allele cross references unless they match

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -33,8 +33,6 @@ export const CATEGORIES = [
       'variantType',
       'alterationType',
       'variants',
-      'alleleCrossReferences',
-      'geneCrossReferences',
       'molecularConsequence',
       'diseases',
     ],


### PR DESCRIPTION
## Summary
Drops `alleleCrossReferences` and `geneCrossReferences` from the allele `displayFields` in `src/constants.js`. They no longer render unconditionally on every allele search result card; instead they fall through the highlight-section path and only appear when the user's query matches them — and only the matched value(s) are shown.

Addresses the two open asks from Chris's 2026-04-27 comment on SCRUM-5829:
- "Allele Cross References" should be removed (now redundant with the allele's "Cross References") or only shown on match
- "Gene Cross References" should not be a forced field — only show when there is a match, and only the matching entries

## Test plan
- [x] On stage, search Alleles broadly (e.g. without a query that matches a cross-ref) — confirm neither "Allele Cross References" nor "Gene Cross References" sections render on result cards
- [ ] Search for a gene cross-reference (e.g. `ENSEMBL:ENSMUSG00000086429`) — confirm "Gene Cross References" appears in the highlight section with only the matching value highlighted
- [ ] Search for an allele primary ID — confirm the matching cross-reference value still surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)