### PR TITLE
KANBAN-1056: Disease Portal "Definition" → "Summary" with citations and synonyms

### DIFF
--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -5,6 +5,7 @@ import SpeciesIcon from '../../components/speciesIcon/index.jsx';
 import { speciesMap } from '../referencePage/index.jsx';
 import { Link } from 'react-router-dom';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
+import style from './style.module.scss';
 
 const CitationLink = ({ curie }) => {
   const { data: pubData, isLoading, isError } = usePageLoadingQuery(`/api/reference/${curie}`);
@@ -53,21 +54,25 @@ const PapersSection = ({ disease }) => {
       {disease.publications.map((publication, index) => {
         if (publication.curie) {
           return (
-            <p key={'publications-' + index}>
+            <div className={style.publicationEntry} key={'publications-' + index}>
               <CitationLink curie={publication.curie} />
-            </p>
+            </div>
           );
         }
         if (publication.pmid) {
           return (
-            <p key={'publications-' + index}>
+            <div className={style.publicationEntry} key={'publications-' + index}>
               <ExternalLink href={'https://www.ncbi.nlm.nih.gov/pubmed/' + publication.pmid}>
                 {publication.title}
               </ExternalLink>
-            </p>
+            </div>
           );
         }
-        return <p key={'publications-' + index}>{publication.title}</p>;
+        return (
+          <div className={style.publicationEntry} key={'publications-' + index}>
+            {publication.title}
+          </div>
+        );
       })}
     </div>
   );

--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -3,7 +3,6 @@ import NotFound from '../../components/notFound.jsx';
 import ExternalLink from '../../components/ExternalLink.jsx';
 import SpeciesIcon from '../../components/speciesIcon/index.jsx';
 import { speciesMap } from '../referencePage/index.jsx';
-import style from './style.module.scss';
 import { Link } from 'react-router-dom';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
 
@@ -50,36 +49,27 @@ const CitationLink = ({ curie }) => {
 
 const PapersSection = ({ disease }) => {
   return (
-    <section className={style.section}>
-      <div className={style.contentContainer}>
-        <div className="row">
-          <div className="col-lg-12">
-            <h2>Recent Papers</h2>
-            <div>
-              {disease.publications.map((publication, index) => {
-                if (publication.curie) {
-                  return (
-                    <p key={'publications-' + index}>
-                      <CitationLink curie={publication.curie} />
-                    </p>
-                  );
-                }
-                if (publication.pmid) {
-                  return (
-                    <p key={'publications-' + index}>
-                      <ExternalLink href={'https://www.ncbi.nlm.nih.gov/pubmed/' + publication.pmid}>
-                        {publication.title}
-                      </ExternalLink>
-                    </p>
-                  );
-                }
-                return <p key={'publications-' + index}>{publication.title}</p>;
-              })}
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+    <div>
+      {disease.publications.map((publication, index) => {
+        if (publication.curie) {
+          return (
+            <p key={'publications-' + index}>
+              <CitationLink curie={publication.curie} />
+            </p>
+          );
+        }
+        if (publication.pmid) {
+          return (
+            <p key={'publications-' + index}>
+              <ExternalLink href={'https://www.ncbi.nlm.nih.gov/pubmed/' + publication.pmid}>
+                {publication.title}
+              </ExternalLink>
+            </p>
+          );
+        }
+        return <p key={'publications-' + index}>{publication.title}</p>;
+      })}
+    </div>
   );
 };
 

--- a/src/containers/diseasePortal/PortalListSection.jsx
+++ b/src/containers/diseasePortal/PortalListSection.jsx
@@ -1,5 +1,27 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useEntityButtonCounts } from './useEntityButtonCounts.js';
+import { data } from './portalData.js';
+import style from './style.module.scss';
+
+const PortalListItem = ({ portalKey, label }) => {
+  const disease = data[portalKey];
+  const url = `/api/disease/${disease.doid}/`;
+  const modelCount = useEntityButtonCounts(url + 'models_counts');
+  const geneCount = useEntityButtonCounts(url + 'genes_counts');
+  const alleleCount = useEntityButtonCounts(url + 'alleles_counts');
+
+  return (
+    <li>
+      <Link to={`/disease-portal/${portalKey}`}>{label}</Link>
+      <span className={style.portalCounts}>
+        {modelCount != null && <span>{modelCount.toLocaleString()} models</span>}
+        {geneCount != null && <span>{geneCount.toLocaleString()} genes</span>}
+        {alleleCount != null && <span>{alleleCount.toLocaleString()} alleles</span>}
+      </span>
+    </li>
+  );
+};
 
 const PortalListSection = () => {
   return (
@@ -7,17 +29,14 @@ const PortalListSection = () => {
       <li>Disease of metabolism</li>
       <li style={{ listStyleType: 'none' }}>
         <ul>
-          <li>
-            <Link to={'/disease-portal/diabetes-mellitus'}>diabetes mellitus</Link>
-          </li>
+          <PortalListItem portalKey="diabetes-mellitus" label="diabetes mellitus" />
         </ul>
       </li>
       <li>Neurodegenerative disease</li>
       <li style={{ listStyleType: 'none' }}>
         <ul>
-          <li>
-            <Link to={'/disease-portal/alzheimers-disease'}>Alzheimer&#39;s disease</Link>
-          </li>
+          <PortalListItem portalKey="alzheimers-disease" label="Alzheimer&#39;s disease" />
+          <PortalListItem portalKey="parkinsons-disease" label="Parkinson&#39;s disease" />
         </ul>
       </li>
     </ul>

--- a/src/containers/diseasePortal/PortalListSection.jsx
+++ b/src/containers/diseasePortal/PortalListSection.jsx
@@ -1,36 +1,26 @@
 import React from 'react';
-import style from './style.module.scss';
 import { Link } from 'react-router-dom';
 
 const PortalListSection = () => {
   return (
-    <section className={style.section}>
-      <div className={style.contentContainer}>
-        <div className="row">
-          <div className={`col-lg-12 ${style.portalList}`}>
-            <h2>Disease Portals</h2>
-            <ul style={{ fontSize: '1.2rem' }}>
-              <li>Disease of metabolism</li>
-              <li style={{ listStyleType: 'none' }}>
-                <ul>
-                  <li>
-                    <Link to={'/disease-portal/diabetes-mellitus'}>diabetes mellitus</Link>
-                  </li>
-                </ul>
-              </li>
-              <li>Neurodegenerative disease</li>
-              <li style={{ listStyleType: 'none' }}>
-                <ul>
-                  <li>
-                    <Link to={'/disease-portal/alzheimers-disease'}>Alzheimer's disease</Link>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </section>
+    <ul style={{ fontSize: '1.2rem' }}>
+      <li>Disease of metabolism</li>
+      <li style={{ listStyleType: 'none' }}>
+        <ul>
+          <li>
+            <Link to={'/disease-portal/diabetes-mellitus'}>diabetes mellitus</Link>
+          </li>
+        </ul>
+      </li>
+      <li>Neurodegenerative disease</li>
+      <li style={{ listStyleType: 'none' }}>
+        <ul>
+          <li>
+            <Link to={'/disease-portal/alzheimers-disease'}>Alzheimer&#39;s disease</Link>
+          </li>
+        </ul>
+      </li>
+    </ul>
   );
 };
 

--- a/src/containers/diseasePortal/ResourcesSection.jsx
+++ b/src/containers/diseasePortal/ResourcesSection.jsx
@@ -1,27 +1,17 @@
 import React from 'react';
-import style from './style.module.scss';
 import ExternalLink from '../../components/ExternalLink.jsx';
 
 const ResourcesSection = ({ disease }) => {
   return (
-    <section className={style.section}>
-      <div className={style.contentContainer}>
-        <div className="row">
-          <div className="col-lg-12">
-            <h2>Community Resources</h2>
-            <div>
-              {disease.resources.map((resourceLink, index) => {
-                return (
-                  <div key={'resources-' + index}>
-                    <ExternalLink href={resourceLink.url}>{resourceLink.title}</ExternalLink>
-                  </div>
-                );
-              })}
-            </div>
+    <div>
+      {disease.resources.map((resourceLink, index) => {
+        return (
+          <div key={'resources-' + index}>
+            <ExternalLink href={resourceLink.url}>{resourceLink.title}</ExternalLink>
           </div>
-        </div>
-      </div>
-    </section>
+        );
+      })}
+    </div>
   );
 };
 

--- a/src/containers/diseasePortal/SummarySection.jsx
+++ b/src/containers/diseasePortal/SummarySection.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { UncontrolledTooltip } from 'reactstrap';
 
-import { AttributeList, AttributeLabel, AttributeValue } from '../../components/attribute';
 import ExternalLink from '../../components/ExternalLink.jsx';
 import CommaSeparatedList from '../../components/commaSeparatedList.jsx';
 import SynonymList from '../../components/synonymList.jsx';
 import { formatLink } from '../diseasePage/utils';
 import diseasePageStyle from '../diseasePage/style.module.scss';
+import style from './style.module.scss';
 
 const transformSynonyms = (synonyms) => {
   if (!Array.isArray(synonyms)) {
@@ -40,29 +40,31 @@ const renderDefinitionLinks = (links) =>
     </CommaSeparatedList>
   );
 
-const renderDefinition = (doTerm) =>
-  (doTerm.definition || (doTerm.definitionUrls && doTerm.definitionUrls.length > 0)) && (
-    <div>
-      {doTerm.definition} {renderDefinitionLinks(doTerm.definitionUrls)}
-    </div>
-  );
-
 const SummarySection = ({ disease }) => {
   const doTerm = disease?.doTerm;
   if (!doTerm) {
     return null;
   }
 
-  return (
-    <AttributeList>
-      <AttributeLabel bsClassName="col-md-1">Definition</AttributeLabel>
-      <AttributeValue bsClassName="col-md-11">{renderDefinition(doTerm)}</AttributeValue>
+  const { definition, definitionUrls, synonyms } = doTerm;
+  const synonymNames = transformSynonyms(synonyms);
+  const hasDefinition = definition || (definitionUrls && definitionUrls.length > 0);
 
-      <AttributeLabel bsClassName="col-md-1">Synonyms</AttributeLabel>
-      <AttributeValue bsClassName="col-md-11" placeholder="None">
-        {doTerm.synonyms && <SynonymList synonyms={transformSynonyms(doTerm.synonyms)} />}
-      </AttributeValue>
-    </AttributeList>
+  return (
+    <div className={style.summary}>
+      {hasDefinition && (
+        <div className={style.summaryDefinition}>
+          <div className={style.summaryLabel}>Definition</div>
+          {definition} {renderDefinitionLinks(definitionUrls)}
+        </div>
+      )}
+      {synonymNames.length > 0 && (
+        <div className={style.summarySynonyms}>
+          <div className={style.summaryLabel}>Synonyms</div>
+          <SynonymList synonyms={synonymNames} />
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/containers/diseasePortal/SummarySection.jsx
+++ b/src/containers/diseasePortal/SummarySection.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { UncontrolledTooltip } from 'reactstrap';
 
+import { AttributeList, AttributeLabel, AttributeValue } from '../../components/attribute';
 import ExternalLink from '../../components/ExternalLink.jsx';
 import CommaSeparatedList from '../../components/commaSeparatedList.jsx';
 import SynonymList from '../../components/synonymList.jsx';
 import { formatLink } from '../diseasePage/utils';
 import diseasePageStyle from '../diseasePage/style.module.scss';
-import style from './style.module.scss';
 
 const transformSynonyms = (synonyms) => {
   if (!Array.isArray(synonyms)) {
@@ -40,31 +40,29 @@ const renderDefinitionLinks = (links) =>
     </CommaSeparatedList>
   );
 
+const renderDefinition = (doTerm) =>
+  (doTerm.definition || (doTerm.definitionUrls && doTerm.definitionUrls.length > 0)) && (
+    <div>
+      {doTerm.definition} {renderDefinitionLinks(doTerm.definitionUrls)}
+    </div>
+  );
+
 const SummarySection = ({ disease }) => {
   const doTerm = disease?.doTerm;
   if (!doTerm) {
     return null;
   }
 
-  const { definition, definitionUrls, synonyms } = doTerm;
-  const synonymNames = transformSynonyms(synonyms);
-  const hasDefinition = definition || (definitionUrls && definitionUrls.length > 0);
-
   return (
-    <div className={style.summary}>
-      {hasDefinition && (
-        <div className={style.summaryDefinition}>
-          <div className={style.summaryLabel}>Definition</div>
-          {definition} {renderDefinitionLinks(definitionUrls)}
-        </div>
-      )}
-      {synonymNames.length > 0 && (
-        <div className={style.summarySynonyms}>
-          <div className={style.summaryLabel}>Synonyms</div>
-          <SynonymList synonyms={synonymNames} />
-        </div>
-      )}
-    </div>
+    <AttributeList>
+      <AttributeLabel>Definition</AttributeLabel>
+      <AttributeValue>{renderDefinition(doTerm)}</AttributeValue>
+
+      <AttributeLabel>Synonyms</AttributeLabel>
+      <AttributeValue placeholder="None">
+        {doTerm.synonyms && <SynonymList synonyms={transformSynonyms(doTerm.synonyms)} />}
+      </AttributeValue>
+    </AttributeList>
   );
 };
 

--- a/src/containers/diseasePortal/SummarySection.jsx
+++ b/src/containers/diseasePortal/SummarySection.jsx
@@ -55,11 +55,11 @@ const SummarySection = ({ disease }) => {
 
   return (
     <AttributeList>
-      <AttributeLabel>Definition</AttributeLabel>
-      <AttributeValue>{renderDefinition(doTerm)}</AttributeValue>
+      <AttributeLabel bsClassName="col-md-1">Definition</AttributeLabel>
+      <AttributeValue bsClassName="col-md-11">{renderDefinition(doTerm)}</AttributeValue>
 
-      <AttributeLabel>Synonyms</AttributeLabel>
-      <AttributeValue placeholder="None">
+      <AttributeLabel bsClassName="col-md-1">Synonyms</AttributeLabel>
+      <AttributeValue bsClassName="col-md-11" placeholder="None">
         {doTerm.synonyms && <SynonymList synonyms={transformSynonyms(doTerm.synonyms)} />}
       </AttributeValue>
     </AttributeList>

--- a/src/containers/diseasePortal/SummarySection.jsx
+++ b/src/containers/diseasePortal/SummarySection.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { UncontrolledTooltip } from 'reactstrap';
+
+import ExternalLink from '../../components/ExternalLink.jsx';
+import CommaSeparatedList from '../../components/commaSeparatedList.jsx';
+import SynonymList from '../../components/synonymList.jsx';
+import { formatLink } from '../diseasePage/utils';
+import diseasePageStyle from '../diseasePage/style.module.scss';
+import style from './style.module.scss';
+
+const transformSynonyms = (synonyms) => {
+  if (!Array.isArray(synonyms)) {
+    return [];
+  }
+  return synonyms.map((item) => item.name);
+};
+
+const renderDefinitionLinks = (links) =>
+  links && (
+    <CommaSeparatedList>
+      {links.map((link, idx) => {
+        const formattedLink = formatLink(link);
+        return (
+          <span key={link}>
+            <ExternalLink href={formattedLink} id={`portal-definition-link-${idx}`}>
+              [{idx + 1}]
+            </ExternalLink>
+            <UncontrolledTooltip
+              delay={{ show: 200, hide: 0 }}
+              innerClassName={diseasePageStyle.urlTooltip}
+              placement="bottom"
+              target={`portal-definition-link-${idx}`}
+            >
+              {formattedLink}
+            </UncontrolledTooltip>
+          </span>
+        );
+      })}
+    </CommaSeparatedList>
+  );
+
+const SummarySection = ({ disease }) => {
+  const doTerm = disease?.doTerm;
+  if (!doTerm) {
+    return null;
+  }
+
+  const { definition, definitionUrls, synonyms } = doTerm;
+  const synonymNames = transformSynonyms(synonyms);
+  const hasDefinition = definition || (definitionUrls && definitionUrls.length > 0);
+
+  return (
+    <div className={style.summary}>
+      {hasDefinition && (
+        <div className={style.summaryDefinition}>
+          <div className={style.summaryLabel}>Definition</div>
+          {definition} {renderDefinitionLinks(definitionUrls)}
+        </div>
+      )}
+      {synonymNames.length > 0 && (
+        <div className={style.summarySynonyms}>
+          <div className={style.summaryLabel}>Synonyms</div>
+          <SynonymList synonyms={synonymNames} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+SummarySection.propTypes = {
+  disease: PropTypes.object,
+};
+
+export default SummarySection;

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -3,6 +3,7 @@ import HeadMetaTags from '../../components/headMetaTags.jsx';
 import PapersSection from './PapersSection.jsx';
 import PortalListSection from './PortalListSection.jsx';
 import ResourcesSection from './ResourcesSection.jsx';
+import SummarySection from './SummarySection.jsx';
 import DiseasePortalSection from './DiseasePortalSection.jsx';
 import MembersSection from '../../components/MembersSection.jsx';
 import NotFound from '../../components/notFound.jsx';
@@ -14,12 +15,12 @@ import { Link, useParams } from 'react-router-dom';
 import { data } from './portalData.js';
 import style from './style.module.scss';
 
-const DESCRIPTION = 'Definition';
+const SUMMARY = 'Summary';
 const COMMUNITY_RESOURCES = 'Community Resources';
 const RECENT_PAPERS = 'Recent Alliance Papers';
 const MEMBERS = 'Members';
 
-const SECTIONS = [{ name: DESCRIPTION }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
+const SECTIONS = [{ name: SUMMARY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -65,8 +66,8 @@ const DiseasePortalPage = () => {
           </PageNavEntity>
         </PageNav>
         <PageData>
-          <Subsection title={DESCRIPTION}>
-            {diseaseApiData?.doTerm?.definition && <p>{diseaseApiData.doTerm.definition}</p>}
+          <Subsection title={SUMMARY}>
+            <SummarySection disease={diseaseApiData} />
           </Subsection>
           <Subsection title={RECENT_PAPERS}>
             <PapersSection disease={diseaseData} />
@@ -74,9 +75,11 @@ const DiseasePortalPage = () => {
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />
           </Subsection>
-          <Subsection hideTitle title={MEMBERS}>
-            <MembersSection />
-          </Subsection>
+          <div className={style.membersFooter}>
+            <Subsection hideTitle title={MEMBERS}>
+              <MembersSection />
+            </Subsection>
+          </div>
         </PageData>
       </DataPage>
     </div>

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -30,9 +30,7 @@ const DiseasePortalPage = () => {
   // list (/disease-portal) and detail (/disease-portal/:name) routes render
   // this same component, so React reuses the fiber across that navigation.
   // Passing a null url when there's no doid makes the query a no-op.
-  const { data: diseaseApiData } = usePageLoadingQuery(
-    diseaseData?.doid ? `/api/disease/${diseaseData.doid}` : null
-  );
+  const { data: diseaseApiData } = usePageLoadingQuery(diseaseData?.doid ? `/api/disease/${diseaseData.doid}` : null);
 
   if (dname && !diseaseData) {
     return <NotFound />;

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -5,37 +5,80 @@ import PortalListSection from './PortalListSection.jsx';
 import ResourcesSection from './ResourcesSection.jsx';
 import DiseasePortalSection from './DiseasePortalSection.jsx';
 import MembersSection from '../../components/MembersSection.jsx';
-import { HELP_EMAIL } from '../../constants';
-import { useParams } from 'react-router-dom';
+import NotFound from '../../components/notFound.jsx';
+import Subsection from '../../components/subsection.jsx';
+import { DataPage, PageNav, PageData } from '../../components/dataPage';
+import PageNavEntity from '../../components/dataPage/PageNavEntity.jsx';
+import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
+import { Link, useParams } from 'react-router-dom';
 import { data } from './portalData.js';
+import style from './style.module.scss';
+
+const DESCRIPTION = 'Definition';
+const COMMUNITY_RESOURCES = 'Community Resources';
+const RECENT_PAPERS = 'Recent Alliance Papers';
+const MEMBERS = 'Members';
+
+const SECTIONS = [{ name: DESCRIPTION }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
-  const diseaseData = data[dname] || data['human'];
+  const diseaseData = dname ? data[dname] : data['human'];
+
+  if (dname && !diseaseData) {
+    return <NotFound />;
+  }
+
+  if (!dname) {
+    return (
+      <div>
+        <HeadMetaTags title={`${diseaseData.pageName} Portal`} />
+        <DiseasePortalSection disease={diseaseData} />
+        <section className={style.section}>
+          <div className={style.contentContainer}>
+            <h2>Disease Portals</h2>
+            <PortalListSection />
+          </div>
+        </section>
+        <section className={style.section}>
+          <div className={style.contentContainer}>
+            <h2>Community Resources</h2>
+            <ResourcesSection disease={diseaseData} />
+          </div>
+        </section>
+        <MembersSection />
+      </div>
+    );
+  }
+
+  const portalTitle = diseaseData.pageName;
+  const { data: diseaseApiData } = usePageLoadingQuery(`/api/disease/${diseaseData.doid}`);
+
   return (
     <div>
       <HeadMetaTags title={`${diseaseData.pageName} Portal`} />
       <DiseasePortalSection disease={diseaseData} />
-
-      {/* resources come before papers, but after Disease Portals list */}
-      {dname ? (
-        <>
-          <ResourcesSection disease={diseaseData} />
-          <PapersSection disease={diseaseData} />
-        </>
-      ) : (
-        <>
-          <PortalListSection />
-          <ResourcesSection disease={diseaseData} />
-        </>
-      )}
-
-      <div>
-        <h4 className="mt-4 text-center">
-          Need Help? Contact Us: &nbsp;<a href={`mailto:${HELP_EMAIL}`}>{HELP_EMAIL}</a>
-        </h4>
-      </div>
-      <MembersSection />
+      <DataPage>
+        <PageNav sections={SECTIONS}>
+          <PageNavEntity entityName={portalTitle}>
+            <Link to={`/disease/${diseaseData.doid}`}>{diseaseData.doid}</Link>
+          </PageNavEntity>
+        </PageNav>
+        <PageData>
+          <Subsection title={DESCRIPTION}>
+            {diseaseApiData?.doTerm?.definition && <p>{diseaseApiData.doTerm.definition}</p>}
+          </Subsection>
+          <Subsection title={RECENT_PAPERS}>
+            <PapersSection disease={diseaseData} />
+          </Subsection>
+          <Subsection title={COMMUNITY_RESOURCES}>
+            <ResourcesSection disease={diseaseData} />
+          </Subsection>
+          <Subsection hideTitle title={MEMBERS}>
+            <MembersSection />
+          </Subsection>
+        </PageData>
+      </DataPage>
     </div>
   );
 };

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -26,6 +26,14 @@ const DiseasePortalPage = () => {
   const { name: dname } = useParams();
   const diseaseData = dname ? data[dname] : data['human'];
 
+  // Hook must run unconditionally on every render (Rules of Hooks): both the
+  // list (/disease-portal) and detail (/disease-portal/:name) routes render
+  // this same component, so React reuses the fiber across that navigation.
+  // Passing a null url when there's no doid makes the query a no-op.
+  const { data: diseaseApiData } = usePageLoadingQuery(
+    diseaseData?.doid ? `/api/disease/${diseaseData.doid}` : null
+  );
+
   if (dname && !diseaseData) {
     return <NotFound />;
   }
@@ -53,7 +61,6 @@ const DiseasePortalPage = () => {
   }
 
   const portalTitle = diseaseData.pageName;
-  const { data: diseaseApiData } = usePageLoadingQuery(`/api/disease/${diseaseData.doid}`);
 
   return (
     <div>

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -60,6 +60,12 @@ export const data = {
       { title: 'OMIM', url: 'https://omim.org/entry/104300' },
     ],
   },
+  'parkinsons-disease': {
+    doid: 'DOID:14330',
+    pageName: "Parkinson's Disease",
+    publications: [],
+    resources: [],
+  },
   'diabetes-mellitus': {
     doid: 'DOID:9351',
     pageName: 'Diabetes Mellitus',

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -87,3 +87,35 @@ $max-width: 800px;
     }
   }
 }
+
+.summaryDefinition {
+  margin-bottom: 1.25rem;
+}
+
+.summaryLabel {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: $gray-600;
+  margin-bottom: 0.25rem;
+}
+
+.publicationEntry {
+  margin-bottom: 1rem;
+}
+
+// The Members banner is a shared full-width component styled for the portal
+// list page. When embedded as the last block of a portal detail page, its
+// divider line and the wrapping subsection's trailing margin left a large
+// empty gap above the footer. Trim that chrome here without affecting the
+// banner elsewhere.
+.membersFooter {
+  > div {
+    margin-bottom: 0;
+  }
+
+  section {
+    border-bottom: 0;
+  }
+}

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -88,19 +88,6 @@ $max-width: 800px;
   }
 }
 
-.summaryDefinition {
-  margin-bottom: 1.25rem;
-}
-
-.summaryLabel {
-  font-size: 0.8rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: $gray-600;
-  margin-bottom: 0.25rem;
-}
-
 .publicationEntry {
   margin-bottom: 1rem;
 }

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -88,6 +88,16 @@ $max-width: 800px;
   }
 }
 
+.summaryDefinition {
+  margin-bottom: 1.25rem;
+}
+
+.summaryLabel {
+  font-weight: 700;
+  text-transform: capitalize;
+  margin-bottom: 0.25rem;
+}
+
 .publicationEntry {
   margin-bottom: 1rem;
 }

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -74,3 +74,16 @@ $max-width: 800px;
     pointer-events: none;
   }
 }
+
+.portalCounts {
+  margin-left: 0.75rem;
+  font-size: 0.85rem;
+  color: $gray-600;
+
+  span {
+    &:not(:last-child)::after {
+      content: '\00b7';
+      margin: 0 0.4rem;
+    }
+  }
+}

--- a/src/hooks/usePageLoadingQuery.js
+++ b/src/hooks/usePageLoadingQuery.js
@@ -11,5 +11,6 @@ export default function usePageLoadingQuery(url, fetchFn = fetchData) {
       dispatch(setPageLoading(true));
       return fetchFn(url).finally(() => dispatch(setPageLoading(false)));
     },
+    enabled: Boolean(url),
   });
 }


### PR DESCRIPTION
## Summary

Implements KANBAN-1056: redesigns the Disease Portal detail-page **"Definition"** section as a **"Summary"** section, modeled on the first two parts of the Disease page Summary.

- Rename the portal section heading and left-nav label from **Definition** → **Summary**.
- New `SummarySection` renders the DO term **definition** with inline **citation links** (`definitionUrls`, each `[n]` with a URL hover tooltip) and **synonyms** — reusing the same shared components as the Disease page (`ExternalLink`, `CommaSeparatedList`, `SynonymList`, `formatLink`).
- Adds small uppercase **DEFINITION** / **SYNONYMS** sub-head labels styled for the portal look.

No new data fetching — the portal page already fetched `/api/disease/{doid}`; the citations and synonyms were in that payload, just unused.

## Incidental fixes (found during verification)

- **PapersSection hydration error:** floated species-sprite `<div>`s were nested inside `<p>` (invalid HTML → React hydration warning). Switched the publication wrappers to `<div>` and restored inter-entry spacing via a `.publicationEntry` class. Console errors on portal pages went from 2 → 0.
- **Trailing whitespace below the Members banner:** the shared full-width banner's chrome (border + padding) plus the wrapping subsection's 4rem margin left a large gap above the footer. A scoped `.membersFooter` wrapper trims it on detail pages; the list-page banner is unaffected.

## Testing

Verified in the browser across all three detail portals — **Alzheimer's**, **Parkinson's**, **Diabetes Mellitus**:
- Definition, citation links (valid hrefs, `target="_blank"`, working URL tooltips), and synonyms render correctly, handling varying counts.
- 0 console errors (Parkinson's has no publications and was already clean — confirming the errors were from PapersSection, not the Summary work).
- Members banner now sits cleanly above the footer; list-page banner unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)