### PR TITLE
KANBAN-1322 add disease ontology browser

### DIFF
--- a/src/components/dataPage/pageNav.jsx
+++ b/src/components/dataPage/pageNav.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import { Collapse } from 'reactstrap';
 import Scrollspy from 'react-scrollspy';
@@ -27,19 +28,40 @@ const PageNav = ({ children, sections }) => {
             className={`list-group list-group-flush ${style.scrollSpy}`}
             componentTag="div"
             currentClassName="active"
-            items={sections.map(({ name }) => makeId(name))}
+            items={sections.filter((s) => !s.to).map(({ name }) => makeId(name))}
           >
-            {sections.map(({ name: section, level = 0 }) => {
-              const style = { paddingLeft: `${level + 1}em`, border: 'none' };
+            {sections.map(({ name: section, level = 0, count, to }) => {
+              const itemStyle = { paddingLeft: `${level + 1}em` };
+              const hasCount = count !== undefined && count !== null;
+              const badgeClass = `${style.navBadge} ${count === 0 ? style.navBadgeZero : ''}`;
+              const inner = (
+                <>
+                  <span>{section}</span>
+                  {hasCount && <span className={badgeClass}>{count.toLocaleString()}</span>}
+                </>
+              );
+              if (to) {
+                return (
+                  <Link
+                    className={`list-group-item list-group-item-action ${style.navItem}`}
+                    key={section}
+                    onClick={() => setIsOpen(false)}
+                    style={itemStyle}
+                    to={to}
+                  >
+                    {inner}
+                  </Link>
+                );
+              }
               return (
                 <HashLink
-                  className="list-group-item list-group-item-action"
+                  className={`list-group-item list-group-item-action ${style.navItem}`}
                   key={section}
                   onClick={() => setIsOpen(false)}
-                  style={style}
+                  style={itemStyle}
                   to={'#' + makeId(section)}
                 >
-                  {section}
+                  {inner}
                 </HashLink>
               );
             })}
@@ -56,6 +78,8 @@ PageNav.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       level: PropTypes.number,
+      count: PropTypes.number,
+      to: PropTypes.string,
     })
   ),
 };

--- a/src/components/dataPage/style.module.scss
+++ b/src/components/dataPage/style.module.scss
@@ -76,6 +76,28 @@ $page-nav-width: 220px;
   }
 }
 
