### PR TITLE
Release/kanban 461 462 1084 (#1795)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ jobs:
   claude-review:
     # Only run on pull requests and PR comments (not issue comments)
     if: |
-      (github.event_name == 'pull_request' && github.event.action == 'opened') || 
+      (github.event_name == 'pull_request' && github.event.action == 'opened') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request)
     permissions:
       contents: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "react-bootstrap-table2-paginator": "^2.1.2",
         "react-dom": "^19.2.5",
         "react-ga4": "^2.1.0",
+        "react-google-recaptcha-v3": "^1.11.0",
         "react-helmet": "^6.1.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.14.2",
@@ -12059,6 +12060,19 @@
       "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
       "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==",
       "license": "MIT"
+    },
+    "node_modules/react-google-recaptcha-v3": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.11.0.tgz",
+      "integrity": "sha512-kLQqpz/77m8+trpBwzqcxNtvWZYoZ/YO6Vm2cVTHW8hs80BWUfDpC7RDwuAvpswwtSYApWfaSpIDFWAIBNIYxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.3 || ^17.0 || ^18.0 || ^19.0",
+        "react-dom": "^17.0 || ^18.0 || ^19.0"
+      }
     },
     "node_modules/react-helmet": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-bootstrap-table2-paginator": "^2.1.2",
     "react-dom": "^19.2.5",
     "react-ga4": "^2.1.0",
+    "react-google-recaptcha-v3": "^1.11.0",
     "react-helmet": "^6.1.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.14.2",

--- a/src/components/YourInputWelcome.jsx
+++ b/src/components/YourInputWelcome.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import styles from './YourInputWelcome.module.scss';
+
+const YourInputWelcome = ({ type, name, allianceId }) => {
+  const params = new URLSearchParams();
+  if (type) params.set('type', type);
+  if (name) params.set('name', name);
+  if (allianceId) params.set('id', allianceId);
+  return (
+    <Link className={`btn btn-primary btn-sm ${styles.floatingButton}`} to={`/contact-us?${params.toString()}`}>
+      Your Input Welcome
+    </Link>
+  );
+};
+
+YourInputWelcome.propTypes = {
+  type: PropTypes.string,
+  name: PropTypes.string,
+  allianceId: PropTypes.string,
+};
+
+export default YourInputWelcome;

--- a/src/components/YourInputWelcome.module.scss
+++ b/src/components/YourInputWelcome.module.scss
@@ -1,0 +1,6 @@
+.floatingButton {
+  position: fixed;
+  top: 120px;
+  right: 20px;
+  //z-index: 1030;
+}

--- a/src/components/disease/diseaseComparisonRibbon.jsx
+++ b/src/components/disease/diseaseComparisonRibbon.jsx
@@ -94,6 +94,21 @@ const DiseaseComparisonRibbon = ({ geneId, geneTaxon }) => {
     return processRibbonData(summary.data);
   }, [summary.data]);
 
