### PR TITLE
feat: Disease Portal Recent Papers via latest-literature-by-disease-per-mod endpoint

### DIFF
--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -1,79 +1,87 @@
 import React from 'react';
 import NotFound from '../../components/notFound.jsx';
-import ExternalLink from '../../components/ExternalLink.jsx';
 import SpeciesIcon from '../../components/speciesIcon/index.jsx';
-import { speciesMap } from '../referencePage/index.jsx';
 import { Link } from 'react-router-dom';
 import usePageLoadingQuery from '../../hooks/usePageLoadingQuery';
 import style from './style.module.scss';
 
-const CitationLink = ({ curie }) => {
-  const { data: pubData, isLoading, isError } = usePageLoadingQuery(`/api/reference/${curie}`);
+// Species shown for each MOD corpus. The authoritative source is the paper's
+// `mods_in_corpus` (set by the curator pipeline), not cross-reference prefixes.
+// Note: the RGD (rat) corpus is intentionally displayed as Human per the curator.
+const MOD_SPECIES = {
+  MGI: 'Mus musculus',
+  RGD: 'Homo sapiens',
+  XB: 'Xenopus tropicalis',
+  ZFIN: 'Danio rerio',
+  FB: 'Drosophila melanogaster',
+  WB: 'Caenorhabditis elegans',
+  SGD: 'Saccharomyces cerevisiae',
+};
+
+// Map a paper's corpus membership to the species icon(s) to render. `AGR` (the
+// Alliance central corpus) has no species of its own, so it is ignored; if no
+// MOD corpus maps, fall back to Homo sapiens.
+const speciesForCorpus = (modsInCorpus = []) => {
+  const species = modsInCorpus.map((mod) => MOD_SPECIES[mod]).filter(Boolean);
+  return species.length ? species : ['Homo sapiens'];
+};
+
+const PaperEntry = ({ reference }) => {
+  if (!reference || !reference.curie) {
+    return null;
+  }
+  const scale = 6 / 13;
+  const species = speciesForCorpus(reference.mods_in_corpus);
+  return (
+    <div className={style.publicationEntry}>
+      {species.map((sp) => (
+        <div style={{ float: 'left', lineHeight: 0.9, paddingRight: 8 }} key={`${reference.curie}-${sp}`}>
+          <SpeciesIcon scale={scale} species={sp} />
+        </div>
+      ))}
+      <Link to={`/reference/${reference.curie}`} dangerouslySetInnerHTML={{ __html: reference.citation }} />
+    </div>
+  );
+};
+
+// The endpoint matches the disease name as free text against title + abstract,
+// requiring all tokens. A trailing "disease" token therefore excludes on-topic
+// papers that don't repeat the word (e.g. "Alzheimer's disease" misses papers
+// titled "...Implications for Alzheimer") and lets the common word "disease"
+// pull in tangential papers. Drop a trailing "disease" word so the query anchors
+// on the distinctive part of the name. See RECENT_PAPERS_API.md.
+const normalizeDiseaseQuery = (name) => {
+  if (!name) {
+    return name;
+  }
+  const trimmed = name.replace(/\s+disease$/i, '').trim();
+  return trimmed || name;
+};
+
+const PapersSection = ({ diseaseName }) => {
+  const query = normalizeDiseaseQuery(diseaseName);
+  const url = query
+    ? `/api/reference/latest-literature-by-disease-per-mod?disease=${encodeURIComponent(query)}&latest=1`
+    : null;
+  const { data, isLoading, isError } = usePageLoadingQuery(url);
+
+  if (!diseaseName || isLoading) {
+    return null;
+  }
   if (isError) {
     return <NotFound />;
   }
-  if (isLoading) {
-    return null;
+
+  const results = data?.results || [];
+  if (results.length === 0) {
+    return <div className={style.publicationEntry}>No recent Alliance papers found for this disease.</div>;
   }
 
-  if (pubData) {
-    const ref = pubData.literatureSummary;
-
-    ref.modXrefs = [];
-    ref.extXrefs = [];
-    for (let xr = 0; xr < ref.cross_references.length; xr++) {
-      if (speciesMap[ref.cross_references[xr].curie.substring(0, ref.cross_references[xr].curie.indexOf(':'))])
-        ref.modXrefs.push(ref.cross_references[xr]);
-      else ref.extXrefs.push(ref.cross_references[xr]);
-    }
-
-    const scale = 6 / 13;
-    const prefs = ref.modXrefs.map((xref) => xref.curie.substring(0, xref.curie.indexOf(':')));
-    let mods = [];
-    for (let i = 0; i < prefs.length; i++) {
-      if (speciesMap[prefs[i]]) mods.push(speciesMap[prefs[i]]);
-    }
-    if (prefs.length === 0) mods.push('Homo sapiens');
-
-    return (
-      <>
-        {mods.map((mid) => (
-          <div style={{ float: 'left', lineHeight: 0.9, paddingRight: 8 }} key={`${mid}-sprite`}>
-            <SpeciesIcon scale={scale} species={mid} />
-          </div>
-        ))}
-        <Link to={`/reference/${curie}`} dangerouslySetInnerHTML={{ __html: ref.citation }} />
-      </>
-    );
-  }
-};
-
-const PapersSection = ({ disease }) => {
   return (
     <div>
-      {disease.publications.map((publication, index) => {
-        if (publication.curie) {
-          return (
-            <div className={style.publicationEntry} key={'publications-' + index}>
-              <CitationLink curie={publication.curie} />
-            </div>
-          );
-        }
-        if (publication.pmid) {
-          return (
-            <div className={style.publicationEntry} key={'publications-' + index}>
-              <ExternalLink href={'https://www.ncbi.nlm.nih.gov/pubmed/' + publication.pmid}>
-                {publication.title}
-              </ExternalLink>
-            </div>
-          );
-        }
-        return (
-          <div className={style.publicationEntry} key={'publications-' + index}>
-            {publication.title}
-          </div>
-        );
-      })}
+      {results.map((result, index) => (
+        <PaperEntry key={result.literatureSummary?.curie || index} reference={result.literatureSummary} />
+      ))}
     </div>
   );
 };

--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -34,12 +34,19 @@ const PaperEntry = ({ reference }) => {
   const species = speciesForCorpus(reference.mods_in_corpus);
   return (
     <div className={style.publicationEntry}>
-      {species.map((sp) => (
-        <div style={{ float: 'left', lineHeight: 0.9, paddingRight: 8 }} key={`${reference.curie}-${sp}`}>
+      {species.map((sp, i) => (
+        // Overlap adjacent corpus icons by ~one border-width so their baked-in
+        // borders read as a single shared edge (honeycomb), not a doubled one.
+        // The gap before the citation is handled by the Link's left margin.
+        <div style={{ lineHeight: 0.9, marginLeft: i === 0 ? 0 : -1 }} key={`${reference.curie}-${sp}`}>
           <SpeciesIcon scale={scale} species={sp} />
         </div>
       ))}
-      <Link to={`/reference/${reference.curie}`} dangerouslySetInnerHTML={{ __html: reference.citation }} />
+      <Link
+        to={`/reference/${reference.curie}`}
+        style={{ marginLeft: 8 }}
+        dangerouslySetInnerHTML={{ __html: reference.citation }}
+      />
     </div>
   );
 };

--- a/src/containers/diseasePortal/RECENT_PAPERS_API.md
+++ b/src/containers/diseasePortal/RECENT_PAPERS_API.md
@@ -1,0 +1,137 @@
+# Disease Portal — Recent Papers API
+
+Status: **implemented** (endpoint live on stage; UI wired in `PapersSection.jsx`)
+Branch: `feature/DPrecentpapersAPI`
+Consumer: `src/containers/diseasePortal/PapersSection.jsx`
+
+## Background
+
+Each Disease Portal's "Recent Papers" list used to be **hand-curated** in
+`src/containers/diseasePortal/portalData.js` as a `publications: [{ curie }]`
+array, with `PapersSection.jsx` fetching each reference individually via
+`/api/reference/{curie}`. That is now replaced by a single call to a shipped
+AGR-API endpoint that returns the newest literature per MOD corpus for a
+disease.
+
+> **History:** earlier planning assumed a new endpoint keyed by **DOID**
+> (topic-entity-tag match) returning results **grouped by species**, backed by a
+> server-side proxy to the Alliance Bibliography Corpus (ABC). The endpoint that
+> actually shipped is different and simpler — a **free-text** search returning a
+> **flat** list — so the contract below documents reality. The companion
+> `RECENT_PAPERS_BACKEND_SCOPE.md` (the ABC-proxy build plan) is obsolete and has
+> been removed.
+
+> **Why free-text matching, not DOID (intentional — do not "fix" back to DOID):**
+> The whole purpose of this section is to surface the _most recent_ literature.
+> DOID-to-paper association is **curated**, which takes time — and the lag
+> differs per MOD corpus. Matching on DOID would therefore systematically miss
+> brand-new papers that haven't been annotated yet, and would be skewed by each
+> MOD's curation backlog. Free-text matching of the disease name against title +
+> abstract surfaces papers _ahead_ of curation. The trade-off is accepted:
+> looser precision (an occasional paper that only mentions the disease in
+> passing) in exchange for freshness. This is why the list barely overlaps the
+> old hand-curated `publications` arrays — those are the older, already-annotated
+> papers this feature is meant to get ahead of.
+
+## Endpoint
+
+```
+GET /api/reference/latest-literature-by-disease-per-mod?disease={text}&latest={n}
+```
+
+| Param     | In    | Required | Default | Notes                                                                                                                                                                             |
+| --------- | ----- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disease` | query | yes      | —       | **Free text**, matched against publication **title and abstract**. The UI passes the disease's display name (`doTerm.name` from `/api/disease/{doid}`), e.g. `diabetes mellitus`. |
+| `latest`  | query | no       | —       | Max papers **per MOD corpus** (NOT a global total). UI uses `1`.                                                                                                                  |
+
+### Selection / ordering
+
+The backend runs the search per MOD corpus and returns the newest `latest`
+publication(s) for each, as a **flat** list (newest-first within each corpus).
+With `latest=1` this yields roughly one paper per corpus (~7–8 entries,
+including the Alliance central `AGR` corpus).
+
+## Response
+
+Standard `JsonResultResponse` envelope:
+
+```jsonc
+{
+  "results": [
+    {
+      "category": "literature_summary",
+      "searchable": false,
+      "literatureSummary": {
+        "curie": "AGRKB:101000001302046",
+        "citation": "O'Reilly L; ... (2026) Acute and resolving ... Diabetologia 69(5):1249-1264",
+        "short_citation": "O'Reilly L (2026) Diabetologia 69(5):1249-1264",
+        "mods_in_corpus": ["MGI"], // authoritative corpus membership
+        "cross_references": [
+          { "curie": "PMID:41454012", "is_obsolete": "false" },
+          { "curie": "DOI:10.1007/s00125-025-06638-6", "is_obsolete": "false" },
+          { "curie": "MGI:8317137", "is_obsolete": "false" },
+        ],
+        "date_published": "2026-05-01",
+        // ...many other fields: title, abstract, authors, mesh_terms, etc.
+      },
+    },
+    // ... one or more per MOD corpus
+  ],
+  "total": 8,
+  "returnedRecords": 8,
+  "requestDuration": "...",
+  "requestDate": "...",
+}
+```
+
+`literatureSummary` is the **same shape** returned by `GET /api/reference/{curie}`,
+so the citation and cross-references are already present — no per-paper follow-up
+request is needed.
+
+## UI consumption (`PapersSection.jsx`)
+
+The component reads exactly what it renders:
+
+- **`literatureSummary.curie`** — links to `/reference/{curie}`.
+- **`literatureSummary.citation`** — rendered via `dangerouslySetInnerHTML`
+  (may contain HTML).
+- **`literatureSummary.mods_in_corpus`** — drives the species icon(s). This is
+  the **authoritative** species source (set by the curator pipeline), replacing
+  the old fragile cross-reference-prefix guessing. Fixed map:
+
+  | Corpus | Species (drives `<SpeciesIcon>`)                             |
+  | ------ | ------------------------------------------------------------ |
+  | MGI    | `Mus musculus`                                               |
+  | RGD    | `Homo sapiens` _(rat corpus is shown as Human, per curator)_ |
+  | XB     | `Xenopus tropicalis`                                         |
+  | ZFIN   | `Danio rerio`                                                |
+  | FB     | `Drosophila melanogaster`                                    |
+  | WB     | `Caenorhabditis elegans`                                     |
+  | SGD    | `Saccharomyces cerevisiae`                                   |
+
+  `AGR` (Alliance central corpus) has no species of its own and is ignored; if a
+  paper maps to no MOD species, the icon falls back to `Homo sapiens`.
+
+The disease name is sourced from the page's existing `/api/disease/{doid}` query
+(`doTerm.name`), so no new lookup table is needed. The root portal (DOID:4) never
+renders this section (it only appears on detail routes).
+
+### Query normalization: strip a trailing "disease" token
+
+Because the endpoint requires **all** tokens of the query to match, a trailing
+`disease` word both **excludes** on-topic papers that don't repeat the word and
+lets the common word `disease` pull in **tangential** papers. So `PapersSection`
+strips a trailing `disease` token before querying (`/\s+disease$/i`):
+
+| `doTerm.name`         | Query sent                                                 |
+| --------------------- | ---------------------------------------------------------- |
+| `Alzheimer's disease` | `Alzheimer's`                                              |
+| `Parkinson's disease` | `Parkinson's`                                              |
+| `diabetes mellitus`   | `diabetes mellitus` (unchanged — doesn't end in "disease") |
+
+Measured impact (stage, June 2026, `latest=1`): for Parkinson's the result set
+turns over almost entirely (1/8 overlap) and becomes 8/8 verifiably on-topic
+(every result mentions "parkinson"), versus several visibly off-topic entries
+with the full name. Alzheimer's similarly recovers on-topic papers that the full
+phrase missed. Diabetes is unaffected. This normalization was chosen with the
+curator over synonym-based or backend tokenization approaches.

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -75,7 +75,7 @@ const DiseasePortalPage = () => {
             <SummarySection disease={diseaseApiData} />
           </Subsection>
           <Subsection title={RECENT_PAPERS}>
-            <PapersSection disease={diseaseData} />
+            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} />
           </Subsection>
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -99,6 +99,12 @@ $max-width: 800px;
 }
 
 .publicationEntry {
+  // Lay out the species icon(s) and citation as flex items so the row's height
+  // is driven by the tallest child. The icons were previously floated, but the
+  // entry never contained the float, so on very wide viewports a single-line
+  // citation (shorter than the icon) let the icon overflow into the next entry.
+  display: flex;
+  align-items: flex-start;
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
Replaces the Disease Portal's hand-curated "Recent Papers" lists with a single
  call to the shipped `/api/reference/latest-literature-by-disease-per-mod`
  endpoint, which returns the newest literature per MOD corpus for a disease.
  
  - Matches on **free-text disease name** (trailing "disease" word stripped) to
    surface papers *ahead* of per-MOD curation lag, rather than keying on DOID
    (which depends on curated annotation and would systematically miss brand-new
    papers).
  - Derives species icons from each paper's `mods_in_corpus` rather than
    cross-reference prefixes. The RGD (rat) corpus is intentionally displayed as
    Human per the curator.
  - Removes the per-reference fetch loop (`/api/reference/{curie}` one at a time)
    in favor of one endpoint call.
  - Adds `RECENT_PAPERS_API.md` documenting the endpoint contract and the
    free-text-vs-DOID rationale.
    
  ## Notes
  
  The new list barely overlaps the old hand-curated `publications` arrays —
  expected, since those were hand-selected a number of months ago, so are stale.