### PR TITLE
KANBAN-678 add reference report sections

### DIFF
--- a/src/components/dataPage/pageNav.jsx
+++ b/src/components/dataPage/pageNav.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import { Collapse } from 'reactstrap';
 import Scrollspy from 'react-scrollspy';
@@ -27,19 +28,40 @@ const PageNav = ({ children, sections }) => {
             className={`list-group list-group-flush ${style.scrollSpy}`}
             componentTag="div"
             currentClassName="active"
-            items={sections.map(({ name }) => makeId(name))}
+            items={sections.filter((s) => !s.to).map(({ name }) => makeId(name))}
           >
-            {sections.map(({ name: section, level = 0 }) => {
-              const style = { paddingLeft: `${level + 1}em`, border: 'none' };
+            {sections.map(({ name: section, level = 0, count, to }) => {
+              const itemStyle = { paddingLeft: `${level + 1}em` };
+              const hasCount = count !== undefined && count !== null;
+              const badgeClass = `${style.navBadge} ${count === 0 ? style.navBadgeZero : ''}`;
+              const inner = (
+                <>
+                  <span>{section}</span>
+                  {hasCount && <span className={badgeClass}>{count.toLocaleString()}</span>}
+                </>
+              );
+              if (to) {
+                return (
+                  <Link
+                    className={`list-group-item list-group-item-action ${style.navItem}`}
+                    key={section}
+                    onClick={() => setIsOpen(false)}
+                    style={itemStyle}
+                    to={to}
+                  >
+                    {inner}
+                  </Link>
+                );
+              }
               return (
                 <HashLink
-                  className="list-group-item list-group-item-action"
+                  className={`list-group-item list-group-item-action ${style.navItem}`}
                   key={section}
                   onClick={() => setIsOpen(false)}
-                  style={style}
+                  style={itemStyle}
                   to={'#' + makeId(section)}
                 >
-                  {section}
+                  {inner}
                 </HashLink>
               );
             })}
@@ -56,6 +78,8 @@ PageNav.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       level: PropTypes.number,
+      count: PropTypes.number,
+      to: PropTypes.string,
     })
   ),
 };

--- a/src/components/dataPage/style.module.scss
+++ b/src/components/dataPage/style.module.scss
@@ -76,6 +76,28 @@ $page-nav-width: 220px;
   }
 }
 
