### PR TITLE
fix: gene page species name shows strain suffix (S288C) [SCRUM-6212]

### DIFF
--- a/src/components/expression/expressionAnnotationTable.jsx
+++ b/src/components/expression/expressionAnnotationTable.jsx
@@ -105,7 +105,7 @@ const ExpressionAnnotationTable = ({ focusGeneId, focusTaxonId, orthologGenes, t
 
   const data = results?.map((result) => ({
     key: hash(result),
-    species: result.geneExpressionAnnotation.expressionAnnotationSubject.taxon.name,
+    species: result.geneExpressionAnnotation.expressionAnnotationSubject.taxon.species.fullName,
     gene: result.geneExpressionAnnotation.expressionAnnotationSubject,
     location: result.geneExpressionAnnotation.whereExpressedStatement,
     stage: result.geneExpressionAnnotation.whenExpressedStageName,

--- a/src/components/homology/utils.js
+++ b/src/components/homology/utils.js
@@ -1,6 +1,7 @@
 export function getOrthologSpeciesName(orthology = {}) {
   const { objectGene = {} } = orthology;
-  return (objectGene.taxon || {}).name;
+  const taxon = objectGene.taxon || {};
+  return (taxon.species || {}).fullName || taxon.name;
 }
 
 export function getOrthologSpeciesId(orthology = {}) {


### PR DESCRIPTION
## SCRUM-6212

Fixes "Saccharomyces cerevisiae S288C" (strain-suffixed) appearing in the gene page **Orthology** section and **Expression** table Species columns, instead of the clean "Saccharomyces cerevisiae".

### Root cause
The strain suffix comes from `taxon.name`. The clean species name is on `taxon.species.fullName`.

### Change
- `expression/expressionAnnotationTable.jsx` — Species column now reads `taxon.species.fullName` (already present in the expression data).
- `homology/utils.js` `getOrthologSpeciesName` — returns `taxon.species.fullName` with a fallback to `taxon.name`.

### Follow-up / dependency
- The **Expression** fix works immediately (clean field already indexed).
- The **Orthology** fix depends on agr_curation PR #2784 (release/v0.50.6) deploying + an orthology reindex to populate `taxon.species.fullName`; until then the fallback renders the old name.