+  //customized max color for ribbon data
+  const MIN_COLOR_LEVEL = 50;
+  const maxColorLevel = useMemo(() => {
+    if (!ribbonData?.subjects?.length) return MIN_COLOR_LEVEL;
+    let max = 0;
+    for (const subject of ribbonData.subjects) {
+      if (!subject.groups) continue;
+      for (const group of Object.values(subject.groups)) {
+        const nb = group?.ALL?.nb_annotations ?? 0;
+        if (nb > max) max = nb;
+      }
+    }
+    return Math.max(max, MIN_COLOR_LEVEL);
+  }, [ribbonData]);
+
   useEffect(() => {
     if (!ribbonRef.current || !ribbonData || ribbonData.subjects.length === 0) return;
     ribbonRef.current.setData(ribbonData);
@@ -136,6 +151,7 @@ const DiseaseComparisonRibbon = ({ geneId, geneTaxon }) => {
             fire-event-on-empty-cells="false"
             group-clickable="false"
             group-open-new-tab="false"
+            max-color-level={maxColorLevel}
             new-tab="false"
             ref={ribbonRef}
             selected="all"

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,6 @@
+export const CONTACT_API_URL = 'https://1ythblxki4.execute-api.us-east-1.amazonaws.com/prod/contact';
 export const HELP_EMAIL = 'help@alliancegenome.org';
+export const RECAPTCHA_SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
 export const SEARCH_API_ERROR_MESSAGE = `There was a problem connecting to the server. Please refresh the page. If you continue to see this message, please contact ${HELP_EMAIL}`;
 export const LARGE_COL_CLASS = 'col-md-8 col-12';
 export const SMALL_COL_CLASS = 'col-md-4 col-12';

--- a/src/containers/contactPage/index.jsx
+++ b/src/containers/contactPage/index.jsx
@@ -1,0 +1,192 @@
+import React, { useCallback, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { GoogleReCaptchaProvider, useGoogleReCaptcha } from 'react-google-recaptcha-v3';
+import { HELP_EMAIL, RECAPTCHA_SITE_KEY } from '../../constants';
+import HeadMetaTags from '../../components/headMetaTags.jsx';
+import style from '../wordpress/style.module.scss';
+import { sendContactEmail } from '../../lib/sendContactEmail';
+
+const ContactForm = () => {
+  const [searchParams] = useSearchParams();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [subject, setSubject] = useState(() => {
+    const explicit = searchParams.get('subject');
+    if (explicit) return explicit;
+    const type = searchParams.get('type');
+    const entityName = searchParams.get('name');
+    const id = searchParams.get('id');
+    if (type || entityName || id) {
+      return `Feedback on ${type || ''} page: ${entityName || ''}${id ? ` (${id})` : ''}`;
+    }
+    return '';
+  });
+  const [message, setMessage] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [submitStatus, setSubmitStatus] = useState(null);
+  const [submitError, setSubmitError] = useState('');
+  const { executeRecaptcha } = useGoogleReCaptcha();
+
+  const clearSubmitStatus = () => {
+    if (submitStatus === 'success' || submitStatus === 'error') {
+      setSubmitStatus(null);
+      setSubmitError('');
+    }
+  };
+
+  const validateEmail = (e) => {
+    if (!e.target.validity.valid) {
+      setEmailError('Please enter a valid email address.');
+    } else {
+      setEmailError('');
+    }
+  };
+
+  const handleReset = () => {
+    setName('');
+    setEmail('');
+    setSubject('');
+    setMessage('');
+    setEmailError('');
+    setSubmitStatus(null);
+    setSubmitError('');
+  };
+
+  const handleSubmit = useCallback(
+    async (e) => {
+      e.preventDefault();
+      if (!executeRecaptcha) {
+        setSubmitError('reCAPTCHA not ready. Please try again.');
+        setSubmitStatus('error');
+        return;
+      }
+      setSubmitStatus('sending');
+      setSubmitError('');
+      try {
+        const captchaToken = await executeRecaptcha('contact');
+        await sendContactEmail({ name, email, subject, message, captchaToken });
+        setSubmitStatus('success');
+        setName('');
+        setEmail('');
+        setSubject('');
+        setMessage('');
+      } catch (err) {
+        setSubmitStatus('error');
+        setSubmitError(err.message || 'Network error. Please try again later.');
+      }
+    },
+    [executeRecaptcha, name, email, subject, message]
+  );
+
+  return (
+    <div>
+      <HeadMetaTags title="Contact Us" />
+      <div className={style.contactMenuContainer}>
+        <div className="container-fluid">
+          <div className={style.secondaryNavEmptyRow}></div>
+          <div className={`row ${style.secondaryNav}`}>
+            <div className="container">
+              <h1>Contact Us</h1>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="container">
+        <div className="row justify-content-center">
+          <div className="col-md-6 col-12">
+            <p>
+              Have a question or need help? &nbsp;&nbsp;Fill out the form below and we will get back to you as soon as
+              possible.
+            </p>
+            <form onFocus={clearSubmitStatus} onSubmit={handleSubmit}>
+              <div className="form-group mb-3">
+                <label htmlFor="contact-name">Name</label>
+                <input
+                  className="form-control"
+                  id="contact-name"
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                  type="text"
+                  value={name}
+                />
+              </div>
+              <div className="form-group mb-3">
+                <label htmlFor="contact-email">Email</label>
+                <input
+                  className={`form-control ${emailError ? 'is-invalid' : ''}`}
+                  id="contact-email"
+                  onBlur={(e) => validateEmail(e)}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    setEmailError('');
+                  }}
+                  required
+                  type="email"
+                  value={email}
+                />
+                {emailError && <div className="invalid-feedback">{emailError}</div>}
+              </div>
+              <div className="form-group mb-3">
+                <label htmlFor="contact-subject">Subject</label>
+                <input
+                  className="form-control"
+                  id="contact-subject"
+                  onChange={(e) => setSubject(e.target.value)}
+                  required
+                  type="text"
+                  value={subject}
+                />
+              </div>
+              <div className="form-group mb-3">
+                <label htmlFor="contact-message">Message</label>
+                <textarea
+                  className="form-control"
+                  id="contact-message"
+                  onChange={(e) => setMessage(e.target.value)}
+                  required
+                  rows="6"
+                  value={message}
+                />
+              </div>
+              <div className="mb-4">
+                <button
+                  className="btn btn-primary"
+                  disabled={submitStatus === 'sending'}
+                  style={{ marginRight: '3rem' }}
+                  type="submit"
+                >
+                  {submitStatus === 'sending' ? 'Sending...' : 'Send'}
+                </button>
+                <button
+                  className="btn btn-primary"
+                  disabled={submitStatus === 'sending'}
+                  onClick={handleReset}
+                  type="button"
+                >
+                  Reset
+                </button>
+              </div>
+              {submitStatus === 'success' && (
+                <div className="alert alert-success">
+                  Your message has been sent successfully. We will get back to you soon.
+                </div>
+              )}
+              {submitStatus === 'error' && <div className="alert alert-danger">{submitError}</div>}
+            </form>
+            <p className="mb-5">
+              To email the Alliance of Genome Resources directly: <a href={`mailto:${HELP_EMAIL}`}>{HELP_EMAIL}</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ContactPage = () => (
+  <GoogleReCaptchaProvider reCaptchaKey={RECAPTCHA_SITE_KEY} useEnterprise>
+    <ContactForm />
+  </GoogleReCaptchaProvider>
+);
+
+export default ContactPage;

--- a/src/containers/diseasePage/index.jsx
+++ b/src/containers/diseasePage/index.jsx
@@ -11,6 +11,7 @@ import DiseaseToModelTable from './DiseaseToModelTable.jsx';
 import PageNavEntity from '../../components/dataPage/PageNavEntity.jsx';
 import DiseaseName from '../../components/disease/DiseaseName.jsx';
 import PageCategoryLabel from '../../components/dataPage/PageCategoryLabel.jsx';
+import YourInputWelcome from '../../components/YourInputWelcome.jsx';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
 import { useParams } from 'react-router-dom';
 import { DISEASE_CATEGORY } from '../../constants';
@@ -89,6 +90,7 @@ const DiseasePage = () => {
       <PageData>
         <PageCategoryLabel category={DISEASE_CATEGORY} />
         <PageHeader>{data.doTerm.name}</PageHeader>
+        <YourInputWelcome type="Disease" name={data.doTerm.name} allianceId={data.doTerm.curie} />
 
         <Subsection hideTitle title={SUMMARY}>
           <BasicDiseaseInfo disease={data} />

--- a/src/containers/genePage/index.jsx
+++ b/src/containers/genePage/index.jsx
@@ -50,6 +50,7 @@ import {
 } from '../../lib/utils';
 import TransgenicAlleleTable from './TransgenicAlleleTable.jsx';
 import GeneSymbolCuration from '../../components/GeneSymbolCuration.jsx';
+import YourInputWelcome from '../../components/YourInputWelcome.jsx';
 import PhenotypeCrossRefs from './PhenotypeCrossRefs.jsx';
 import SpeciesName from '../../components/SpeciesName.jsx';
 import SequenceFeatureViewerSectionHelp from '../../components/sequenceFeatureViewer/sequenceFeatureViewerSectionHelp.jsx';
@@ -180,6 +181,7 @@ const GenePage = () => {
         <PageHeader>
           <GeneSymbolCuration gene={gene} />
         </PageHeader>
+        <YourInputWelcome type="Gene" name={geneSymbolText} allianceId={gene.primaryExternalId} />
 
         <Subsection hideTitle title={SUMMARY}>
           <GeneSummary gene={gene} crossReferenceMap={crossReferenceMap} gcrpCrossReference={gene.gcrpCrossReference} />

--- a/src/containers/layout/topBar.jsx
+++ b/src/containers/layout/topBar.jsx
@@ -1,23 +1,21 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
-import { HELP_EMAIL } from '../../constants';
 import SocialMedia from './SocialMedia';
 
 import style from './style.module.scss';
 
-class TopBar extends Component {
-  render() {
-    return (
-      <div className={style.topBar}>
-        <div className="align-items-center container-fluid d-flex justify-content-between py-2">
-          <span>
-            Questions? <a href={`mailto:${HELP_EMAIL}`}>Contact Us</a>
-          </span>
-          <SocialMedia />
-        </div>
+const TopBar = () => {
+  return (
+    <div className={style.topBar}>
+      <div className="align-items-center container-fluid d-flex justify-content-between py-2">
+        <span>
+          Questions? <Link to="/contact-us">Contact Us</Link>
+        </span>
+        <SocialMedia />
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 export default TopBar;

--- a/src/lib/sendContactEmail.js
+++ b/src/lib/sendContactEmail.js
@@ -1,0 +1,23 @@
+import { CONTACT_API_URL } from '../constants.js';
+
+export const sendContactEmail = async ({ name, email, subject, message, captchaToken }) => {
+  const response = await fetch(CONTACT_API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email, subject, message, captchaToken }),
+  });
+  if (!response.ok) {
+    let errMessage = 'Failed to send message.';
+    const text = await response.text();
+
+    try {
+      const data = JSON.parse(text);
+      errMessage = data.errors?.join(', ') || data.error || errMessage;
+    } catch {
+      errMessage = text || errMessage;
+    }
+
+    throw new Error(errMessage);
+  }
+  return response.json();
+};

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,7 +1,7 @@
 // make the routes easier to read
 /*eslint react/jsx-sort-props:0*/
 import React from 'react';
-import { Route, Routes, Navigate, useParams } from 'react-router-dom';
+import { Route, Routes, Navigate, useParams, useLocation } from 'react-router-dom';
 
 import { WordpressPage, WordpressPostList, WordpressPost } from './containers/wordpress';
 import Homepage from './containers/homepage/index.jsx';
@@ -18,6 +18,7 @@ import ReferencePage from './containers/referencePage/index.jsx';
 import MODLanding from './containers/modLanding/Main.jsx';
 import DiseasePortalPage from './containers/diseasePortal/index.jsx';
 import BlastPage from './containers/blastPage/index.jsx';
+import ContactPage from './containers/contactPage/index.jsx';
 
 const WordpressRedirect = () => {
   const { slug } = useParams();
@@ -48,7 +49,7 @@ const LayoutWithRoutes = () => (
 
       <Route exact path="/disease-portal" element={<DiseasePortalPage name="human" />} />
       <Route exact path="/disease-portal/:name" element={<DiseasePortalPage />} />
-
+      <Route exact path="/contact-us" element={<ContactPage />} />
       <Route exact path="/wordpress/:slug" component={WordpressRedirect} />
       <Route path="/:slug" element={<WordpressPage />} />
 


### PR DESCRIPTION
* fix(claude-workflow): Add actions:read permission, remove old model override

- Add missing 'actions: read' permission required by reusable workflow
- Remove hardcoded model override to use org-level CLAUDE_PR_REVIEW_MODEL variable
- Matches stage branch configuration that is already working

* KANBAN-462 Create 'contact us' form linked to 'Contact Us' menu item (#1678)

* KANBAN-462 Create 'contact us' form linked to 'Contact Us' menu item

* Modified error process and move constant to constant file, make prettier

---------



* Revert "KANBAN-462 Create 'contact us' form linked to 'Contact Us' menu item (#1678)"

This reverts commit b0ad81e0cf142b943df176f3e1aba689516fd7c7.

* Remove the COVID-19 resources page banner and link KANBAN-1157 (#1714)

Remove the COVID-19 resources page banner and link

* Feature/kanban 778 (#1722)

* removed covid banner

* KANBAN-778

---------



* Feature/kanban 461 462 1084 (#1787)

* KANBAN-462 Create 'contact us' form linked to 'Contact Us' menu item
* Modified error process and move constant to constant file, make prettier
* Added google recaptch
* WIP
* prettier format
* KANBAN-462: Add Contact Us form with reCAPTCHA v3 integration
* KANBAN-461, KANBAN-462, KANBAN-1084
* prettier
* Fixed issues after claude reviews

---------



* Update RECAPTCHA_SITE_KEY to use environment variable

---------