### PR TITLE
Recent Papers: rat icon for RGD corpus + order rows by MOD

### DIFF
--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -7,10 +7,9 @@ import style from './style.module.scss';
 
 // Species shown for each MOD corpus. The authoritative source is the paper's
 // `mods_in_corpus` (set by the curator pipeline), not cross-reference prefixes.
-// Note: the RGD (rat) corpus is intentionally displayed as Human per the curator.
 const MOD_SPECIES = {
   MGI: 'Mus musculus',
-  RGD: 'Homo sapiens',
+  RGD: 'Rattus norvegicus',
   XB: 'Xenopus tropicalis',
   ZFIN: 'Danio rerio',
   FB: 'Drosophila melanogaster',

--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -17,6 +17,17 @@ const MOD_SPECIES = {
   SGD: 'Saccharomyces cerevisiae',
 };
 
+// Display order for the paper rows: mouse, rat, frog, zebrafish, fly, worm,
+// yeast (matching the species order used elsewhere on the site). Rows are sorted
+// by the highest-priority MOD in their corpus membership; rows with no known MOD
+// (e.g. AGR-only) sort last.
+const MOD_DISPLAY_ORDER = ['MGI', 'RGD', 'XB', 'ZFIN', 'FB', 'WB', 'SGD'];
+
+const rowSortKey = (reference) => {
+  const indices = (reference?.mods_in_corpus || []).map((mod) => MOD_DISPLAY_ORDER.indexOf(mod)).filter((i) => i >= 0);
+  return indices.length ? Math.min(...indices) : MOD_DISPLAY_ORDER.length;
+};
+
 // Map a paper's corpus membership to the species icon(s) to render. `AGR` (the
 // Alliance central corpus) has no species of its own, so it is ignored; if no
 // MOD corpus maps, fall back to Homo sapiens.
@@ -111,9 +122,14 @@ const PapersSection = ({ diseaseName }) => {
     return <div className={style.publicationEntry}>No recent Alliance papers found for this disease.</div>;
   }
 
+  // Order the rows mouse → rat → frog → zebrafish → fly → worm → yeast. Array
+  // .sort is stable, so papers sharing a MOD keep the backend's newest-first
+  // order.
+  const orderedResults = [...results].sort((a, b) => rowSortKey(a.literatureSummary) - rowSortKey(b.literatureSummary));
+
   return (
     <div>
-      {results.map((result, index) => (
+      {orderedResults.map((result, index) => (
         <PaperEntry key={result.literatureSummary?.curie || index} reference={result.literatureSummary} />
       ))}
     </div>


### PR DESCRIPTION
## Summary

Two changes to the Disease Portal **Recent Papers** section (`PapersSection.jsx`):

1. **RGD corpus now shows the rat icon.** It was mapped to the human icon (`Homo sapiens`) per an earlier curator decision; per Ranjana, RGD-corpus papers should display the rat MOD icon. `MOD_SPECIES.RGD` → `Rattus norvegicus`.

2. **Paper rows are ordered by MOD**: mouse → rat → frog → zebrafish → fly → worm → yeast (MGI, RGD, XB, ZFIN, FB, WB, SGD). Each row is keyed off the highest-priority MOD in its `mods_in_corpus`. The sort is stable, so papers sharing a MOD keep the backend's newest-first order; rows with no known MOD (e.g. AGR-only) sort last.

## Out of scope (backend follow-up)

Ordering the **icons within a single multi-corpus row** (floating the row's "own" MOD first) is intentionally deferred: the `latest-literature-by-disease-per-mod` endpoint returns a flat list and does not expose which corpus slot each row filled, so the associated MOD can't be reliably determined client-side. Tracked for a backend enhancement.

## Test plan

- [ ] Visit a Disease Portal detail page (e.g. Parkinson's, Alzheimer's, Diabetes) and confirm rows appear in mouse→rat→…→yeast order.
- [ ] Confirm RGD-corpus papers render the rat icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
