### PR TITLE
UI deploy 9.0.0: update ALB target instance

### DIFF
--- a/cdk/cdk-app.ts
+++ b/cdk/cdk-app.ts
@@ -10,7 +10,7 @@ const app = new cdk.App();
 new AmplifyALBStack(app, 'test-alb-stack', {
   stackName: 'test-alb-stack',
   dnsName: 'test',
-  targetInstanceId: 'i-03856fee92636f4cc',
+  targetInstanceId: 'i-0ce9397d5e3cd8c96',
   env: {
     region: process.env.CDK_DEFAULT_REGION,
     account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -20,7 +20,7 @@ new AmplifyALBStack(app, 'test-alb-stack', {
 new AmplifyALBStack(app, 'prod-alb-stack', {
   stackName: 'prod-alb-stack',
   dnsName: 'prod',
-  targetInstanceId: 'i-03856fee92636f4cc',
+  targetInstanceId: 'i-0ce9397d5e3cd8c96',
   env: {
     region: process.env.CDK_DEFAULT_REGION,
     account: process.env.CDK_DEFAULT_ACCOUNT,


### PR DESCRIPTION
## Summary
Release branch for the **9.0.0** production release. Updates `cdk/cdk-app.ts` to point the ALB stacks at the new 9.0.0 release box.

- `test-alb-stack` and `prod-alb-stack` `targetInstanceId`: `i-03856fee92636f4cc` (8.3.0 box) → `i-0ce9397d5e3cd8c96` (9.0.0 box)
- Generated by `ui_deploy.py` during the GoCD `DeployUI` stage.

## Release flow
1. **This PR**: `9_0_0` → `stage` (here)
2. Next: `stage` → `test` → triggers `DeployLB`, deploys `test-alb-stack`
3. Later: `test` → `main` → triggers `DeployProd` (Amplify + `prod-alb-stack`)

## Review
Requesting UI team review (Olin / Adam Gibson / Howie). Enable auto-merge once checks pass.