### PR TITLE
feat: embed scoped disease ontology browser on portal pages (KANBAN-1391)

### DIFF
--- a/src/containers/diseasePortal/OntologyContextSection.jsx
+++ b/src/containers/diseasePortal/OntologyContextSection.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import fetchData from '../../lib/fetchData';
+import OntologyTree from '../ontologyBrowser/OntologyTree.jsx';
+import { CountsProvider } from '../ontologyBrowser/useDiseaseCounts.jsx';
+import { TermsProvider } from '../ontologyBrowser/useDiseaseTerms.jsx';
+import style from './style.module.scss';
+
+// Embedded, scoped ontology view for a disease portal page (KANBAN-1391).
+// Two interaction modes by region:
+//  - Ancestor context (immediate parents) renders as links OUT to the full-page
+//    ontology browser, so the user can jump up the hierarchy.
+//  - The focus term and its descendants stay in-page: the reused OntologyTree
+//    handles expand/collapse drill-down locally, no route change.
+const OntologyContextSection = ({ curie, name }) => {
+  // Immediate parents come from the single-term doc (same shape the standalone
+  // TermDetailPanel uses). The DO is a DAG, so there can be more than one.
+  const { data, isLoading } = useQuery({
+    queryKey: ['disease-term', curie],
+    queryFn: () => fetchData(`/api/disease/${encodeURIComponent(curie)}`),
+    enabled: !!curie,
+    staleTime: 5 * 60_000,
+  });
+
+  // Highlight the term the user last clicked in the tree; selection is local,
+  // it does not navigate. Start on the focus term.
+  const [selectedCurie, setSelectedCurie] = useState(curie);
+  // Open the focus node on load so its children are immediately visible.
+  const [forceExpanded] = useState(() => new Set([curie]));
+
+  if (!curie) {
+    return null;
+  }
+
+  const parents = data?.parents || [];
+
+  return (
+    <CountsProvider>
+      <TermsProvider>
+        {parents.length > 0 && (
+          <div className={style.ontologyParents}>
+            <span className={style.ontologyParentsLabel}>Parent terms:</span>
+            {parents.map((p) => (
+              <span key={p.curie} className={style.ontologyParentItem}>
+                <em className={style.ontologyRelation}>is-a</em>
+                <Link to={`/ontology/disease/${p.curie}`}>{p.name}</Link>
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className={style.ontologyTreePane}>
+          <OntologyTree
+            curie={curie}
+            name={name || (isLoading ? curie : data?.doTerm?.name) || curie}
+            forceExpanded={forceExpanded}
+            focusedCurie={selectedCurie}
+            onSelect={setSelectedCurie}
+            scrollOnFocus={false}
+          />
+        </div>
+      </TermsProvider>
+    </CountsProvider>
+  );
+};
+
+OntologyContextSection.propTypes = {
+  curie: PropTypes.string,
+  name: PropTypes.string,
+};
+
+export default OntologyContextSection;

--- a/src/containers/diseasePortal/OntologyContextSection.jsx
+++ b/src/containers/diseasePortal/OntologyContextSection.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import fetchData from '../../lib/fetchData';
 import OntologyTree from '../ontologyBrowser/OntologyTree.jsx';
+import { ANNOTATION_TYPES } from '../ontologyBrowser/annotationTypes.js';
 import { CountsProvider } from '../ontologyBrowser/useDiseaseCounts.jsx';
 import { TermsProvider } from '../ontologyBrowser/useDiseaseTerms.jsx';
 import style from './style.module.scss';
@@ -39,17 +40,28 @@ const OntologyContextSection = ({ curie, name }) => {
   return (
     <CountsProvider>
       <TermsProvider>
-        {parents.length > 0 && (
-          <div className={style.ontologyParents}>
-            <span className={style.ontologyParentsLabel}>Parent terms:</span>
-            {parents.map((p) => (
-              <span key={p.curie} className={style.ontologyParentItem}>
-                <em className={style.ontologyRelation}>is-a</em>
-                <Link to={`/ontology/disease/${p.curie}`}>{p.name}</Link>
+        <div className={style.ontologyHeader}>
+          {parents.length > 0 && (
+            <div className={style.ontologyParents}>
+              <span className={style.ontologyParentsLabel}>Parent terms:</span>
+              {parents.map((p) => (
+                <span key={p.curie} className={style.ontologyParentItem}>
+                  <em className={style.ontologyRelation}>is-a</em>
+                  <Link to={`/ontology/disease/${p.curie}`}>{p.name}</Link>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className={style.ontologyLegend}>
+            <span className={style.ontologyLegendLabel}>Annotation Available:</span>
+            {ANNOTATION_TYPES.map((t) => (
+              <span key={t.id} className={style.ontologyLegendItem} style={{ background: t.bg, color: t.fg }}>
+                {t.label}
               </span>
             ))}
           </div>
-        )}
+        </div>
 
         <div className={style.ontologyTreePane}>
           <OntologyTree
@@ -59,7 +71,7 @@ const OntologyContextSection = ({ curie, name }) => {
             focusedCurie={selectedCurie}
             onSelect={setSelectedCurie}
             scrollOnFocus={false}
-            leafHref={(c) => `/disease/${c}`}
+            nodeHref={(c) => `/ontology/disease/${c}`}
           />
         </div>
       </TermsProvider>

--- a/src/containers/diseasePortal/OntologyContextSection.jsx
+++ b/src/containers/diseasePortal/OntologyContextSection.jsx
@@ -59,6 +59,7 @@ const OntologyContextSection = ({ curie, name }) => {
             focusedCurie={selectedCurie}
             onSelect={setSelectedCurie}
             scrollOnFocus={false}
+            leafHref={(c) => `/disease/${c}`}
           />
         </div>
       </TermsProvider>

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -83,7 +83,13 @@ const DiseasePortalPage = () => {
             <ResourcesSection disease={diseaseData} />
           </Subsection>
           <Subsection title={ONTOLOGY}>
-            <OntologyContextSection curie={diseaseData.doid} name={diseaseApiData?.doTerm?.name || portalTitle} />
+            {/* key on doid forces a remount per disease: the reused fiber (see above)
+                would otherwise leave the embedded tree's scoped state stale. */}
+            <OntologyContextSection
+              key={diseaseData.doid}
+              curie={diseaseData.doid}
+              name={diseaseApiData?.doTerm?.name || portalTitle}
+            />
           </Subsection>
           <div className={style.membersFooter}>
             <Subsection hideTitle title={MEMBERS}>

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -17,12 +17,12 @@ import { data } from './portalData.js';
 import style from './style.module.scss';
 
 const SUMMARY = 'Summary';
-const ONTOLOGY = 'Disease Ontology';
+const ONTOLOGY = 'Ontology View';
 const COMMUNITY_RESOURCES = 'Community Resources';
 const RECENT_PAPERS = 'Recent Alliance Papers';
 const MEMBERS = 'Members';
 
-const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
+const SECTIONS = [{ name: SUMMARY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }, { name: ONTOLOGY }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -76,14 +76,14 @@ const DiseasePortalPage = () => {
           <Subsection title={SUMMARY}>
             <SummarySection disease={diseaseApiData} />
           </Subsection>
-          <Subsection title={ONTOLOGY}>
-            <OntologyContextSection curie={diseaseData.doid} name={diseaseApiData?.doTerm?.name || portalTitle} />
-          </Subsection>
           <Subsection title={RECENT_PAPERS}>
             <PapersSection disease={diseaseData} />
           </Subsection>
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />
+          </Subsection>
+          <Subsection title={ONTOLOGY}>
+            <OntologyContextSection curie={diseaseData.doid} name={diseaseApiData?.doTerm?.name || portalTitle} />
           </Subsection>
           <div className={style.membersFooter}>
             <Subsection hideTitle title={MEMBERS}>

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import HeadMetaTags from '../../components/headMetaTags.jsx';
 import PapersSection from './PapersSection.jsx';
+import OntologyContextSection from './OntologyContextSection.jsx';
 import PortalListSection from './PortalListSection.jsx';
 import ResourcesSection from './ResourcesSection.jsx';
 import SummarySection from './SummarySection.jsx';
@@ -16,11 +17,12 @@ import { data } from './portalData.js';
 import style from './style.module.scss';
 
 const SUMMARY = 'Summary';
+const ONTOLOGY = 'Disease Ontology';
 const COMMUNITY_RESOURCES = 'Community Resources';
 const RECENT_PAPERS = 'Recent Alliance Papers';
 const MEMBERS = 'Members';
 
-const SECTIONS = [{ name: SUMMARY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
+const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -73,6 +75,9 @@ const DiseasePortalPage = () => {
         <PageData>
           <Subsection title={SUMMARY}>
             <SummarySection disease={diseaseApiData} />
+          </Subsection>
+          <Subsection title={ONTOLOGY}>
+            <OntologyContextSection curie={diseaseData.doid} name={diseaseApiData?.doTerm?.name || portalTitle} />
           </Subsection>
           <Subsection title={RECENT_PAPERS}>
             <PapersSection disease={diseaseData} />

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -104,12 +104,21 @@ $max-width: 800px;
 
 // Embedded ontology context (KANBAN-1391): immediate-parent links above the
 // scoped, in-page-explorable focus-term tree.
+// One row: parent-term links on the left, annotation legend pushed to the
+// right (margin-left:auto), baseline-aligned. Wraps on narrow viewports.
+.ontologyHeader {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
 .ontologyParents {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
   gap: 0.25rem 0.75rem;
-  margin-bottom: 0.75rem;
 }
 
 .ontologyParentsLabel {
@@ -126,6 +135,27 @@ $max-width: 800px;
 .ontologyRelation {
   margin-right: 0.4rem;
   color: $gray-600;
+}
+
+.ontologyLegend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  font-size: 0.85rem;
+}
+
+.ontologyLegendLabel {
+  color: $gray-700;
+  margin-right: 4px;
+}
+
+.ontologyLegendItem {
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
 .ontologyTreePane {

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -102,6 +102,40 @@ $max-width: 800px;
   margin-bottom: 1rem;
 }
 
+// Embedded ontology context (KANBAN-1391): immediate-parent links above the
+// scoped, in-page-explorable focus-term tree.
+.ontologyParents {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.25rem 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.ontologyParentsLabel {
+  font-size: 0.75rem;
+  color: $gray-600;
+  text-transform: uppercase;
+}
+
+.ontologyParentItem {
+  display: inline-flex;
+  align-items: baseline;
+}
+
+.ontologyRelation {
+  margin-right: 0.4rem;
+  color: $gray-600;
+}
+
+.ontologyTreePane {
+  border: 1px solid $border-color;
+  border-radius: 4px;
+  padding: 0.75rem 0.5rem;
+  max-height: 60vh;
+  overflow: auto;
+}
+
 // The Members banner is a shared full-width component styled for the portal
 // list page. When embedded as the last block of a portal detail page, its
 // divider line and the wrapping subsection's trailing margin left a large

--- a/src/containers/ontologyBrowser/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/OntologyTree.jsx
@@ -70,7 +70,7 @@ const OntologyTree = ({ curie, name, depth = 0, forceExpanded, focusedCurie, onS
       {open && childTerms.length > 0 && (
         <div className={style.children}>
           {[...childTerms]
-            .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+            .sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { numeric: true }))
             .map((c) => (
               <OntologyTree
                 key={c.curie}

--- a/src/containers/ontologyBrowser/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/OntologyTree.jsx
@@ -3,12 +3,22 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { Link } from 'react-router-dom';
 import CountBadge from './CountBadge.jsx';
 import { ANNOTATION_TYPES } from './annotationTypes.js';
 import { useDiseaseTerm } from './useDiseaseTerms.jsx';
 import style from './style.module.scss';
 
-const OntologyTree = ({ curie, name, depth = 0, forceExpanded, focusedCurie, onSelect, scrollOnFocus = true }) => {
+const OntologyTree = ({
+  curie,
+  name,
+  depth = 0,
+  forceExpanded,
+  focusedCurie,
+  onSelect,
+  scrollOnFocus = true,
+  leafHref,
+}) => {
   const [open, setOpen] = useState(false);
   const rowRef = useRef(null);
 
@@ -33,6 +43,10 @@ const OntologyTree = ({ curie, name, depth = 0, forceExpanded, focusedCurie, onS
   const knownEmpty = !!data && childTerms.length === 0 && !(data.doTerm?.descendantCount > 0);
   const hasChildren = !knownEmpty;
   const isFocused = focusedCurie === curie;
+  // A leaf has nothing to drill into, so when the consumer supplies a leafHref
+  // its label becomes a link out to that entity's page. Non-leaf rows keep
+  // their expand/select behavior.
+  const leafUrl = !hasChildren && leafHref ? leafHref(curie) : null;
 
   const toggle = (e) => {
     e.stopPropagation();
@@ -59,7 +73,13 @@ const OntologyTree = ({ curie, name, depth = 0, forceExpanded, focusedCurie, onS
         ) : (
           <span className={style.toggleSpacer} />
         )}
-        <span>{name}</span>
+        {leafUrl ? (
+          <Link to={leafUrl} onClick={(e) => e.stopPropagation()}>
+            {name}
+          </Link>
+        ) : (
+          <span>{name}</span>
+        )}
         <span className={style.curie}>&nbsp;{curie}</span>
         <span className={style.badgeRow}>
           {ANNOTATION_TYPES.map((t) => (
@@ -81,6 +101,7 @@ const OntologyTree = ({ curie, name, depth = 0, forceExpanded, focusedCurie, onS
                 focusedCurie={focusedCurie}
                 onSelect={onSelect}
                 scrollOnFocus={scrollOnFocus}
+                leafHref={leafHref}
               />
             ))}
         </div>
@@ -97,6 +118,7 @@ OntologyTree.propTypes = {
   focusedCurie: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   scrollOnFocus: PropTypes.bool,
+  leafHref: PropTypes.func,
 };
 
 export default OntologyTree;

--- a/src/containers/ontologyBrowser/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/OntologyTree.jsx
@@ -17,7 +17,7 @@ const OntologyTree = ({
   focusedCurie,
   onSelect,
   scrollOnFocus = true,
-  leafHref,
+  nodeHref,
 }) => {
   const [open, setOpen] = useState(false);
   const rowRef = useRef(null);
@@ -43,10 +43,10 @@ const OntologyTree = ({
   const knownEmpty = !!data && childTerms.length === 0 && !(data.doTerm?.descendantCount > 0);
   const hasChildren = !knownEmpty;
   const isFocused = focusedCurie === curie;
-  // A leaf has nothing to drill into, so when the consumer supplies a leafHref
-  // its label becomes a link out to that entity's page. Non-leaf rows keep
-  // their expand/select behavior.
-  const leafUrl = !hasChildren && leafHref ? leafHref(curie) : null;
+  // When the consumer supplies nodeHref, every term label (leaf or not) becomes
+  // a link to that URL. Drill-down stays on the separate chevron control, so
+  // linking the label doesn't interfere with exploring children in place.
+  const nodeUrl = nodeHref ? nodeHref(curie) : null;
 
   const toggle = (e) => {
     e.stopPropagation();
@@ -73,8 +73,8 @@ const OntologyTree = ({
         ) : (
           <span className={style.toggleSpacer} />
         )}
-        {leafUrl ? (
-          <Link to={leafUrl} onClick={(e) => e.stopPropagation()}>
+        {nodeUrl ? (
+          <Link to={nodeUrl} onClick={(e) => e.stopPropagation()}>
             {name}
           </Link>
         ) : (
@@ -101,7 +101,7 @@ const OntologyTree = ({
                 focusedCurie={focusedCurie}
                 onSelect={onSelect}
                 scrollOnFocus={scrollOnFocus}
-                leafHref={leafHref}
+                nodeHref={nodeHref}
               />
             ))}
         </div>
@@ -118,7 +118,7 @@ OntologyTree.propTypes = {
   focusedCurie: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   scrollOnFocus: PropTypes.bool,
-  leafHref: PropTypes.func,
+  nodeHref: PropTypes.func,
 };
 
 export default OntologyTree;


### PR DESCRIPTION
## Summary
Embeds a scoped Disease Ontology browser on disease portal detail pages (KANBAN-1391). Adds a new **Ontology View** section at the bottom of the portal page showing an in-page ontology tree rooted at the focus term, with drill-down into descendants and links out to the full-page ontology browser.

## Changes
- **New `OntologyContextSection.jsx`**: renders the focus term's immediate parents as links to the standalone ontology browser, plus an in-page tree rooted at the focus term with expand/collapse drill-down. Reuses the existing `ontologyBrowser` tree and batch providers.
- **`OntologyTree.jsx`**: generalized the leaf-only `leafHref` into a `nodeHref` applied to *all* nodes, so every term links to the browser focused at that term (drill-down stays on the chevron). Also natural-sorts numbered sibling terms (`localeCompare` with `{ numeric: true }`) so "disease 1, 2, 3, 14" order numerically.
- **`index.jsx`**: registers the **Ontology View** section + sidebar jump-link.
- **`style.module.scss`**: styles for the section, parent-term links, and the G|M|A "Annotation Available" legend.

## Notes
- Multi-parent (DAG) terms don't focus correctly in the standalone browser when opened via these links — tracked separately in **KANBAN-1395**.
- Branch includes a merge of `stage` (brings in the recently merged Recent Papers work); the net PR diff is only the KANBAN-1391 ontology files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)