+.navItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: none;
+}
+
+.navBadge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  background-color: $gray-100;
+  color: $gray-700;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-left: 0.5rem;
+}
+
+.navBadgeZero {
+  color: $gray-500;
+}
+
 .titleTooltip {
   max-width: 100%;
   font-size: 1rem;

--- a/src/constants.js
+++ b/src/constants.js
@@ -128,6 +128,10 @@ export const NAV_MENU = [
         route: '/disease-portal',
       },
       {
+        label: 'Ontology Browser',
+        route: '/ontology/disease',
+      },
+      {
         label: 'SimpleMine',
         route: '/agr_simplemine.cgi',
         external: true,

--- a/src/containers/diseasePage/index.jsx
+++ b/src/containers/diseasePage/index.jsx
@@ -19,7 +19,7 @@ const SUMMARY = 'Summary';
 const GENES = 'Associated Genes';
 const ALLELES = 'Associated Alleles';
 const MODELS = 'Associated Models';
-const SECTIONS = [{ name: SUMMARY }, { name: GENES }, { name: ALLELES }, { name: MODELS }];
+const BROWSE_ONTOLOGY = 'Browse Ontology';
 
 const DiseasePage = () => {
   const { id: diseaseId } = useParams();
@@ -32,8 +32,6 @@ const DiseasePage = () => {
   if (isLoading) {
     return null; // the main page loading bar is sufficient
   }
-
-  console.log(data);
 
   const title = data.doTerm.name || data.doTerm.curie;
 
@@ -81,7 +79,15 @@ const DiseasePage = () => {
   return (
     <DataPage>
       <HeadMetaTags jsonLd={jsonLd} title={title} />
-      <PageNav sections={SECTIONS}>
+      <PageNav
+        sections={[
+          { name: SUMMARY },
+          { name: GENES },
+          { name: ALLELES },
+          { name: MODELS },
+          { name: BROWSE_ONTOLOGY, to: `/ontology/disease/${data.doTerm.curie}` },
+        ]}
+      >
         <PageNavEntity entityName={<DiseaseName disease={data.doTerm} />}>
           <ExternalLink href={data.diseaseURL}>{data.doTerm.curie}</ExternalLink>
         </PageNavEntity>

--- a/src/containers/ontologyBrowser/browse/CountBadge.jsx
+++ b/src/containers/ontologyBrowser/browse/CountBadge.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useDiseaseCounts } from './useDiseaseCounts.jsx';
+import style from './style.module.scss';
+
+const CountBadge = ({ curie, type, hideZero, expanded }) => {
+  const counts = useDiseaseCounts(curie);
+  const count = counts ? counts[type.id] : undefined;
+
+  // Hide entirely when there are no records, regardless of hideZero. The
+  // pill is a shortcut — useless if there is nothing to jump to.
+  if (typeof count !== 'number' || count === 0) return null;
+  if (hideZero && count === 0) return null;
+
+  const href = `/disease/${curie}#${type.hash}`;
+  const display = expanded ? `View ${type.label.toLowerCase()}` : type.label.charAt(0).toUpperCase();
+  const title = `${count.toLocaleString()} ${type.label.toLowerCase()} — open in new window`;
+  const badgeClass = expanded ? `${style.countBadge} ${style.countBadgeExpanded}` : style.countBadge;
+
+  if (!type.hash) {
+    return (
+      <span
+        className={badgeClass}
+        style={{ background: type.bg, color: type.fg }}
+        title={`${count.toLocaleString()} ${type.label.toLowerCase()}`}
+      >
+        {display}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className={`${badgeClass} ${style.countBadgeLink}`}
+      style={{ background: type.bg, color: type.fg }}
+      title={title}
+    >
+      {display}
+    </a>
+  );
+};
+
+CountBadge.propTypes = {
+  curie: PropTypes.string.isRequired,
+  type: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    hash: PropTypes.string,
+    bg: PropTypes.string.isRequired,
+    fg: PropTypes.string.isRequired,
+  }).isRequired,
+  hideZero: PropTypes.bool,
+  expanded: PropTypes.bool,
+};
+
+export default CountBadge;

--- a/src/containers/ontologyBrowser/browse/OntologySearchBox.jsx
+++ b/src/containers/ontologyBrowser/browse/OntologySearchBox.jsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import Autosuggest from 'react-autosuggest';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
+import fetchData from '../../../lib/fetchData';
+
+const ENDPOINT = '/api/search_autocomplete';
+const SEARCH_ENDPOINT = '/api/search';
+const FULL_RESULTS_LIMIT = 200;
+
+const FullResultsModal = ({ isOpen, query, category, onSelect, onClose }) => {
+  const [results, setResults] = useState(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || !query) return;
+    setResults(null);
+    setError(false);
+    const url = `${SEARCH_ENDPOINT}?q=${encodeURIComponent(query)}&category=${category}&limit=${FULL_RESULTS_LIMIT}`;
+    fetchData(url)
+      .then((data) => setResults(data?.results || []))
+      .catch(() => setError(true));
+  }, [isOpen, query, category]);
+
+  return (
+    <Modal isOpen={isOpen} toggle={onClose} size="lg" scrollable>
+      <ModalHeader toggle={onClose}>
+        Search results for &ldquo;{query}&rdquo;
+        {results && (
+          <small style={{ marginLeft: 8, color: '#6c757d', fontWeight: 'normal' }}>
+            {results.length} term{results.length === 1 ? '' : 's'}
+          </small>
+        )}
+      </ModalHeader>
+      <ModalBody>
+        {error && <em>Could not load results.</em>}
+        {!error && results === null && <em>Loading…</em>}
+        {!error && results && results.length === 0 && <em>No matches.</em>}
+        {!error && results && results.length > 0 && (
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {results.map((r) => {
+              const curie = r.curie || r.primaryKey;
+              const name = r.name || r.nameKey || curie;
+              return (
+                <li key={curie} style={{ borderBottom: '1px solid #f1f3f5' }}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (curie) onSelect(curie);
+                    }}
+                    style={{
+                      display: 'block',
+                      width: '100%',
+                      textAlign: 'left',
+                      padding: '8px 6px',
+                      border: 'none',
+                      background: 'transparent',
+                      cursor: 'pointer',
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = '#f8f9fa')}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                  >
+                    <strong>{name}</strong>{' '}
+                    <span style={{ color: '#868e96', fontSize: '0.8rem', fontFamily: 'monospace' }}>{curie}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </ModalBody>
+    </Modal>
+  );
+};
+
+FullResultsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  query: PropTypes.string,
+  category: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+const OntologySearchBox = ({ onSelect, category, placeholder }) => {
+  const [value, setValue] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
+  const [modalQuery, setModalQuery] = useState(null);
+  const abortRef = useRef(null);
+
+  const openModalFor = (q) => {
+    if (q && q.trim()) setModalQuery(q);
+  };
+  const closeModal = () => setModalQuery(null);
+  const onModalSelect = (curie) => {
+    setModalQuery(null);
+    setValue('');
+    setSuggestions([]);
+    onSelect(curie);
+  };
+
+  const onSuggestionsFetchRequested = ({ value: q }) => {
+    if (!q || q.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const url = `${ENDPOINT}?q=${encodeURIComponent(q)}&category=${category}`;
+    fetchData(url, { signal: controller.signal })
+      .then((data) => {
+        setSuggestions(data?.results || []);
+      })
+      .catch(() => {
+        // aborted or failed; leave existing suggestions
+      });
+  };
+
+  const onSuggestionsClearRequested = () => setSuggestions([]);
+
+  const onSuggestionSelected = (_e, { suggestion }) => {
+    const curie = suggestion.curie || suggestion.primaryKey;
+    if (curie) onSelect(curie);
+    setValue('');
+    setSuggestions([]);
+  };
+
+  return (
+    <>
+    <Autosuggest
+      suggestions={suggestions}
+      onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+      onSuggestionsClearRequested={onSuggestionsClearRequested}
+      onSuggestionSelected={onSuggestionSelected}
+      getSuggestionValue={(s) => s.name || s.nameKey || ''}
+      renderSuggestion={(s) => (
+        <div style={{ padding: '4px 8px' }}>
+          <strong>{s.name || s.nameKey}</strong>{' '}
+          <span style={{ color: '#868e96', fontSize: '0.8rem', fontFamily: 'monospace' }}>{s.curie}</span>
+        </div>
+      )}
+      renderSuggestionsContainer={({ containerProps, children, query }) => {
+        const { key, ...containerRest } = containerProps;
+        return (
+        <div key={key} {...containerRest}>
+          <div style={{ maxHeight: 280, overflowY: 'auto' }}>{children}</div>
+          {children && query && (
+            <button
+              type="button"
+              aria-label={`View all results for ${query}`}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                openModalFor(query);
+              }}
+              style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
+                padding: '9px 12px',
+                borderTop: '1px solid #dee2e6',
+                borderLeft: 'none',
+                borderRight: 'none',
+                borderBottom: 'none',
+                background: '#f8f9fa',
+                color: '#0d6efd',
+                fontSize: '0.85rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              View all results for &ldquo;{query}&rdquo; &rarr;
+            </button>
+          )}
+        </div>
+        );
+      }}
+      inputProps={{
+        value,
+        placeholder: placeholder || 'Search terms',
+        onChange: (_e, { newValue }) => setValue(newValue),
+        onKeyDown: (e) => {
+          if (e.key === 'Enter' && suggestions.length > 0) {
+            e.preventDefault();
+            const top = suggestions[0];
+            const curie = top.curie || top.primaryKey;
+            if (curie) onSelect(curie);
+            setValue('');
+            setSuggestions([]);
+          }
+        },
+        className: 'form-control',
+      }}
+      theme={{
+        container: { position: 'relative' },
+        suggestionsContainer: {
+          position: 'absolute',
+          top: '100%',
+          left: 0,
+          right: 0,
+          zIndex: 100,
+          background: 'white',
+          border: '1px solid #dee2e6',
+          borderTop: 'none',
+          boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+        },
+        suggestionsList: { listStyle: 'none', margin: 0, padding: 0 },
+        suggestion: { cursor: 'pointer' },
+        suggestionHighlighted: { backgroundColor: '#e9ecef' },
+      }}
+    />
+    <FullResultsModal
+      isOpen={!!modalQuery}
+      query={modalQuery || ''}
+      category={category}
+      onSelect={onModalSelect}
+      onClose={closeModal}
+    />
+    </>
+  );
+};
+
+OntologySearchBox.propTypes = {
+  onSelect: PropTypes.func.isRequired,
+  category: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+};
+
+export default OntologySearchBox;

--- a/src/containers/ontologyBrowser/browse/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/browse/OntologyTree.jsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronRight, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import CountBadge from './CountBadge.jsx';
+import { ANNOTATION_TYPES } from './annotationTypes.js';
+import { useDiseaseTerm } from './useDiseaseTerms.jsx';
+import style from './style.module.scss';
+
+const TreeNode = ({ curie, name, depth, forceExpanded, focusedCurie, onSelect, scrollOnFocus }) => {
+  const [open, setOpen] = useState(false);
+  const rowRef = useRef(null);
+
+  // Term doc comes from the batched provider so every visible node knows its
+  // children without firing per-node requests.
+  const data = useDiseaseTerm(curie);
+
+  useEffect(() => {
+    if (forceExpanded.has(curie)) setOpen(true);
+  }, [forceExpanded, curie]);
+
+  useEffect(() => {
+    if (scrollOnFocus && focusedCurie === curie && rowRef.current) {
+      rowRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }, [focusedCurie, curie, scrollOnFocus]);
+
+  const children = data?.children || [];
+  // We don't know if a node has children until we've expanded it and
+  // fetched its doc. Show the arrow optimistically; hide it only after a
+  // fetch confirms no children.
+  const knownEmpty = !!data && children.length === 0 && !(data.doTerm?.descendantCount > 0);
+  const hasChildren = !knownEmpty;
+  const isFocused = focusedCurie === curie;
+
+  const toggle = (e) => {
+    e.stopPropagation();
+    setOpen((v) => !v);
+  };
+
+  return (
+    <div className={style.node}>
+      <div
+        ref={rowRef}
+        className={`${style.nodeRow} ${isFocused ? style.nodeRowFocused : ''}`}
+        onClick={() => onSelect(curie)}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            className={style.toggle}
+            onClick={toggle}
+            title={open ? 'Collapse' : 'Expand children'}
+            aria-label={open ? 'Collapse' : 'Expand children'}
+          >
+            <FontAwesomeIcon icon={open ? faChevronDown : faChevronRight} fixedWidth />
+          </button>
+        ) : (
+          <span className={style.toggleSpacer} />
+        )}
+        <span>{name}</span>
+        <span className={style.curie}>&nbsp;{curie}</span>
+        <span className={style.badgeRow}>
+          {ANNOTATION_TYPES.map((t) => (
+            <CountBadge key={t.id} curie={curie} type={t} hideZero />
+          ))}
+        </span>
+      </div>
+      {open && children.length > 0 && (
+        <div className={style.children}>
+          {[...children]
+            .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+            .map((c) => (
+              <TreeNode
+                key={c.curie}
+                curie={c.curie}
+                name={c.name}
+                depth={depth + 1}
+                forceExpanded={forceExpanded}
+                focusedCurie={focusedCurie}
+                onSelect={onSelect}
+                scrollOnFocus={scrollOnFocus}
+              />
+            ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+TreeNode.propTypes = {
+  curie: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  depth: PropTypes.number.isRequired,
+  forceExpanded: PropTypes.instanceOf(Set).isRequired,
+  focusedCurie: PropTypes.string,
+  onSelect: PropTypes.func.isRequired,
+  scrollOnFocus: PropTypes.bool,
+};
+
+const OntologyTree = ({ rootCurie, rootName, forceExpanded, focusedCurie, onSelect, scrollOnFocus = true }) => {
+  return (
+    <TreeNode
+      curie={rootCurie}
+      name={rootName}
+      depth={0}
+      forceExpanded={forceExpanded}
+      focusedCurie={focusedCurie}
+      onSelect={onSelect}
+      scrollOnFocus={scrollOnFocus}
+    />
+  );
+};
+
+OntologyTree.propTypes = {
+  rootCurie: PropTypes.string.isRequired,
+  rootName: PropTypes.string.isRequired,
+  forceExpanded: PropTypes.instanceOf(Set).isRequired,
+  focusedCurie: PropTypes.string,
+  onSelect: PropTypes.func.isRequired,
+  scrollOnFocus: PropTypes.bool,
+};
+
+export default OntologyTree;

--- a/src/containers/ontologyBrowser/browse/TermDetailPanel.jsx
+++ b/src/containers/ontologyBrowser/browse/TermDetailPanel.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
+import fetchData from '../../../lib/fetchData';
+import { CollapsibleList } from '../../../components/collapsibleList';
+import ExternalLink from '../../../components/ExternalLink.jsx';
+import CountBadge from './CountBadge.jsx';
+import { ANNOTATION_TYPES } from './annotationTypes.js';
+import { data as portalData } from '../../diseasePortal/portalData.js';
+import style from './style.module.scss';
+
+const portalSlugForCurie = (curie) => {
+  return Object.entries(portalData).find(([, v]) => v.doid === curie)?.[0];
+};
+
+const TermDetailPanel = ({ curie }) => {
+  const { ontology = 'disease' } = useParams();
+  const { data, isLoading } = useQuery({
+    queryKey: ['disease-term', curie],
+    queryFn: () => fetchData(`/api/disease/${encodeURIComponent(curie)}`),
+    enabled: !!curie,
+    staleTime: 5 * 60_000,
+  });
+
+
+  if (!curie) return <em>Select a term to see details.</em>;
+  if (isLoading || !data) return <em>Loading…</em>;
+
+  const term = data.doTerm || {};
+  const synonyms = term.synonyms || [];
+  const xrefs = data.crossReferenceLinkUrls || [];
+  const parents = data.parents || [];
+  const portalSlug = portalSlugForCurie(curie);
+
+  return (
+    <div>
+      <h3 className={style.detailTitle}>{term.name}</h3>
+      <div className={style.curie}>{curie}</div>
+      <div className={style.detailBadgeRow}>
+        {ANNOTATION_TYPES.map((t) => (
+          <CountBadge key={t.id} curie={curie} type={t} expanded />
+        ))}
+      </div>
+
+      <div className={style.detailSection}>
+        <Link to={`/disease/${curie}`} className={`btn btn-primary ${style.viewPageButton}`}>
+          View disease page <FontAwesomeIcon icon={faArrowRight} />
+        </Link>
+        {portalSlug && (
+          <Link
+            to={`/disease-portal/${portalSlug}`}
+            className={`btn btn-outline-primary ${style.viewPageButton}`}
+          >
+            View disease portal
+          </Link>
+        )}
+      </div>
+
+      {term.definition && (
+        <div className={style.detailSection}>
+          <div className={style.detailSectionLabel}>Definition</div>
+          <div>{term.definition}</div>
+        </div>
+      )}
+
+      {parents.length > 0 && (
+        <div className={style.detailSection}>
+          <div className={style.detailSectionLabel}>Parent Terms</div>
+          <ul className={style.parentList}>
+            {parents.map((p) => (
+              <li key={p.curie}>
+                <em className={style.relation}>is-a</em>
+                <Link to={`/ontology/${ontology}/${p.curie}`}>{p.name}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {synonyms.length > 0 && (
+        <div className={style.detailSection}>
+          <div className={style.detailSectionLabel}>Synonyms</div>
+          <CollapsibleList collapsedSize={5}>
+            {synonyms.map((s, i) => (
+              <span key={i}>{typeof s === 'string' ? s : s?.name || JSON.stringify(s)}</span>
+            ))}
+          </CollapsibleList>
+        </div>
+      )}
+
+      {xrefs.length > 0 && (
+        <div className={style.detailSection}>
+          <div className={style.detailSectionLabel}>Cross-references</div>
+          <CollapsibleList collapsedSize={5}>
+            {xrefs.map((x, i) => (
+              <ExternalLink key={i} href={x.url}>
+                {x.referencedCurie || x.url}
+              </ExternalLink>
+            ))}
+          </CollapsibleList>
+        </div>
+      )}
+    </div>
+  );
+};
+
+TermDetailPanel.propTypes = {
+  curie: PropTypes.string,
+};
+
+export default TermDetailPanel;

--- a/src/containers/ontologyBrowser/browse/annotationTypes.js
+++ b/src/containers/ontologyBrowser/browse/annotationTypes.js
@@ -1,0 +1,30 @@
+// Annotation type configuration for ontology-browser count pills.
+// Each type defines a label, the endpoint suffix that returns a Long count,
+// the hash anchor on the disease page, and a colour pair (background / text)
+// for the pill.
+export const ANNOTATION_TYPES = [
+  {
+    id: 'genes',
+    label: 'Genes',
+    endpoint: 'genes_counts',
+    hash: 'associated-genes',
+    bg: '#cfe2ff',
+    fg: '#084298',
+  },
+  {
+    id: 'models',
+    label: 'Models',
+    endpoint: 'models_counts',
+    hash: 'associated-models',
+    bg: '#d1e7dd',
+    fg: '#0f5132',
+  },
+  {
+    id: 'alleles',
+    label: 'Alleles',
+    endpoint: 'alleles_counts',
+    hash: 'associated-alleles',
+    bg: '#fff3cd',
+    fg: '#664d03',
+  },
+];

--- a/src/containers/ontologyBrowser/browse/index.jsx
+++ b/src/containers/ontologyBrowser/browse/index.jsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import HeadMetaTags from '../../../components/headMetaTags.jsx';
+import fetchData from '../../../lib/fetchData';
+import OntologyTree from './OntologyTree.jsx';
+import TermDetailPanel from './TermDetailPanel.jsx';
+import OntologySearchBox from './OntologySearchBox.jsx';
+import { ONTOLOGIES, DEFAULT_ONTOLOGY_ID, getOntology } from './ontologies.js';
+import { ANNOTATION_TYPES } from './annotationTypes.js';
+import { CountsProvider } from './useDiseaseCounts.jsx';
+import { TermsProvider } from './useDiseaseTerms.jsx';
+import style from './style.module.scss';
+
+const PAGE_TITLE = 'Ontology Browser';
+
+const OntologyBrowser = () => {
+  const { ontology: ontologyParam, id } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const ontology = getOntology(ontologyParam || DEFAULT_ONTOLOGY_ID);
+  const focusedCurie = id || null;
+  // When the user clicks a term inside the tree we set fromTree=true so we
+  // skip re-anchoring the tree to the canonical ancestor chain (which can
+  // belong to a different parent for DAG terms) and skip scrolling.
+  const fromTree = !!location.state?.fromTree;
+
+  const { data: ancestors } = useQuery({
+    queryKey: ['ontology-ancestors', ontology.id, focusedCurie],
+    queryFn: () => fetchData(`/api/disease/${encodeURIComponent(focusedCurie)}/ancestors`),
+    enabled: !!focusedCurie && ontology.available && ontology.id === 'disease' && !fromTree,
+    staleTime: 5 * 60_000,
+  });
+
+  const [forceExpanded, setForceExpanded] = useState(() =>
+    ontology.rootCurie ? new Set([ontology.rootCurie]) : new Set()
+  );
+
+  useEffect(() => {
+    if (fromTree) return; // keep current expansion state
+    const next = new Set();
+    if (ontology.rootCurie) next.add(ontology.rootCurie);
+    if (ancestors && Array.isArray(ancestors)) {
+      ancestors.forEach((a) => next.add(a.curie));
+    } else if (focusedCurie) {
+      next.add(focusedCurie);
+    }
+    setForceExpanded(next);
+  }, [ancestors, focusedCurie, ontology.rootCurie, fromTree]);
+
+  const handleSelect = (curie, opts = {}) =>
+    navigate(`/ontology/${ontology.id}/${curie}`, opts.fromTree ? { state: { fromTree: true } } : undefined);
+  const handleTreeSelect = (curie) => handleSelect(curie, { fromTree: true });
+  const handleOntologyChange = (newId) => navigate(`/ontology/${newId}`);
+
+  const detailCurie = useMemo(
+    () => focusedCurie || ontology.rootCurie || null,
+    [focusedCurie, ontology.rootCurie]
+  );
+
+  return (
+    <CountsProvider>
+    <TermsProvider>
+    <div className={style.page}>
+      <HeadMetaTags title={PAGE_TITLE} />
+      <h2>{PAGE_TITLE}</h2>
+
+      <div className={style.chooserRow}>
+        <label htmlFor="ontology-chooser" className={style.chooserLabel}>
+          Ontology:
+        </label>
+        <select
+          id="ontology-chooser"
+          className="form-control"
+          style={{ maxWidth: 360, display: 'inline-block' }}
+          value={ontology.id}
+          onChange={(e) => handleOntologyChange(e.target.value)}
+        >
+          {ONTOLOGIES.map((o) => (
+            <option key={o.id} value={o.id}>
+              {o.label}
+              {o.available ? '' : ' — coming soon'}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {!ontology.available ? (
+        <div className={style.placeholder}>
+          <p>
+            <strong>{ontology.label}</strong> is not yet available in the browser. This ontology has not been indexed
+            into Elasticsearch. Pick another ontology above, or check back once it is loaded.
+          </p>
+        </div>
+      ) : (
+        <>
+          <p style={{ color: '#6c757d' }}>
+            Browsing <strong>{ontology.label}</strong> starting at <strong>{ontology.rootName}</strong> (
+            {ontology.rootCurie}). Use the search box to jump to any term.
+          </p>
+
+          <div className={style.searchRow}>
+            <OntologySearchBox
+              onSelect={handleSelect}
+              category={ontology.searchCategory}
+              placeholder={`Search ${ontology.label} terms`}
+            />
+          </div>
+
+          <div className={style.legend}>
+            <span className={style.legendLabel}>Annotation Available:</span>
+            {ANNOTATION_TYPES.map((t) => (
+              <span
+                key={t.id}
+                className={style.legendItem}
+                style={{ background: t.bg, color: t.fg }}
+              >
+                {t.label}
+              </span>
+            ))}
+          </div>
+
+          <div className={style.layout}>
+            <div className={style.treePane}>
+              <OntologyTree
+                rootCurie={ontology.rootCurie}
+                rootName={ontology.rootName}
+                forceExpanded={forceExpanded}
+                focusedCurie={focusedCurie}
+                onSelect={handleTreeSelect}
+                scrollOnFocus={!fromTree}
+              />
+            </div>
+            <div className={style.detailPane}>
+              <TermDetailPanel curie={detailCurie} />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+    </TermsProvider>
+    </CountsProvider>
+  );
+};
+
+export default OntologyBrowser;

--- a/src/containers/ontologyBrowser/browse/ontologies.js
+++ b/src/containers/ontologyBrowser/browse/ontologies.js
@@ -1,0 +1,24 @@
+// Supported ontologies in the browser. Only entries with `available: true` are
+// backed by data today; the others render a "coming soon" placeholder until
+// they are indexed into Elasticsearch.
+export const ONTOLOGIES = [
+  {
+    id: 'disease',
+    label: 'Disease (DO)',
+    rootCurie: 'DOID:4',
+    rootName: 'disease',
+    searchCategory: 'disease_search_result',
+    available: true,
+  },
+  { id: 'go', label: 'Gene Ontology (GO)', available: false },
+  { id: 'mp', label: 'Mammalian Phenotype (MP)', available: false },
+  { id: 'hp', label: 'Human Phenotype (HP)', available: false },
+  { id: 'wbphenotype', label: 'WormBase Phenotype', available: false },
+  { id: 'anatomy', label: 'Anatomy (UBERON / MA / EMAPA)', available: false },
+  { id: 'eco', label: 'Evidence and Conclusion (ECO)', available: false },
+];
+
+export const DEFAULT_ONTOLOGY_ID = 'disease';
+
+export const getOntology = (id) =>
+  ONTOLOGIES.find((o) => o.id === id) || ONTOLOGIES.find((o) => o.id === DEFAULT_ONTOLOGY_ID);

--- a/src/containers/ontologyBrowser/browse/style.module.scss
+++ b/src/containers/ontologyBrowser/browse/style.module.scss
@@ -1,0 +1,245 @@
+@import '../../../theme.module';
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins';
+
+.page {
+  padding: 1rem 1.25rem;
+  max-width: 1520px;
+  margin: 0 auto;
+}
+
+.layout {
+  display: flex;
+  gap: 1.25rem;
+  flex-direction: column;
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+  }
+}
+
+.treePane {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 1px solid $border-color;
+  border-radius: 4px;
+  padding: 0.75rem 0.5rem;
+  max-height: 70vh;
+  overflow: auto;
+}
+
+.detailPane {
+  flex: 0 0 380px;
+  border: 1px solid $border-color;
+  border-radius: 4px;
+  padding: 1rem;
+  align-self: flex-start;
+}
+
+.searchRow {
+  margin-bottom: 1rem;
+}
+
+.chooserRow {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.chooserLabel {
+  margin: 0;
+  font-weight: 600;
+}
+
+.placeholder {
+  padding: 1.5rem;
+  border: 1px dashed $border-color;
+  border-radius: 4px;
+  color: $gray-700;
+  background: $gray-100;
+}
+
+.node {
+  user-select: none;
+}
+
+.nodeRow {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 2px 4px;
+  border-radius: 3px;
+  cursor: pointer;
+
+  &:hover {
+    background: $gray-100;
+  }
+}
+
+.nodeRowFocused {
+  background: $primary-100;
+  font-weight: 600;
+
+  &:hover {
+    background: $primary-100;
+  }
+}
+
+.toggle {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: $gray-700;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 0;
+  cursor: pointer;
+
+  &:hover {
+    background: $gray-200;
+    border-color: $gray-400;
+    color: $gray-800;
+  }
+
+  &:focus {
+    outline: none;
+    background: $gray-200;
+    border-color: $primary;
+  }
+}
+
+.toggleSpacer {
+  width: 24px;
+  flex: 0 0 24px;
+}
+
+.children {
+  margin-left: 1.25rem;
+  border-left: 1px dashed $border-color;
+  padding-left: 0.5rem;
+}
+
+.curie {
+  color: $gray-600;
+  font-size: 0.8rem;
+  font-family: monospace;
+}
+
+.countBadge {
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 11px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.countBadgeExpanded {
+  min-width: 0;
+  height: auto;
+  padding: 4px 12px;
+  border-radius: 14px;
+  font-size: 0.85rem;
+}
+
+.countBadgeLink {
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: none;
+    filter: brightness(0.92);
+  }
+}
+
+.badgeRow {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-left: 0.5rem;
+}
+
+.detailBadgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 0.5rem;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.legendLabel {
+  color: $gray-700;
+  margin-right: 4px;
+}
+
+.legendItem {
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.detailTitle {
+  margin: 0 0 0.25rem;
+  font-size: 1.25rem;
+}
+
+.countLine {
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  color: $gray-700;
+}
+
+.detailSection {
+  margin-top: 1rem;
+}
+
+.detailSectionLabel {
+  font-size: 0.75rem;
+  color: $gray-600;
+  text-transform: uppercase;
+  margin-bottom: 0.25rem;
+}
+
+.viewPageButton {
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+
+  :global(.svg-inline--fa) {
+    margin-left: 0.4rem;
+  }
+}
+
+.parentList {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+
+  li {
+    padding: 1px 0;
+  }
+}
+
+.relation {
+  margin-right: 0.6rem;
+}

--- a/src/containers/ontologyBrowser/browse/useDiseaseCounts.jsx
+++ b/src/containers/ontologyBrowser/browse/useDiseaseCounts.jsx
@@ -1,0 +1,63 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import fetchData from '../../../lib/fetchData';
+
+const Ctx = createContext(null);
+const DEBOUNCE_MS = 40;
+const MAX_BATCH = 200;
+
+export const CountsProvider = ({ children }) => {
+  const [counts, setCounts] = useState({});
+  const pendingRef = useRef(new Set());
+  const inFlightRef = useRef(new Set());
+  const timerRef = useRef(null);
+  const countsRef = useRef(counts);
+
+  useEffect(() => {
+    countsRef.current = counts;
+  }, [counts]);
+
+  const flush = useCallback(async () => {
+    const batch = Array.from(pendingRef.current).slice(0, MAX_BATCH);
+    if (batch.length === 0) return;
+    batch.forEach((id) => {
+      pendingRef.current.delete(id);
+      inFlightRef.current.add(id);
+    });
+    try {
+      const data = await fetchData(`/api/disease/counts?ids=${encodeURIComponent(batch.join(','))}`);
+      setCounts((prev) => ({ ...prev, ...(data || {}) }));
+    } catch {
+      // leave the curies un-resolved; CountBadge renders nothing for them
+    } finally {
+      batch.forEach((id) => inFlightRef.current.delete(id));
+    }
+    if (pendingRef.current.size > 0) {
+      timerRef.current = setTimeout(flush, DEBOUNCE_MS);
+    }
+  }, []);
+
+  const request = useCallback(
+    (curie) => {
+      if (!curie) return;
+      if (countsRef.current[curie]) return;
+      if (inFlightRef.current.has(curie) || pendingRef.current.has(curie)) return;
+      pendingRef.current.add(curie);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(flush, DEBOUNCE_MS);
+    },
+    [flush]
+  );
+
+  return <Ctx.Provider value={{ counts, request }}>{children}</Ctx.Provider>;
+};
+
+CountsProvider.propTypes = { children: PropTypes.node };
+
+export const useDiseaseCounts = (curie) => {
+  const ctx = useContext(Ctx);
+  useEffect(() => {
+    if (ctx && curie) ctx.request(curie);
+  }, [ctx, curie]);
+  return ctx?.counts?.[curie] || null;
+};

--- a/src/containers/ontologyBrowser/browse/useDiseaseTerms.jsx
+++ b/src/containers/ontologyBrowser/browse/useDiseaseTerms.jsx
@@ -1,0 +1,70 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import fetchData from '../../../lib/fetchData';
+
+// Batches disease term-doc fetches across all tree nodes so the page only
+// makes a few round-trips even when many nodes are visible. Each TreeNode
+// calls useDiseaseTerm(curie) on mount; the provider debounces and pulls
+// many ids in one /api/disease/batch request.
+
+const Ctx = createContext(null);
+const DEBOUNCE_MS = 40;
+const MAX_BATCH = 200;
+
+export const TermsProvider = ({ children }) => {
+  const [terms, setTerms] = useState({});
+  const pendingRef = useRef(new Set());
+  const inFlightRef = useRef(new Set());
+  const timerRef = useRef(null);
+  const termsRef = useRef(terms);
+
+  useEffect(() => {
+    termsRef.current = terms;
+  }, [terms]);
+
+  const flush = useCallback(async () => {
+    const batch = Array.from(pendingRef.current).slice(0, MAX_BATCH);
+    if (batch.length === 0) return;
+    batch.forEach((id) => {
+      pendingRef.current.delete(id);
+      inFlightRef.current.add(id);
+    });
+    try {
+      const data = await fetchData(
+        `/api/disease/batch?ids=${encodeURIComponent(batch.join(','))}`
+      );
+      setTerms((prev) => ({ ...prev, ...(data || {}) }));
+    } catch {
+      // unresolved terms stay undefined; TreeNode will show arrow optimistically
+    } finally {
+      batch.forEach((id) => inFlightRef.current.delete(id));
+    }
+    if (pendingRef.current.size > 0) {
+      timerRef.current = setTimeout(flush, DEBOUNCE_MS);
+    }
+  }, []);
+
+  const request = useCallback(
+    (curie) => {
+      if (!curie) return;
+      if (termsRef.current[curie]) return;
+      if (inFlightRef.current.has(curie) || pendingRef.current.has(curie)) return;
+      pendingRef.current.add(curie);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(flush, DEBOUNCE_MS);
+    },
+    [flush]
+  );
+
+  return <Ctx.Provider value={{ terms, request }}>{children}</Ctx.Provider>;
+};
+
+TermsProvider.propTypes = { children: PropTypes.node };
+
+export const useDiseaseTerm = (curie) => {
+  const ctx = useContext(Ctx);
+  useEffect(() => {
+    if (ctx && curie) ctx.request(curie);
+  }, [ctx, curie]);
+  return ctx?.terms?.[curie] || null;
+};

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -18,6 +18,7 @@ import ReferencePage from './containers/referencePage/index.jsx';
 import MODLanding from './containers/modLanding/Main.jsx';
 import DiseasePortalPage from './containers/diseasePortal/index.jsx';
 import BlastPage from './containers/blastPage/index.jsx';
+import OntologyBrowser from './containers/ontologyBrowser/browse/index.jsx';
 
 const WordpressRedirect = () => {
   const { slug } = useParams();
@@ -48,6 +49,10 @@ const LayoutWithRoutes = () => (
 
       <Route exact path="/disease-portal" element={<DiseasePortalPage name="human" />} />
       <Route exact path="/disease-portal/:name" element={<DiseasePortalPage />} />
+
+      <Route exact path="/ontology" element={<Navigate replace to="/ontology/disease" />} />
+      <Route exact path="/ontology/:ontology" element={<OntologyBrowser />} />
+      <Route exact path="/ontology/:ontology/:id" element={<OntologyBrowser />} />
 
       <Route exact path="/wordpress/:slug" component={WordpressRedirect} />
       <Route path="/:slug" element={<WordpressPage />} />


### PR DESCRIPTION
## Summary
Adds a new disease ontology browser page at `/ontology/disease`:
- Collapsible tree view with batched term + count fetching
- Autosuggest search with full-results modal
- Term detail panel (definition, parents, synonyms, xrefs, annotation counts)
- New "Browse Ontology" entry on the disease page that deep-links into the browser at the current term

Also extends `PageNav` to support count badges and external links (used by the new disease-page entry).

Depends on **KANBAN-1322 in agr_java_software** (https://github.com/alliance-genome/agr_java_software/pull/1610) for the matching `/api/disease/batch`, `/api/disease/counts`, and `/api/disease/{id}/ancestors` endpoints. Merge that one first.

## Test plan
- [ ] `/ontology/disease` loads, top-level DOID terms render
- [ ] Clicking a term expands children; counts appear as badges
- [ ] Search box autosuggests after 2+ chars; "View all results" opens the modal
- [ ] Term detail panel shows definition, parents, synonyms, xrefs
- [ ] Disease page (e.g. `/disease/DOID:14330`) shows "Browse Ontology" in left nav and navigates to the browser at that term

Generated with Claude Code (https://claude.com/claude-code)
