### PR TITLE
fix: drop redundant AGR-corpus entry in DP Recent Papers

### DIFF
--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -79,7 +79,35 @@ const PapersSection = ({ diseaseName }) => {
     return <NotFound />;
   }
 
-  const results = data?.results || [];
+  // The endpoint returns the newest paper per corpus, treating the Alliance
+  // central `AGR` corpus as one of those corpora. The AGR paper has no species
+  // of its own but is itself a member of one or more MOD corpora, so it renders
+  // the same icon(s) as those MODs' dedicated papers — looking like a duplicate
+  // (e.g. two "mouse" papers). We can't display the AGR entry distinctly yet, so
+  // we drop it — but ONLY when it's truly redundant: an AGR paper is frequently
+  // the sole carrier of a species (e.g. the only RGD/SGD/WB paper for a disease),
+  // and blanket-dropping every AGR-tagged row silently removes that species. So
+  // drop an AGR row only if every MOD species it carries is already represented
+  // by a non-AGR row; keep it when it's the only source of a species. Also
+  // dedupe repeated curies (the backend can return one paper in two slots).
+  const rawResults = data?.results || [];
+  const isAgr = (r) => (r.literatureSummary?.mods_in_corpus || []).includes('AGR');
+  const modsOf = (r) => (r.literatureSummary?.mods_in_corpus || []).filter((m) => MOD_SPECIES[m]);
+  const coveredByNonAgr = new Set(rawResults.filter((r) => !isAgr(r)).flatMap(modsOf));
+  const seenCuries = new Set();
+  const results = rawResults.filter((r) => {
+    const curie = r.literatureSummary?.curie;
+    if (curie && seenCuries.has(curie)) {
+      return false;
+    }
+    if (curie) {
+      seenCuries.add(curie);
+    }
+    if (!isAgr(r)) {
+      return true;
+    }
+    return modsOf(r).some((m) => !coveredByNonAgr.has(m));
+  });
   if (results.length === 0) {
     return <div className={style.publicationEntry}>No recent Alliance papers found for this disease.</div>;
   }

--- a/src/containers/diseasePortal/RECENT_PAPERS_API.md
+++ b/src/containers/diseasePortal/RECENT_PAPERS_API.md
@@ -51,6 +51,18 @@ publication(s) for each, as a **flat** list (newest-first within each corpus).
 With `latest=1` this yields roughly one paper per corpus (~7–8 entries,
 including the Alliance central `AGR` corpus).
 
+**UI note:** the `AGR` central-corpus entry has no species of its own but is
+itself a member of one or more MOD corpora, so it renders the same icon(s) as
+those MODs' dedicated papers — looking like a duplicate (e.g. two "mouse"
+papers). `PapersSection` drops the AGR entry, but only when it is **redundant**:
+an AGR paper is frequently the _sole_ carrier of a species for a disease (e.g.
+the only RGD/SGD/WB paper), so a blanket drop of every `AGR`-tagged row silently
+removes that species (measured ~15% of diseases). The UI therefore drops an AGR
+row only when every MOD species it carries is already covered by a non-AGR row,
+and additionally dedupes repeated curies (the backend can return one paper in
+two corpus slots). The clean long-term fix is backend-side (exclude `AGR` from
+the per-corpus grouping, or expose which slot each paper filled).
+
 ## Response
 
 Standard `JsonResultResponse` envelope:


### PR DESCRIPTION
## Summary
Fixes the Disease Portal **Recent Papers** section showing two papers with the same species icon on every disease page (e.g. two "mouse" papers on Alzheimer's, Parkinson's, and Diabetes Mellitus).

## Root cause
The `latest-literature-by-disease-per-mod` endpoint returns the newest paper **per corpus** and treats the Alliance central **`AGR`** corpus as one of those slots. That extra AGR paper has no species of its own, but is itself a member of one or more MOD corpora, so the UI rendered it with the same icon(s) as those MODs' dedicated papers — looking like a duplicate. The labels were never wrong; both papers genuinely are in the mouse corpus.

## Fix
Drop the AGR entry, but **only when it is redundant**. A naive "drop every `AGR`-tagged row" filter silently removes a species, because the AGR paper is frequently the *sole* carrier of one — measured across 20 diseases on stage, ~15% lose RGD/SGD/WB that way (e.g. `['ZFIN','RGD','AGR']`, `['SGD','AGR']`, `['AGR','WB']`). So an AGR row is dropped only when **every MOD species it carries is already covered by a non-AGR row**, and repeated curies are deduped (the backend can return one paper in two slots).

## Verification
- Live stage data for all three portal pages now render one paper per MOD species with a single mouse icon.
- 0/20 sampled diseases lose a species under the new rule.
- ESLint + Prettier clean.

## Notes
The clean long-term fix is backend-side (exclude `AGR` from the per-corpus grouping, or expose which slot each paper filled); documented in `RECENT_PAPERS_API.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
