### PR TITLE
KANBAN-1096: Add ModelMatcher and FlyBase Disease Model index to root DP resources

### DIFF
--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -8,11 +8,13 @@ export const data = {
         title: 'Disease Portals - Rat Genome Database',
         url: 'https://rgd.mcw.edu/wg/portals/',
       },
+      { title: 'FlyBase Human Disease Model Report Index', url: 'https://flybase.org/lists/FBhh/' },
       {
         title: 'Human Mouse Disease Connection',
         url: 'http://www.informatics.jax.org/mgihome/projects/aboutHMDC.shtml',
       },
       { title: 'Matchmaker Exchange', url: 'https://www.matchmakerexchange.org/' },
+      { title: 'ModelMatcher', url: 'https://www.modelmatcher.net/' },
       { title: 'Online Mendelian Inheritance of Man (OMIM)', url: 'https://www.omim.org/' },
       { title: 'Portal Kids First DRC', url: 'https://portal.kidsfirstdrc.org/login?redirect_path=/data-exploration' },
     ],


### PR DESCRIPTION
## Summary

Adds two links to the **root** Disease Portal page's Community Resources (`portalData.js`, `human` / DOID:4 section), inserted alphabetically by title:

- **FlyBase Human Disease Model Report Index** — https://flybase.org/lists/FBhh/
- **ModelMatcher** — https://www.modelmatcher.net/

Note the capital **B** in "FlyBase" per curator feedback on the ticket.

Per KANBAN-1096: these were requested at the Alliance All Hands (Feb 27, 2026) and the FlyBase index was reconfirmed missing by Sian Gramates (May 14, 2026). Neither is present in the current `stage` version, so both are (re-)added here.

Jira: KANBAN-1096

## Test plan

- [ ] Visit the root Disease Portal page and confirm both links appear under Community Resources in alphabetical order and open the correct destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
