### PR TITLE
KANBAN-1402: Add Community Resource links to Parkinson's portal page

### DIFF
--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -64,7 +64,18 @@ export const data = {
     doid: 'DOID:14330',
     pageName: "Parkinson's Disease",
     publications: [],
-    resources: [],
+    resources: [
+      {
+        title: 'Age and Age-Related Disease Portal - Rat Genome Database',
+        url: 'https://rgd.mcw.edu/rgdweb/portal/home.jsp?p=1',
+      },
+      { title: 'National Institute on Aging', url: 'https://www.nia.nih.gov/' },
+      {
+        title: "Parkinson's Disease Clinical Trials",
+        url: 'https://clinicaltrials.gov/search?cond=Parkinson%27s%20Disease&viewType=Card',
+      },
+      { title: "Parkinson's Precision Medicine Initiative", url: 'https://www.ppmi-info.org/' },
+    ],
   },
   'diabetes-mellitus': {
     doid: 'DOID:9351',


### PR DESCRIPTION
## Summary

Populates the previously empty Community Resources list on the **Parkinson's Disease** Disease Portal page (`portalData.js`) with four resources, alphabetized by title to match the other portal sections:

- Age and Age-Related Disease Portal - Rat Genome Database
- National Institute on Aging
- Parkinson's Disease Clinical Trials
- Parkinson's Precision Medicine Initiative

Partial set provided by Ranjana; additional links may be added in a follow-up.

Jira: KANBAN-1402

## Test plan

- [ ] Visit the Parkinson's Disease portal page and confirm the four resource links render under Community Resources and each opens the correct destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
