### PR TITLE
SCRUM-6012 add Phenotypes section and All genes row to downloads page

### DIFF
--- a/src/containers/downloadsPage/index.jsx
+++ b/src/containers/downloadsPage/index.jsx
@@ -134,10 +134,7 @@ const DownloadsPage = () => {
 
         <Subsection title={GENE_DESCRIPTIONS}>
           <DownloadFileTable>
-            <DownloadFileRow
-              description="All genes"
-              files={getFilesForDataType('GENE', 'COMBINED')}
-            />
+            <DownloadFileRow description="All genes" files={getFilesForDataType('GENE', 'COMBINED')} />
             {SPECIES_SUBTYPES.map((speciesSubType) => (
               <DownloadFileRow
                 description={

--- a/src/containers/downloadsPage/index.jsx
+++ b/src/containers/downloadsPage/index.jsx
@@ -94,19 +94,17 @@ const DownloadsPage = () => {
               description="All expression annotations"
               files={getFilesForDataType('EXPRESSION-ALLIANCE', 'COMBINED')}
             />
-            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map(
-              (speciesSubType) => (
-                <DownloadFileRow
-                  description={
-                    <>
-                      <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
-                    </>
-                  }
-                  key={speciesSubType.species}
-                  files={getFilesForDataType('EXPRESSION-ALLIANCE', speciesSubType.subType)}
-                />
-              )
-            )}
+            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map((speciesSubType) => (
+              <DownloadFileRow
+                description={
+                  <>
+                    <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
+                  </>
+                }
+                key={speciesSubType.species}
+                files={getFilesForDataType('EXPRESSION-ALLIANCE', speciesSubType.subType)}
+              />
+            ))}
           </DownloadFileTable>
         </Subsection>
 
@@ -116,19 +114,17 @@ const DownloadsPage = () => {
               description="All phenotype annotations"
               files={getFilesForDataType('PHENOTYPE-ALLIANCE', 'COMBINED')}
             />
-            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map(
-              (speciesSubType) => (
-                <DownloadFileRow
-                  description={
-                    <>
-                      <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
-                    </>
-                  }
-                  key={speciesSubType.species}
-                  files={getFilesForDataType('PHENOTYPE-ALLIANCE', speciesSubType.subType)}
-                />
-              )
-            )}
+            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map((speciesSubType) => (
+              <DownloadFileRow
+                description={
+                  <>
+                    <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
+                  </>
+                }
+                key={speciesSubType.species}
+                files={getFilesForDataType('PHENOTYPE-ALLIANCE', speciesSubType.subType)}
+              />
+            ))}
           </DownloadFileTable>
         </Subsection>
 
@@ -156,18 +152,16 @@ const DownloadsPage = () => {
                 <span>
                   All molecular interactions{' '}
                   <HelpPopup id="interactions-help">
-                    This file provides a set of annotations of molecular interactions for genes
-                    and gene products for all Alliance species (human, rat, mouse, zebrafish,
-                    fruit fly, nematode, and yeast). The file is in the{' '}
+                    This file provides a set of annotations of molecular interactions for genes and gene products for
+                    all Alliance species (human, rat, mouse, zebrafish, fruit fly, nematode, and yeast). The file is in
+                    the{' '}
                     <ExternalLink href="https://github.com/HUPO-PSI/miTab/blob/master/PSI-MITAB27Format.md">
                       PSI-MI TAB 2.7 format
                     </ExternalLink>
                     , a tab-delimited format established by the{' '}
-                    <ExternalLink href="http://www.psidev.info">
-                      HUPO Proteomics Standards Initiative
-                    </ExternalLink>{' '}
-                    Molecular Interactions (PSI-MI) working group. The interaction data is sourced
-                    from Alliance members WormBase and FlyBase, as well as the{' '}
+                    <ExternalLink href="http://www.psidev.info">HUPO Proteomics Standards Initiative</ExternalLink>{' '}
+                    Molecular Interactions (PSI-MI) working group. The interaction data is sourced from Alliance members
+                    WormBase and FlyBase, as well as the{' '}
                     <ExternalLink href="http://www.imexconsortium.org">IMEx consortium</ExternalLink>
                     {' and the '}
                     <ExternalLink href="https://thebiogrid.org">BioGRID database</ExternalLink>.

--- a/src/containers/downloadsPage/index.jsx
+++ b/src/containers/downloadsPage/index.jsx
@@ -94,17 +94,19 @@ const DownloadsPage = () => {
               description="All expression annotations"
               files={getFilesForDataType('EXPRESSION-ALLIANCE', 'COMBINED')}
             />
-            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map((speciesSubType) => (
-              <DownloadFileRow
-                description={
-                  <>
-                    <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
-                  </>
-                }
-                key={speciesSubType.species}
-                files={getFilesForDataType('EXPRESSION-ALLIANCE', speciesSubType.subType)}
-              />
-            ))}
+            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map(
+              (speciesSubType) => (
+                <DownloadFileRow
+                  description={
+                    <>
+                      <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
+                    </>
+                  }
+                  key={speciesSubType.species}
+                  files={getFilesForDataType('EXPRESSION-ALLIANCE', speciesSubType.subType)}
+                />
+              )
+            )}
           </DownloadFileTable>
         </Subsection>
 
@@ -114,17 +116,19 @@ const DownloadsPage = () => {
               description="All phenotype annotations"
               files={getFilesForDataType('PHENOTYPE-ALLIANCE', 'COMBINED')}
             />
-            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map((speciesSubType) => (
-              <DownloadFileRow
-                description={
-                  <>
-                    <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
-                  </>
-                }
-                key={speciesSubType.species}
-                files={getFilesForDataType('PHENOTYPE-ALLIANCE', speciesSubType.subType)}
-              />
-            ))}
+            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map(
+              (speciesSubType) => (
+                <DownloadFileRow
+                  description={
+                    <>
+                      <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
+                    </>
+                  }
+                  key={speciesSubType.species}
+                  files={getFilesForDataType('PHENOTYPE-ALLIANCE', speciesSubType.subType)}
+                />
+              )
+            )}
           </DownloadFileTable>
         </Subsection>
 
@@ -155,17 +159,20 @@ const DownloadsPage = () => {
                 <span>
                   All molecular interactions{' '}
                   <HelpPopup id="interactions-help">
-                    This file provides a set of annotations of molecular interactions for genes and gene products for
-                    all Alliance species (human, rat, mouse, zebrafish, fruit fly, nematode, and yeast). The file is in
-                    the{' '}
+                    This file provides a set of annotations of molecular interactions for genes
+                    and gene products for all Alliance species (human, rat, mouse, zebrafish,
+                    fruit fly, nematode, and yeast). The file is in the{' '}
                     <ExternalLink href="https://github.com/HUPO-PSI/miTab/blob/master/PSI-MITAB27Format.md">
                       PSI-MI TAB 2.7 format
                     </ExternalLink>
                     , a tab-delimited format established by the{' '}
-                    <ExternalLink href="http://www.psidev.info">HUPO Proteomics Standards Initiative</ExternalLink>{' '}
-                    Molecular Interactions (PSI-MI) working group. The interaction data is sourced from Alliance members
-                    WormBase and FlyBase, as well as the{' '}
-                    <ExternalLink href="http://www.imexconsortium.org">IMEx consortium</ExternalLink> and the{' '}
+                    <ExternalLink href="http://www.psidev.info">
+                      HUPO Proteomics Standards Initiative
+                    </ExternalLink>{' '}
+                    Molecular Interactions (PSI-MI) working group. The interaction data is sourced
+                    from Alliance members WormBase and FlyBase, as well as the{' '}
+                    <ExternalLink href="http://www.imexconsortium.org">IMEx consortium</ExternalLink>
+                    {' and the '}
                     <ExternalLink href="https://thebiogrid.org">BioGRID database</ExternalLink>.
                   </HelpPopup>
                 </span>

--- a/src/containers/downloadsPage/index.jsx
+++ b/src/containers/downloadsPage/index.jsx
@@ -5,7 +5,6 @@ import { DataPage, PageData, PageHeader, PageNav } from '../../components/dataPa
 
 import DownloadFileTable from './downloadFileTable.jsx';
 import HelpPopup from '../../components/helpPopup.jsx';
-import GeneDescriptionsHelp from './geneDescriptionsHelp.jsx';
 import GeneticInteractionsHelp from './geneticInteractionsHelp.jsx';
 import VariantsHelp from './variantsHelp.jsx';
 import HeadMetaTags from '../../components/headMetaTags.jsx';
@@ -17,15 +16,17 @@ import { useRelease } from '../../hooks/ReleaseContextProvider.jsx';
 
 const DISEASE = 'Disease';
 const EXPRESSION = 'Expression';
+const PHENOTYPES = 'Phenotypes';
 const MOLECULAR_INTERACTIONS = 'Molecular Interactions';
 const GENETIC_INTERACTIONS = 'Genetic Interactions';
-const GENE_DESCRIPTIONS = 'Gene Descriptions';
+const GENE_DESCRIPTIONS = 'Genes';
 const ORTHOLOGY = 'Orthology';
 const VARIANTS = 'Variants (VCF)';
 const VARIANT_ALLELE = 'Variants/Alleles';
 const SECTIONS = [
   { name: DISEASE },
   { name: EXPRESSION },
+  { name: PHENOTYPES },
   { name: GENE_DESCRIPTIONS },
   { name: MOLECULAR_INTERACTIONS },
   { name: GENETIC_INTERACTIONS },
@@ -107,8 +108,32 @@ const DownloadsPage = () => {
           </DownloadFileTable>
         </Subsection>
 
-        <Subsection help={<GeneDescriptionsHelp />} title={GENE_DESCRIPTIONS}>
+        <Subsection title={PHENOTYPES}>
           <DownloadFileTable>
+            <DownloadFileRow
+              description="All phenotype annotations"
+              files={getFilesForDataType('PHENOTYPE-ALLIANCE', 'COMBINED')}
+            />
+            {SPECIES_SUBTYPES.filter(({ subType }) => subType !== 'HUMAN').map((speciesSubType) => (
+              <DownloadFileRow
+                description={
+                  <>
+                    <SpeciesName>{speciesSubType.species}</SpeciesName> annotations
+                  </>
+                }
+                key={speciesSubType.species}
+                files={getFilesForDataType('PHENOTYPE-ALLIANCE', speciesSubType.subType)}
+              />
+            ))}
+          </DownloadFileTable>
+        </Subsection>
+
+        <Subsection title={GENE_DESCRIPTIONS}>
+          <DownloadFileTable>
+            <DownloadFileRow
+              description="All genes"
+              files={getFilesForDataType('GENE', 'COMBINED')}
+            />
             {SPECIES_SUBTYPES.map((speciesSubType) => (
               <DownloadFileRow
                 description={


### PR DESCRIPTION
- Add new Phenotypes section with combined and per-species files (PHENOTYPE-ALLIANCE dataType, no Homo sapiens entry)
- Add All genes combined row to Genes section
- Relabel Gene Descriptions section to Genes
- Remove help icon from Genes section