+.navItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: none;
+}
+
+.navBadge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  background-color: $gray-100;
+  color: $gray-700;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-left: 0.5rem;
+}
+
+.navBadgeZero {
+  color: $gray-500;
+}
+
 .titleTooltip {
   max-width: 100%;
   font-size: 1rem;

--- a/src/containers/referencePage/RelatedPapersList.jsx
+++ b/src/containers/referencePage/RelatedPapersList.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { useQuery, useQueries } from '@tanstack/react-query';
+import fetchData from '../../lib/fetchData';
+
+const fetchCitation = (curie) =>
+  fetchData(`/api/reference/${curie}`)
+    .then((d) => d?.literatureSummary?.short_citation || d?.literatureSummary?.citation || curie)
+    .catch(() => curie);
+
+const RelatedPapersList = ({ referenceId }) => {
+  const [includeOrthologs, setIncludeOrthologs] = useState(false);
+  const related = useQuery({
+    queryKey: ['related-papers', referenceId, includeOrthologs],
+    queryFn: () =>
+      fetchData(
+        `/api/reference/${referenceId}/related-papers?limit=10&includeOrthologs=${includeOrthologs}`
+      ),
+    staleTime: 60_000,
+  });
+
+  const results = related.data?.results || [];
+
+  const citations = useQueries({
+    queries: results.map((r) => ({
+      queryKey: ['citation', r.referenceCurie],
+      queryFn: () => fetchCitation(r.referenceCurie),
+      staleTime: 5 * 60_000,
+    })),
+  });
+
+  if (related.isLoading) return <div style={{ color: '#6c757d' }}>Loading related papers…</div>;
+  if (!results.length) return <div style={{ color: '#6c757d' }}>No related papers found.</div>;
+
+  return (
+    <>
+      <div style={{ marginBottom: 8 }}>
+        <label style={{ fontSize: '0.875rem', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={includeOrthologs}
+            onChange={(e) => setIncludeOrthologs(e.target.checked)}
+            style={{ marginRight: 6 }}
+          />
+          Include cross-species papers (expand via orthology)
+        </label>
+      </div>
+      <div style={{ fontSize: '0.75rem', color: '#6c757d', marginBottom: 8 }}>
+        {includeOrthologs
+          ? 'Gene set expanded via ortholog object-gene lookup; a match includes papers that cite an ortholog of any focus gene.'
+          : 'Exact-match only. Ortholog matches are not counted — genes must share the exact curie.'}
+      </div>
+      <ol style={{ paddingLeft: 20, marginBottom: 0 }}>
+        {results.map((r, i) => {
+          const citation = citations[i].data;
+          const species = r.sharedSpecies || [];
+          return (
+            <li key={r.referenceCurie} style={{ marginBottom: 6 }}>
+              <Link to={`/reference/${r.referenceCurie}`}>
+                <span dangerouslySetInnerHTML={{ __html: citation || r.referenceCurie }} />
+              </Link>{' '}
+              <span
+                style={{ fontSize: '0.75rem', color: '#6c757d' }}
+                title={`${r.sharedGenes} of ${r.focusGeneCount} focus genes shared. Candidate has ${r.candidateGeneCount} genes total.`}
+              >
+                ({r.sharedGenes} shared gene{r.sharedGenes === 1 ? '' : 's'}, Jaccard {r.jaccard.toFixed(2)})
+              </span>
+              {species.length > 0 && (
+                <>
+                  {' — '}
+                  <strong>{species.join(', ')}</strong>
+                </>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </>
+  );
+};
+
+RelatedPapersList.propTypes = {
+  referenceId: PropTypes.string.isRequired,
+};
+
+export default RelatedPapersList;

--- a/src/containers/referencePage/index.jsx
+++ b/src/containers/referencePage/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useQueries } from '@tanstack/react-query';
 import NotFound from '../../components/notFound.jsx';
 import HeadMetaTags from '../../components/headMetaTags.jsx';
 import SpeciesIcon from '../../components/speciesIcon/index.jsx';
@@ -10,8 +11,19 @@ import { CollapsibleList } from '../../components/collapsibleList';
 import NoData from '../../components/noData.jsx';
 import PageCategoryLabel from '../../components/dataPage/PageCategoryLabel.jsx';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
+import fetchData from '../../lib/fetchData';
 import ReferenceSummary from './ReferenceSummary.jsx';
 import ApplySpeciesNameFormat from './SpeciesFinderFormatter.jsx';
+import ReferenceDiseaseTable from './tables/ReferenceDiseaseTable.jsx';
+import ReferencePhenotypeTable from './tables/ReferencePhenotypeTable.jsx';
+import ReferenceExpressionTable from './tables/ReferenceExpressionTable.jsx';
+import ReferenceInteractionTable from './tables/ReferenceInteractionTable.jsx';
+import ReferenceGeneticInteractionTable from './tables/ReferenceGeneticInteractionTable.jsx';
+import ReferenceOrthologyTable from './tables/ReferenceOrthologyTable.jsx';
+import RelatedPapersList from './RelatedPapersList.jsx';
+import ReferenceGeneTable from './tables/ReferenceGeneTable.jsx';
+import ReferenceAlleleTable from './tables/ReferenceAlleleTable.jsx';
+import ReferenceModelTable from './tables/ReferenceModelTable.jsx';
 import { useParams } from 'react-router-dom';
 import { getSingleReferenceUrl } from '../../components/dataTable/utils.jsx';
 import styles from './style.module.scss';
@@ -20,7 +32,45 @@ import styles from './style.module.scss';
 const CITATION = 'Citation';
 const SUMMARY = 'Summary';
 const ABSTRACT = 'Abstract';
-const SECTIONS = [{ name: SUMMARY }, { name: ABSTRACT }];
+const GENES = 'Genes';
+const ALLELES_AND_VARIANTS = 'Alleles and Variants';
+const MODELS = 'Models';
+const DISEASE_ASSOCIATIONS = 'Disease Associations';
+const PHENOTYPES = 'Phenotypes';
+const EXPRESSION = 'Expression';
+const MOLECULAR_INTERACTIONS = 'Molecular Interactions';
+const GENETIC_INTERACTIONS = 'Genetic Interactions';
+const ORTHOLOGY = 'Orthology';
+const RELATED_PAPERS = 'Related Papers';
+const totalUrl = (base) => {
+  const sep = base.includes('?') ? '&' : '?';
+  return `${base}${sep}limit=0`;
+};
+
+function useSectionCounts(referenceId, crossReferenceCuries) {
+  const xrefParam = crossReferenceCuries.length
+    ? `?crossReferences=${encodeURIComponent(crossReferenceCuries.join(','))}`
+    : '';
+  const countable = [
+    { name: GENES, url: `/api/reference/${referenceId}/genes` },
+    { name: ORTHOLOGY, url: `/api/reference/${referenceId}/orthology` },
+    { name: PHENOTYPES, url: `/api/reference/${referenceId}/phenotype-annotations` },
+    { name: DISEASE_ASSOCIATIONS, url: `/api/reference/${referenceId}/disease-annotations` },
+    { name: ALLELES_AND_VARIANTS, url: `/api/reference/${referenceId}/alleles` },
+    { name: MODELS, url: `/api/reference/${referenceId}/models` },
+    { name: EXPRESSION, url: `/api/reference/${referenceId}/expression-annotations${xrefParam}` },
+    { name: MOLECULAR_INTERACTIONS, url: `/api/reference/${referenceId}/molecular-interactions${xrefParam}` },
+    { name: GENETIC_INTERACTIONS, url: `/api/reference/${referenceId}/genetic-interactions${xrefParam}` },
+  ];
+  const queries = useQueries({
+    queries: countable.map((s) => ({
+      queryKey: ['ref-section-count', referenceId, s.name, s.url],
+      queryFn: () => fetchData(totalUrl(s.url)).then((d) => d?.total ?? 0),
+      staleTime: 60_000,
+    })),
+  });
+  return Object.fromEntries(countable.map((s, i) => [s.name, queries[i].data]));
+}
 
 const modMap = {
   FB: 'flybase',
@@ -86,15 +136,23 @@ const ModSprites = ({ xrefs, size }) => {
 const ReferencePage = () => {
   const { id: referenceId } = useParams();
   const { data, isLoading, isError } = usePageLoadingQuery(`/api/reference/${referenceId}`);
-  // const { data, isLoading, isError } = usePageLoadingQuery(    `https://literature-rest.alliancegenome.org/reference/${referenceId}`  );
+
+  const crossReferenceCuries = React.useMemo(
+    () =>
+      (data?.literatureSummary?.cross_references || [])
+        .map((x) => x.curie)
+        .filter(Boolean),
+    [data]
+  );
+  const counts = useSectionCounts(referenceId, crossReferenceCuries);
+
   if (isError) {
     return <NotFound />;
   }
-  if (isLoading) {
+  if (isLoading || !data) {
     return null;
   }
   const ref = data.literatureSummary;
-  // const ref = data;
 
   // separate xrefs into mod xrefs and external xrefs here, and attach them to ref object
   ref.modXrefs = [];
@@ -104,7 +162,20 @@ const ReferencePage = () => {
       ref.modXrefs.push(ref.cross_references[xr]);
     else ref.extXrefs.push(ref.cross_references[xr]);
   }
-  // console.log(ref.modXrefs);
+  const sections = [
+    { name: SUMMARY },
+    { name: ABSTRACT },
+    { name: GENES, count: counts[GENES] },
+    { name: ORTHOLOGY, count: counts[ORTHOLOGY] },
+    { name: PHENOTYPES, count: counts[PHENOTYPES] },
+    { name: DISEASE_ASSOCIATIONS, count: counts[DISEASE_ASSOCIATIONS] },
+    { name: ALLELES_AND_VARIANTS, count: counts[ALLELES_AND_VARIANTS] },
+    { name: MODELS, count: counts[MODELS] },
+    { name: EXPRESSION, count: counts[EXPRESSION] },
+    { name: MOLECULAR_INTERACTIONS, count: counts[MOLECULAR_INTERACTIONS] },
+    { name: GENETIC_INTERACTIONS, count: counts[GENETIC_INTERACTIONS] },
+    { name: RELATED_PAPERS },
+  ];
 
   const FormattedAbstract = ({ abstract }) => {
     if (!abstract) return <NoData>Not Available</NoData>;
@@ -117,7 +188,7 @@ const ReferencePage = () => {
     <DataPage>
       <HeadMetaTags title={ref.title} />
 
-      <PageNav sections={SECTIONS}>
+      <PageNav sections={sections}>
         <PageNavEntity>
           <ModSprites xrefs={ref.modXrefs} size="48" />
         </PageNavEntity>
@@ -138,6 +209,36 @@ const ReferencePage = () => {
         </Subsection>
         <Subsection title={ABSTRACT}>
           <FormattedAbstract abstract={ref.abstract} />
+        </Subsection>
+        <Subsection title={GENES}>
+          <ReferenceGeneTable id={referenceId} />
+        </Subsection>
+        <Subsection title={ORTHOLOGY}>
+          <ReferenceOrthologyTable id={referenceId} />
+        </Subsection>
+        <Subsection title={PHENOTYPES}>
+          <ReferencePhenotypeTable id={referenceId} />
+        </Subsection>
+        <Subsection title={DISEASE_ASSOCIATIONS}>
+          <ReferenceDiseaseTable id={referenceId} />
+        </Subsection>
+        <Subsection title={ALLELES_AND_VARIANTS}>
+          <ReferenceAlleleTable id={referenceId} />
+        </Subsection>
+        <Subsection title={MODELS}>
+          <ReferenceModelTable id={referenceId} />
+        </Subsection>
+        <Subsection title={EXPRESSION}>
+          <ReferenceExpressionTable id={referenceId} crossReferences={crossReferenceCuries} />
+        </Subsection>
+        <Subsection title={MOLECULAR_INTERACTIONS}>
+          <ReferenceInteractionTable id={referenceId} crossReferences={crossReferenceCuries} />
+        </Subsection>
+        <Subsection title={GENETIC_INTERACTIONS}>
+          <ReferenceGeneticInteractionTable id={referenceId} crossReferences={crossReferenceCuries} />
+        </Subsection>
+        <Subsection title={RELATED_PAPERS}>
+          <RelatedPapersList referenceId={referenceId} />
         </Subsection>
       </PageData>
     </DataPage>

--- a/src/containers/referencePage/tables/ReferenceAlleleTable.jsx
+++ b/src/containers/referencePage/tables/ReferenceAlleleTable.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { SpeciesCell } from '../../../components/dataTable';
+import createReferenceTable from './createReferenceTable.jsx';
+
+const synonymNames = (allele) => {
+  const syns = allele.alleleSynonyms || allele.synonyms || [];
+  return syns.map((s) => s.displayText || s.name || s).filter(Boolean);
+};
+
+const columns = [
+  {
+    dataField: 'species',
+    text: 'Species',
+    headerStyle: { width: '130px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'symbol',
+    text: 'Symbol',
+    headerStyle: { width: '160px' },
+    formatter: (symbol, row) => (
+      <Link to={`/allele/${row.curie}`}>
+        <span dangerouslySetInnerHTML={{ __html: symbol || row.curie }} />
+      </Link>
+    ),
+  },
+  {
+    dataField: 'synonyms',
+    text: 'Synonyms',
+    headerStyle: { width: '200px' },
+    formatter: (syns) =>
+      syns && syns.length ? <span dangerouslySetInnerHTML={{ __html: syns.join(', ') }} /> : null,
+  },
+  { dataField: 'mutationType', text: 'Mutation type', headerStyle: { width: '150px' } },
+  { dataField: 'molecularConsequence', text: 'Molecular consequence', headerStyle: { width: '180px' } },
+  { dataField: 'source', text: 'Source', headerStyle: { width: '100px' } },
+];
+
+const ReferenceAlleleTable = createReferenceTable({
+  displayName: 'ReferenceAlleleTable',
+  endpoint: 'alleles',
+  columns,
+  transform: (allele) => ({
+    species: allele.taxon,
+    symbol: allele.alleleSymbol?.displayText,
+    synonyms: synonymNames(allele),
+    mutationType: allele.alleleMutationTypes
+      ?.map((m) => m.mutationTypes?.map((t) => t.name))
+      .flat()
+      .filter(Boolean)
+      .join(', '),
+    molecularConsequence: allele.alleleMolecularConsequences
+      ?.map((c) => c.molecularConsequence?.name)
+      .filter(Boolean)
+      .join(', '),
+    source:
+      allele.dataProvider?.abbreviation ||
+      allele.dataProviderCrossReference?.resourceDescriptorPage?.resourceDescriptor?.name,
+    curie: allele.primaryExternalId,
+  }),
+});
+
+export default ReferenceAlleleTable;

--- a/src/containers/referencePage/tables/ReferenceDiseaseTable.jsx
+++ b/src/containers/referencePage/tables/ReferenceDiseaseTable.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import {
+  BasedOnGeneCellCuration,
+  EvidenceCodesCellCuration,
+  GeneCellCuration,
+  SpeciesCell,
+} from '../../../components/dataTable';
+import AssociationType from '../../../components/AssociationType.jsx';
+import DiseaseLinkCuration from '../../../components/disease/DiseaseLinkCuration.jsx';
+import DiseaseQualifiersColumn from '../../../components/dataTable/DiseaseQualifiersColumn.jsx';
+import ProvidersCellCuration from '../../../components/dataTable/ProvidersCellCuration.jsx';
+import { getIdentifier } from '../../../components/dataTable/utils.jsx';
+import createReferenceTable from './createReferenceTable.jsx';
+
+const subjectFormatter = (subject) => {
+  if (!subject) return null;
+  const identifier = getIdentifier(subject);
+  if (subject.type === 'Gene') {
+    return <GeneCellCuration identifier={identifier} gene={subject} />;
+  }
+  const label = subject.alleleSymbol?.displayText || subject.name || identifier;
+  return <span dangerouslySetInnerHTML={{ __html: label }} />;
+};
+
+const columns = [
+  {
+    dataField: 'species',
+    text: 'Species',
+    filterable: true,
+    filterName: 'species',
+    headerStyle: { width: '100px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'subject',
+    text: 'Gene / Allele / Model',
+    headerStyle: { width: '150px' },
+    formatter: subjectFormatter,
+  },
+  {
+    dataField: 'generatedRelationString',
+    text: 'Association',
+    filterable: true,
+    filterName: 'associationType',
+    headerStyle: { width: '120px' },
+    formatter: (type) => <AssociationType type={type} />,
+  },
+  {
+    dataField: 'diseaseQualifiers',
+    text: 'Disease Qualifier',
+    headerStyle: { width: '100px' },
+    formatter: (qualifiers) => <DiseaseQualifiersColumn qualifiers={qualifiers} />,
+  },
+  {
+    dataField: 'disease',
+    text: 'Disease',
+    filterable: true,
+    filterName: 'disease',
+    headerStyle: { width: '150px' },
+    formatter: (disease) => disease && <DiseaseLinkCuration disease={disease} />,
+  },
+  {
+    dataField: 'evidenceCodes',
+    text: 'Evidence',
+    filterable: true,
+    filterName: 'evidenceCode',
+    headerStyle: { width: '100px' },
+    formatter: (codes) => <EvidenceCodesCellCuration evidenceCodes={codes} />,
+  },
+  {
+    dataField: 'providers',
+    text: 'Source',
+    filterable: true,
+    filterName: 'dataProvider',
+    headerStyle: { width: '100px' },
+    formatter: (providers) => providers && <ProvidersCellCuration providers={providers} />,
+  },
+  {
+    dataField: 'basedOnGenes',
+    text: 'Based On',
+    headerStyle: { width: '100px' },
+    formatter: BasedOnGeneCellCuration,
+  },
+];
+
+const ReferenceDiseaseTable = createReferenceTable({
+  displayName: 'ReferenceDiseaseTable',
+  endpoint: 'disease-annotations',
+  columns,
+  transform: (record) => ({
+    ...record,
+    disease: record.object,
+    species: record.subject?.taxon,
+  }),
+});
+
+export default ReferenceDiseaseTable;

--- a/src/containers/referencePage/tables/ReferenceExpressionTable.jsx
+++ b/src/containers/referencePage/tables/ReferenceExpressionTable.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { GeneCellCuration, SpeciesCell } from '../../../components/dataTable';
+import createReferenceTable from './createReferenceTable.jsx';
+
+const dataProviderFormatter = (provider, row) => {
+  if (!provider) return null;
+  const abbr = provider.abbreviation;
+  const xref = row.geneExpressionAnnotation?.dataProviderCrossReference?.referencedCurie;
+  return <span>{abbr}{xref ? `: ${xref}` : ''}</span>;
+};
+
+const columns = [
+  {
+    dataField: 'species',
+    text: 'Species',
+    headerStyle: { width: '120px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'gene',
+    text: 'Gene',
+    headerStyle: { width: '120px' },
+    formatter: (gene) => gene && <GeneCellCuration gene={gene} />,
+  },
+  { dataField: 'location', text: 'Location', headerStyle: { width: '180px' } },
+  { dataField: 'stage', text: 'Stage', headerStyle: { width: '120px' } },
+  { dataField: 'assay', text: 'Assay', headerStyle: { width: '140px' } },
+  {
+    dataField: 'dataProvider',
+    text: 'Source',
+    headerStyle: { width: '120px' },
+    formatter: dataProviderFormatter,
+  },
+];
+
+const ReferenceExpressionTable = createReferenceTable({
+  displayName: 'ReferenceExpressionTable',
+  endpoint: 'expression-annotations',
+  supportsCrossReferences: true,
+  columns,
+  transform: (record) => {
+    const gea = record.geneExpressionAnnotation || {};
+    return {
+      ...record,
+      gene: gea.expressionAnnotationSubject,
+      species: gea.expressionAnnotationSubject?.taxon,
+      location: gea.whereExpressedStatement,
+      stage: gea.whenExpressedStageName,
+      assay: gea.expressionAssayUsed?.name,
+      dataProvider: gea.dataProvider,
+      annotation: gea,
+    };
+  },
+});
+
+export default ReferenceExpressionTable;

--- a/src/containers/referencePage/tables/ReferenceGeneTable.jsx
+++ b/src/containers/referencePage/tables/ReferenceGeneTable.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { SpeciesCell } from '../../../components/dataTable';
+import createReferenceTable from './createReferenceTable.jsx';
+
+const formatLocation = (gene) => {
+  const assoc = gene.geneGenomicLocationAssociations?.[0];
+  if (!assoc) return null;
+  const loc = assoc.geneGenomicLocationAssociationObject || assoc;
+  const chrom = loc.chromosome || loc.chromosomeAccession;
+  const start = loc.start ?? loc.startPosition;
+  const end = loc.end ?? loc.endPosition;
+  if (!chrom) return null;
+  if (start && end) return `${chrom}:${start}-${end}`;
+  return chrom;
+};
+
+const columns = [
+  {
+    dataField: 'species',
+    text: 'Species',
+    headerStyle: { width: '130px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'symbol',
+    text: 'Symbol',
+    headerStyle: { width: '120px' },
+    formatter: (symbol, row) => (
+      <Link to={`/gene/${row.curie}`}>
+        <span dangerouslySetInnerHTML={{ __html: symbol || row.curie }} />
+      </Link>
+    ),
+  },
+  {
+    dataField: 'name',
+    text: 'Name',
+    headerStyle: { width: '220px' },
+    formatter: (n) => n && <span dangerouslySetInnerHTML={{ __html: n }} />,
+  },
+  { dataField: 'biotype', text: 'Biotype', headerStyle: { width: '120px' } },
+  { dataField: 'location', text: 'Genome location', headerStyle: { width: '160px' } },
+];
+
+const ReferenceGeneTable = createReferenceTable({
+  displayName: 'ReferenceGeneTable',
+  endpoint: 'genes',
+  columns,
+  transform: (gene) => ({
+    species: gene.taxon,
+    symbol: gene.geneSymbol?.displayText,
+    name: gene.geneFullName?.displayText,
+    biotype: gene.geneType?.name,
+    location: formatLocation(gene),
+    curie: gene.primaryExternalId,
+  }),
+});
+
+export default ReferenceGeneTable;

--- a/src/containers/referencePage/tables/ReferenceGeneticInteractionTable.jsx
+++ b/src/containers/referencePage/tables/ReferenceGeneticInteractionTable.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { GeneCellCuration, SpeciesCell } from '../../../components/dataTable';
+import createReferenceTable from './createReferenceTable.jsx';
+import { namesList, sourceFormatter } from './utils.jsx';
+
+const columns = [
+  {
+    dataField: 'species',
+    text: 'Species',
+    headerStyle: { width: '110px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'gene',
+    text: 'Gene',
+    headerStyle: { width: '110px' },
+    formatter: (gene) => gene && <GeneCellCuration gene={gene} />,
+  },
+  { dataField: 'geneRole', text: 'Gene role', headerStyle: { width: '110px' } },
+  { dataField: 'geneticPerturbation', text: 'Genetic perturbation', headerStyle: { width: '150px' } },
+  {
+    dataField: 'interactorSpecies',
+    text: 'Interactor species',
+    headerStyle: { width: '120px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'interactorGene',
+    text: 'Interactor gene',
+    headerStyle: { width: '120px' },
+    formatter: (gene) => gene && <GeneCellCuration gene={gene} />,
+  },
+  { dataField: 'interactorRole', text: 'Interactor role', headerStyle: { width: '120px' } },
+  {
+    dataField: 'interactorGeneticPerturbation',
+    text: 'Interactor genetic perturbation',
+    headerStyle: { width: '180px' },
+  },
+  { dataField: 'interactionType', text: 'Interaction type', headerStyle: { width: '140px' } },
+  { dataField: 'phenotypeOrTrait', text: 'Phenotype or trait', headerStyle: { width: '160px' } },
+  {
+    dataField: 'evidence',
+    text: 'Source',
+    headerStyle: { width: '140px' },
+    formatter: sourceFormatter,
+  },
+];
+
+const ReferenceGeneticInteractionTable = createReferenceTable({
+  displayName: 'ReferenceGeneticInteractionTable',
+  endpoint: 'genetic-interactions',
+  supportsCrossReferences: true,
+  columns,
+  transform: (record) => {
+    const ggi = record.geneGeneticInteraction || {};
+    return {
+      ...record,
+      gene: ggi.geneAssociationSubject,
+      species: ggi.geneAssociationSubject?.taxon,
+      geneRole: ggi.interactorARole?.name,
+      geneticPerturbation: namesList(ggi.interactorAGeneticPerturbations),
+      interactorGene: ggi.geneGeneAssociationObject,
+      interactorSpecies: ggi.geneGeneAssociationObject?.taxon,
+      interactorRole: ggi.interactorBRole?.name,
+      interactorGeneticPerturbation: namesList(ggi.interactorBGeneticPerturbations),
+      interactionType: ggi.interactionType?.name,
+      phenotypeOrTrait: ggi.phenotypesOrTraits
+        ?.map((p) => p.name || p.statement)
+        .filter(Boolean)
+        .join(', '),
+      evidence: ggi.evidence,
+    };
+  },
+});
+
+export default ReferenceGeneticInteractionTable;

--- a/src/containers/referencePage/tables/ReferenceInteractionTable.jsx
+++ b/src/containers/referencePage/tables/ReferenceInteractionTable.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { GeneCellCuration, SpeciesCell } from '../../../components/dataTable';
+import createReferenceTable from './createReferenceTable.jsx';
+import { namesList, sourceFormatter } from './utils.jsx';
+
+const columns = [
+  {
+    dataField: 'species',
+    text: 'Species',
+    headerStyle: { width: '110px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'gene',
+    text: 'Gene',
+    headerStyle: { width: '110px' },
+    formatter: (gene) => gene && <GeneCellCuration gene={gene} />,
+  },
+  { dataField: 'moleculeType', text: 'Molecule Type', headerStyle: { width: '120px' } },
+  {
+    dataField: 'interactorSpecies',
+    text: 'Interactor Species',
+    headerStyle: { width: '120px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'interactorGene',
+    text: 'Interactor Gene',
+    headerStyle: { width: '120px' },
+    formatter: (gene) => gene && <GeneCellCuration gene={gene} />,
+  },
+  { dataField: 'detectionMethod', text: 'Detection Method', headerStyle: { width: '160px' } },
+  {
+    dataField: 'evidence',
+    text: 'Source',
+    headerStyle: { width: '150px' },
+    formatter: sourceFormatter,
+  },
+];
+
+const ReferenceInteractionTable = createReferenceTable({
+  displayName: 'ReferenceInteractionTable',
+  endpoint: 'molecular-interactions',
+  supportsCrossReferences: true,
+  columns,
+  transform: (record) => {
+    const gmi = record.geneMolecularInteraction || {};
+    return {
+      ...record,
+      gene: gmi.geneAssociationSubject,
+      species: gmi.geneAssociationSubject?.taxon,
+      interactorGene: gmi.geneGeneAssociationObject,
+      interactorSpecies: gmi.geneGeneAssociationObject?.taxon,
+      moleculeType: namesList(gmi.interactorAType),
+      interactorMoleculeType: namesList(gmi.interactorBType),
+      detectionMethod: namesList(gmi.detectionMethod),
+      evidence: gmi.evidence,
+    };
+  },
+});
+
+export default ReferenceInteractionTable;

--- a/src/containers/referencePage/tables/ReferenceModelTable.jsx
+++ b/src/containers/referencePage/tables/ReferenceModelTable.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { SpeciesCell } from '../../../components/dataTable';
+import ExternalLink from '../../../components/ExternalLink.jsx';
+import createReferenceTable from './createReferenceTable.jsx';
+
+const columns = [
+  {
+    dataField: 'species',
+    text: 'Species',
+    headerStyle: { width: '130px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'name',
+    text: 'Name',
+    headerStyle: { width: '400px' },
+    formatter: (n) => n && <span dangerouslySetInnerHTML={{ __html: n }} />,
+  },
+  { dataField: 'type', text: 'Type', headerStyle: { width: '120px' } },
+  {
+    dataField: 'source',
+    text: 'Source',
+    headerStyle: { width: '140px' },
+    formatter: (source, row) =>
+      row.sourceUrl ? <ExternalLink href={row.sourceUrl}>{row.curie}</ExternalLink> : row.curie,
+  },
+];
+
+const ReferenceModelTable = createReferenceTable({
+  displayName: 'ReferenceModelTable',
+  endpoint: 'models',
+  columns,
+  transform: (agm) => ({
+    species: agm.taxon,
+    name: agm.agmFullName?.displayText || agm.name,
+    type: agm.subtype?.name,
+    curie: agm.primaryExternalId,
+    sourceUrl: agm.dataProviderCrossReference?.resourceDescriptorPage
+      ? (agm.dataProviderCrossReference.resourceDescriptorPage.urlTemplate || '').replace(
+          '[%s]',
+          agm.dataProviderCrossReference.referencedCurie?.replace(/^[^:]+:/, '') || ''
+        )
+      : null,
+    source: agm.dataProviderCrossReference?.resourceDescriptorPage?.resourceDescriptor?.name,
+  }),
+});
+
+export default ReferenceModelTable;

--- a/src/containers/referencePage/tables/ReferenceOrthologyTable.jsx
+++ b/src/containers/referencePage/tables/ReferenceOrthologyTable.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { SpeciesCell } from '../../../components/dataTable';
+import createReferenceTable from './createReferenceTable.jsx';
+
+const geneLink = (gene) => {
+  if (!gene) return null;
+  const id = gene.primaryExternalId;
+  const symbol = gene.geneSymbol?.displayText || id;
+  return (
+    <Link to={`/gene/${id}`}>
+      <span dangerouslySetInnerHTML={{ __html: symbol }} />
+    </Link>
+  );
+};
+
+const methodsCell = (predictionMethods) =>
+  (predictionMethods || []).map((m) => m.name || m).filter(Boolean).join(', ');
+
+const columns = [
+  {
+    dataField: 'subjectSpecies',
+    text: 'Species',
+    headerStyle: { width: '120px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'subjectGene',
+    text: 'Gene',
+    headerStyle: { width: '120px' },
+    formatter: geneLink,
+  },
+  {
+    dataField: 'objectSpecies',
+    text: 'Ortholog species',
+    headerStyle: { width: '140px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'objectGene',
+    text: 'Ortholog gene',
+    headerStyle: { width: '140px' },
+    formatter: geneLink,
+  },
+  { dataField: 'confidence', text: 'Confidence', headerStyle: { width: '100px' } },
+  { dataField: 'methods', text: 'Prediction methods matched', headerStyle: { width: '260px' } },
+];
+
+const ReferenceOrthologyTable = createReferenceTable({
+  displayName: 'ReferenceOrthologyTable',
+  endpoint: 'orthology',
+  columns,
+  transform: (record) => {
+    const g = record.geneToGeneOrthologyGenerated || {};
+    return {
+      subjectGene: g.subjectGene,
+      subjectSpecies: g.subjectGene?.taxon,
+      objectGene: g.objectGene,
+      objectSpecies: g.objectGene?.taxon,
+      confidence: g.confidence?.name,
+      methods: methodsCell(g.predictionMethodsMatched),
+    };
+  },
+});
+
+export default ReferenceOrthologyTable;

--- a/src/containers/referencePage/tables/ReferencePhenotypeTable.jsx
+++ b/src/containers/referencePage/tables/ReferencePhenotypeTable.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { GeneCellCuration, SpeciesCell } from '../../../components/dataTable';
+import { getIdentifier } from '../../../components/dataTable/utils.jsx';
+import createReferenceTable from './createReferenceTable.jsx';
+
+const subjectFormatter = (subject) => {
+  if (!subject) return null;
+  const identifier = getIdentifier(subject);
+  if (subject.type === 'Gene') {
+    return <GeneCellCuration identifier={identifier} gene={subject} />;
+  }
+  const label = subject.alleleSymbol?.displayText || subject.name || identifier;
+  return <span dangerouslySetInnerHTML={{ __html: label }} />;
+};
+
+const columns = [
+  {
+    dataField: 'species',
+    text: 'Species',
+    filterable: true,
+    filterName: 'species',
+    headerStyle: { width: '120px' },
+    formatter: (species) => species && <SpeciesCell species={species} />,
+  },
+  {
+    dataField: 'subject',
+    text: 'Name (Gene / Allele / AGM)',
+    headerStyle: { width: '180px' },
+    formatter: subjectFormatter,
+  },
+  {
+    dataField: 'phenotypeStatement',
+    text: 'Phenotype Term',
+    filterable: true,
+    filterName: 'phenotype',
+    headerStyle: { width: '300px' },
+  },
+  {
+    dataField: 'category',
+    text: 'Type',
+    headerStyle: { width: '160px' },
+    formatter: (cat) => {
+      if (cat === 'gene_phenotype_annotation') return 'Gene';
+      if (cat === 'allele_phenotype_annotation') return 'Allele';
+      if (cat === 'agm_phenotype_annotation') return 'AGM';
+      return cat;
+    },
+  },
+  {
+    dataField: 'experimentalConditionsAggregated',
+    text: 'Experimental Condition',
+    headerStyle: { width: '200px' },
+  },
+];
+
+const ReferencePhenotypeTable = createReferenceTable({
+  displayName: 'ReferencePhenotypeTable',
+  endpoint: 'phenotype-annotations',
+  columns,
+  transform: (record) => ({
+    ...record,
+    species: record.subject?.taxon,
+  }),
+});
+
+export default ReferencePhenotypeTable;

--- a/src/containers/referencePage/tables/createReferenceTable.jsx
+++ b/src/containers/referencePage/tables/createReferenceTable.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import hash from 'object-hash';
+import { DataTable } from '../../../components/dataTable';
+import useDataTableQuery from '../../../hooks/useDataTableQuery';
+
+const createReferenceTable = ({ endpoint, transform, columns, displayName, supportsCrossReferences = false }) => {
+  const Table = ({ id, crossReferences = [] }) => {
+    const queryParams =
+      supportsCrossReferences && crossReferences.length
+        ? `?crossReferences=${encodeURIComponent(crossReferences.join(','))}`
+        : '';
+    const tableQuery = useDataTableQuery(`/api/reference/${id}/${endpoint}${queryParams}`);
+    const data = (tableQuery.data || []).map((record) => ({
+      ...transform(record),
+      id: hash(record),
+    }));
+    return <DataTable {...tableQuery} data={data} columns={columns} keyField="id" />;
+  };
+
+  Table.displayName = displayName;
+  Table.propTypes = {
+    id: PropTypes.string.isRequired,
+    ...(supportsCrossReferences ? { crossReferences: PropTypes.arrayOf(PropTypes.string) } : {}),
+  };
+  return Table;
+};
+
+export default createReferenceTable;

--- a/src/containers/referencePage/tables/utils.jsx
+++ b/src/containers/referencePage/tables/utils.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ExternalLink from '../../../components/ExternalLink.jsx';
+
+export const namesList = (value) => {
+  if (!value) return '';
+  const items = Array.isArray(value) ? value : [value];
+  return items.map((item) => item?.name).filter(Boolean).join(', ');
+};
+
+export const sourceFormatter = (evidence) => {
+  if (!evidence || !evidence.length) return null;
+  const first = evidence[0] || {};
+  const xref = (first.crossReferences || []).find((x) => x.referencedCurie?.startsWith('PMID:'));
+  if (xref?.referencedCurie) {
+    const pmid = xref.referencedCurie.replace('PMID:', '');
+    return <ExternalLink href={`https://pubmed.ncbi.nlm.nih.gov/${pmid}/`}>{xref.referencedCurie}</ExternalLink>;
+  }
+  return first.referenceID || first.curie || null;
+};


### PR DESCRIPTION
## Summary
Reference detail page now shows a full set of data tables for a publication's associated entities and annotations:

- Genes, Alleles, Models
- Disease, Phenotype, Expression annotations
- Molecular and Genetic interactions
- Orthology
- Related papers (Jaccard-ranked; optional one-hop ortholog expansion)

Section counts appear as badges in the left nav.

Tables are built on a shared `createReferenceTable` factory so each section file declares only its endpoint, transform, and columns. The 9 tables that previously shared ~170 lines of boilerplate are now collapsed around the factory plus a small `utils.jsx` for the duplicated `namesList` / `sourceFormatter` helpers.

Also extends `PageNav` to support count badges and external links. The same `PageNav` change ships in `feature/KANBAN-1322` (#1770) — whichever lands first will be a no-op for the other.

Depends on **KANBAN-678 in agr_java_software** (https://github.com/alliance-genome/agr_java_software/pull/1611) for the matching `/api/reference/{id}/...` endpoints. Merge that one first.

## Test plan
- [ ] Open a reference detail page (e.g. `/reference/AGRKB:101000000828456`)
- [ ] Each section's table renders: Genes, Alleles, Models, Disease, Phenotype, Expression, Molecular Interactions, Genetic Interactions, Orthology
- [ ] Section counts appear as badges in the left-nav
- [ ] Related papers list renders citations and a "Include cross-species papers (expand via orthology)" toggle works
- [ ] For a reference with multiple curated PMIDs/MOD curies, the Expression / Molecular Interactions / Genetic Interactions tables include those cross-references in the lookup
- [ ] No requests in DevTools Network tab go to `test.alliancegenome.org`

Generated with Claude Code (https://claude.com/claude-code)
