### PR TITLE
Feature/kanban 715

### DIFF
--- a/src/components/YourInputWelcome.jsx
+++ b/src/components/YourInputWelcome.jsx
@@ -1,15 +1,30 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styles from './YourInputWelcome.module.scss';
 
+const HIDE_AFTER_SCROLL_PX = 200;
+
 const YourInputWelcome = ({ type, name, allianceId }) => {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setHidden(window.scrollY > HIDE_AFTER_SCROLL_PX);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   const params = new URLSearchParams();
   if (type) params.set('type', type);
   if (name) params.set('name', name);
   if (allianceId) params.set('id', allianceId);
+
   return (
-    <Link className={`btn btn-primary btn-sm ${styles.floatingButton}`} to={`/contact-us?${params.toString()}`}>
+    <Link
+      className={`btn btn-primary btn-sm ${styles.floatingButton} ${hidden ? styles.hidden : ''}`}
+      to={`/contact-us?${params.toString()}`}
+    >
       Your Input Welcome
     </Link>
   );

--- a/src/components/YourInputWelcome.module.scss
+++ b/src/components/YourInputWelcome.module.scss
@@ -2,5 +2,14 @@
   position: fixed;
   top: 120px;
   right: 20px;
-  //z-index: 1030;
+  z-index: 1030;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.hidden {
+  transform: translateY(-200px);
+  opacity: 0;
+  pointer-events: none;
 }

--- a/src/components/dataSourceLink.jsx
+++ b/src/components/dataSourceLink.jsx
@@ -1,18 +1,14 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ExternalLink from './ExternalLink.jsx';
 import { dataSourceType } from '../lib/types';
 
-class DataSourceLink extends Component {
-  render() {
-    const { children, reference } = this.props;
-    return reference ? (
-      <ExternalLink href={reference && reference.crossRefCompleteUrl}>
-        {children || reference.displayName || reference.name}
-      </ExternalLink>
-    ) : null;
-  }
-}
+const DataSourceLink = ({ children, reference }) =>
+  reference ? (
+    <ExternalLink href={reference && reference.crossRefCompleteUrl}>
+      {children || reference.displayName || reference.name}
+    </ExternalLink>
+  ) : null;
 
 DataSourceLink.propTypes = {
   children: PropTypes.node,

--- a/src/components/dataTable/columnHeader.jsx
+++ b/src/components/dataTable/columnHeader.jsx
@@ -7,44 +7,41 @@ import { faFilter } from '@fortawesome/free-solid-svg-icons';
 
 import style from './style.module.scss';
 
-class ColumnHeader extends React.Component {
-  render() {
-    const { column, filter, filterElement } = this.props;
-    const classes = '';
-    const popperModifiers = [
-      {
-        name: 'preventOverflow',
-        options: {
-          rootBoundary: 'viewport',
-        },
+const ColumnHeader = ({ column, filter, filterElement }) => {
+  const classes = '';
+  const popperModifiers = [
+    {
+      name: 'preventOverflow',
+      options: {
+        rootBoundary: 'viewport',
       },
-    ];
-    const active = Array.isArray(filter) ? filter.length > 0 : filter;
-    const { helpPopupProps } = column;
-    return (
-      <div className={classes}>
-        {column.headerNode || column.text}
-        {filterElement && (
-          <UncontrolledButtonDropdown>
-            <DropdownToggle className={`${style.filterToggle} ${active ? style.active : ''}`} color="link" tag="span">
-              <FontAwesomeIcon icon={faFilter} />
-            </DropdownToggle>
-            <DropdownMenu className="shadow-sm px-4 py-3" modifiers={popperModifiers} strategy="fixed">
-              {filterElement}
-            </DropdownMenu>
-          </UncontrolledButtonDropdown>
-        )}
-        {helpPopupProps ? (
-          <div className="btn-group">
-            <span className={style.helpIconWrapper}>
-              <HelpPopup {...helpPopupProps} />
-            </span>
-          </div>
-        ) : null}
-      </div>
-    );
-  }
-}
+    },
+  ];
+  const active = Array.isArray(filter) ? filter.length > 0 : filter;
+  const { helpPopupProps } = column;
+  return (
+    <div className={classes}>
+      {column.headerNode || column.text}
+      {filterElement && (
+        <UncontrolledButtonDropdown>
+          <DropdownToggle className={`${style.filterToggle} ${active ? style.active : ''}`} color="link" tag="span">
+            <FontAwesomeIcon icon={faFilter} />
+          </DropdownToggle>
+          <DropdownMenu className="shadow-sm px-4 py-3" modifiers={popperModifiers} strategy="fixed">
+            {filterElement}
+          </DropdownMenu>
+        </UncontrolledButtonDropdown>
+      )}
+      {helpPopupProps ? (
+        <div className="btn-group">
+          <span className={style.helpIconWrapper}>
+            <HelpPopup {...helpPopupProps} />
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+};
 
 ColumnHeader.propTypes = {
   column: PropTypes.object,

--- a/src/components/dataTable/columnHeader.jsx
+++ b/src/components/dataTable/columnHeader.jsx
@@ -7,20 +7,19 @@ import { faFilter } from '@fortawesome/free-solid-svg-icons';
 
 import style from './style.module.scss';
 
-const ColumnHeader = ({ column, filter, filterElement }) => {
-  const classes = '';
-  const popperModifiers = [
-    {
-      name: 'preventOverflow',
-      options: {
-        rootBoundary: 'viewport',
-      },
+const popperModifiers = [
+  {
+    name: 'preventOverflow',
+    options: {
+      rootBoundary: 'viewport',
     },
-  ];
+  },
+];
+const ColumnHeader = ({ column, filter, filterElement }) => {
   const active = Array.isArray(filter) ? filter.length > 0 : filter;
   const { helpPopupProps } = column;
   return (
-    <div className={classes}>
+    <div>
       {column.headerNode || column.text}
       {filterElement && (
         <UncontrolledButtonDropdown>
@@ -32,13 +31,13 @@ const ColumnHeader = ({ column, filter, filterElement }) => {
           </DropdownMenu>
         </UncontrolledButtonDropdown>
       )}
-      {helpPopupProps ? (
+      {helpPopupProps && (
         <div className="btn-group">
           <span className={style.helpIconWrapper}>
             <HelpPopup {...helpPopupProps} />
           </span>
         </div>
-      ) : null}
+      )}
     </div>
   );
 };

--- a/src/components/dataTable/referencesCellCuration.jsx
+++ b/src/components/dataTable/referencesCellCuration.jsx
@@ -14,21 +14,18 @@ const removeDuplicates = (refs) => {
 };
 
 const ReferencesCellCuration = ({ pubModIds }) => {
+  if (!pubModIds || pubModIds.length === 0) return null;
   const refStringsAndUrls = getMultipleReferencesUrls(pubModIds);
   const uniqueRefs = removeDuplicates(refStringsAndUrls);
 
   return (
-    pubModIds && (
-      <CollapsibleList>
-        {uniqueRefs.map(({ pubModId, url }) => {
-          return (
-            <ExternalLink href={url} key={pubModId} title={pubModId}>
-              {pubModId}
-            </ExternalLink>
-          );
-        })}
-      </CollapsibleList>
-    )
+    <CollapsibleList>
+      {uniqueRefs.map(({ pubModId, url }) => (
+        <ExternalLink href={url} key={pubModId} title={pubModId}>
+          {pubModId}
+        </ExternalLink>
+      ))}
+    </CollapsibleList>
   );
 };
 

--- a/src/components/dataTable/singleReferenceCellCuration.jsx
+++ b/src/components/dataTable/singleReferenceCellCuration.jsx
@@ -16,7 +16,7 @@ const SingleReferenceCellCuration = ({ singleReference, pubModIds }) => {
 
 const getSingleReferencePubModId = (reference, pubModIds) => {
   // for human references we have orphanet IDs coming from ExternalDatabase
-  if (!reference.crossReferences) return reference.curie;
+  if (!reference.crossReferences || !Array.isArray(pubModIds)) return reference.curie;
   return reference.crossReferences
     .filter((crossRef) => pubModIds.includes(crossRef.referencedCurie))
     .map((crossRef) => crossRef.referencedCurie)[0];

--- a/src/components/dataTable/utils.jsx
+++ b/src/components/dataTable/utils.jsx
@@ -27,6 +27,7 @@ export const getIdentifier = (subject) => {
 };
 
 export const getSingleReferenceUrl = (pubModId) => {
+  if (!pubModId) return { pubModId, url: null };
   let url;
   if (
     pubModId.includes('PMID') ||
@@ -42,7 +43,11 @@ export const getSingleReferenceUrl = (pubModId) => {
 };
 
 export const getMultipleReferencesUrls = (pubModIds) => {
-  return pubModIds.sort().map((pubModId) => getSingleReferenceUrl(pubModId));
+  if (!Array.isArray(pubModIds)) return [];
+  return pubModIds
+    .filter(Boolean)
+    .sort()
+    .map((pubModId) => getSingleReferenceUrl(pubModId));
 };
 
 const buildProvider = (annotation) => {

--- a/src/components/headMetaTags.jsx
+++ b/src/components/headMetaTags.jsx
@@ -1,49 +1,47 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { HELP_EMAIL } from '../constants';
 
-class HeadMetaTags extends Component {
-  render() {
-    const title = `${this.props.title} | Alliance of Genome Resources`;
-    let jsonLd = this.props.jsonLd || [];
-    if (!Array.isArray(jsonLd)) {
-      jsonLd = [jsonLd];
-    }
-    const schemas = [
-      // general view
-      {
-        '@context': 'http://schema.org',
-        '@type': 'Organization',
-        url: 'https://www.alliancegenome.org',
-        logo: 'https://i1.wp.com/alliancegenome.files.wordpress.com/2016/11/banner_1_flyin_logo.png',
-        email: HELP_EMAIL,
-      },
-
-      // specify actions
-      {
-        '@context': 'http://schema.org',
-        '@type': 'WebSite',
-        url: 'https://www.alliancegenome.org/',
-        potentialAction: {
-          '@type': 'SearchAction',
-          target: 'https://www.alliancegenome.org/search?q={term}',
-          'query-input': 'required name=term',
-        },
-      },
-
-      // passed from props
-      ...jsonLd,
-    ];
-
-    const scripts = schemas.map((schema) => ({
-      type: 'application/ld+json',
-      innerHTML: JSON.stringify(schema),
-    }));
-
-    return <Helmet meta={[{ property: 'og:title', content: { title } }]} script={scripts} title={title} />;
+const HeadMetaTags = ({ title, jsonLd }) => {
+  const fullTitle = `${title} | Alliance of Genome Resources`;
+  let extraSchemas = jsonLd || [];
+  if (!Array.isArray(extraSchemas)) {
+    extraSchemas = [extraSchemas];
   }
-}
+  const schemas = [
+    // general view
+    {
+      '@context': 'http://schema.org',
+      '@type': 'Organization',
+      url: 'https://www.alliancegenome.org',
+      logo: 'https://i1.wp.com/alliancegenome.files.wordpress.com/2016/11/banner_1_flyin_logo.png',
+      email: HELP_EMAIL,
+    },
+
+    // specify actions
+    {
+      '@context': 'http://schema.org',
+      '@type': 'WebSite',
+      url: 'https://www.alliancegenome.org/',
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: 'https://www.alliancegenome.org/search?q={term}',
+        'query-input': 'required name=term',
+      },
+    },
+
+    // passed from props
+    ...extraSchemas,
+  ];
+
+  const scripts = schemas.map((schema) => ({
+    type: 'application/ld+json',
+    innerHTML: JSON.stringify(schema),
+  }));
+
+  return <Helmet meta={[{ property: 'og:title', content: { title: fullTitle } }]} script={scripts} title={fullTitle} />;
+};
 
 HeadMetaTags.propTypes = {
   jsonLd: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),

--- a/src/components/helpPopup.jsx
+++ b/src/components/helpPopup.jsx
@@ -5,16 +5,17 @@ import { makeId } from '../lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion } from '@fortawesome/free-solid-svg-icons';
 
+const popperModifiers = [
+  {
+    name: 'preventOverflow',
+    options: {
+      rootBoundary: 'viewport',
+    },
+  },
+];
 const HelpPopup = ({ children, id, placement = 'top-start', ...otherProps }) => {
   id = makeId(id);
-  const popperModifiers = [
-    {
-      name: 'preventOverflow',
-      options: {
-        rootBoundary: 'viewport',
-      },
-    },
-  ];
+
   return (
     <>
       <FontAwesomeIcon icon={faCircleQuestion} id={id} style={{ cursor: 'pointer' }} className="text-primary" />

--- a/src/components/loadingPage.jsx
+++ b/src/components/loadingPage.jsx
@@ -1,25 +1,21 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import style from './style.module.scss';
 import { SMALL_COL_CLASS, LARGE_COL_CLASS } from '../constants';
 
-class LoadingPage extends Component {
-  render() {
-    return (
-      <div className={`row ${style.fadeInAndOut}`}>
-        <div className={SMALL_COL_CLASS}>
-          <div className={style.loadingText} />
-          <div className={style.loadingText} />
-        </div>
-        <div className={LARGE_COL_CLASS}>
-          <div className={`${style.loadingText} ${style.loadingHeader}`} />
-          <div className={style.loadingText} />
-          <div className={style.loadingText} />
-          <div className={style.loadingText} />
-        </div>
-      </div>
-    );
-  }
-}
+const LoadingPage = () => (
+  <div className={`row ${style.fadeInAndOut}`}>
+    <div className={SMALL_COL_CLASS}>
+      <div className={style.loadingText} />
+      <div className={style.loadingText} />
+    </div>
+    <div className={LARGE_COL_CLASS}>
+      <div className={`${style.loadingText} ${style.loadingHeader}`} />
+      <div className={style.loadingText} />
+      <div className={style.loadingText} />
+      <div className={style.loadingText} />
+    </div>
+  </div>
+);
 
 export default LoadingPage;

--- a/src/components/notFound.jsx
+++ b/src/components/notFound.jsx
@@ -11,7 +11,11 @@ const NotFound = () => (
         If you continue to see this page, please email <a href={`mailto:${HELP_EMAIL}`}>{HELP_EMAIL}</a>.
       </p>
     </div>
-    <img alt="" src={notFoundImg} style={{ display: 'block', maxWidth: '45rem', margin: '0 auto', padding: '3rem 0' }} />
+    <img
+      alt=""
+      src={notFoundImg}
+      style={{ display: 'block', maxWidth: '45rem', margin: '0 auto', padding: '3rem 0' }}
+    />
   </div>
 );
 

--- a/src/components/notFound.jsx
+++ b/src/components/notFound.jsx
@@ -1,26 +1,18 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { HELP_EMAIL } from '../constants';
 
 import notFoundImg from './notFound.png';
 
-class NotFound extends Component {
-  render() {
-    return (
-      <div className="container">
-        <div className="alert alert-info" style={{ margin: '0 auto', maxWidth: '45rem', textAlign: 'center' }}>
-          <h1>Page Not Found</h1>
-          <p>
-            If you continue to see this page, please email <a href={`mailto:${HELP_EMAIL}`}>{HELP_EMAIL}</a>.
-          </p>
-        </div>
-        <img
-          alt=""
-          src={notFoundImg}
-          style={{ display: 'block', maxWidth: '45rem', margin: '0 auto', padding: '3rem 0' }}
-        />
-      </div>
-    );
-  }
-}
+const NotFound = () => (
+  <div className="container">
+    <div className="alert alert-info" style={{ margin: '0 auto', maxWidth: '45rem', textAlign: 'center' }}>
+      <h1>Page Not Found</h1>
+      <p>
+        If you continue to see this page, please email <a href={`mailto:${HELP_EMAIL}`}>{HELP_EMAIL}</a>.
+      </p>
+    </div>
+    <img alt="" src={notFoundImg} style={{ display: 'block', maxWidth: '45rem', margin: '0 auto', padding: '3rem 0' }} />
+  </div>
+);
 
 export default NotFound;

--- a/src/components/orthology/orthologyTable.jsx
+++ b/src/components/orthology/orthologyTable.jsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import MethodHeader from '../homology/methodHeader.jsx';
@@ -37,70 +37,68 @@ export function isBest(value = '') {
   return typeof value === 'boolean' ? value : !!value.match(/yes/i);
 }
 
-class OrthologyTable extends Component {
-  render() {
-    let rowGroup = 0;
-    return (
-      <table className="table">
-        <thead className="text-capitalize">
-          <tr>
-            {columns.map((column) => {
-              if (column.name === 'Method') {
-                return <MethodHeader key={column.name} name={column.name} />;
-              } else {
-                return (
-                  <th key={column.name}>
-                    {column.name} {column.help && <HelpPopup id={`help-${column.name}`}>{column.help}</HelpPopup>}
-                  </th>
-                );
-              }
-            })}
-          </tr>
-        </thead>
-        <tbody>
-          {sortBy(this.props.data, [
-            compareByFixedOrder(TAXON_ORDER, (o) => getOrthologSpeciesId(o)),
-            (orthDataA, orthDataB) =>
-              orthDataB.predictionMethodsMatched.length - orthDataA.predictionMethodsMatched.length,
-          ]).map((orthData, idx, orthList) => {
-            const scoreNumerator = orthData.predictionMethodsMatched?.length;
-            const scoreDemominator = scoreNumerator + (orthData.predictionMethodsNotMatched?.length || 0);
-            const orthId = getOrthologId(orthData);
-
-            if (idx > 0 && getOrthologSpeciesName(orthList[idx - 1]) !== getOrthologSpeciesName(orthData)) {
-              rowGroup += 1;
+const OrthologyTable = ({ data }) => {
+  let rowGroup = 0;
+  return (
+    <table className="table">
+      <thead className="text-capitalize">
+        <tr>
+          {columns.map((column) => {
+            if (column.name === 'Method') {
+              return <MethodHeader key={column.name} name={column.name} />;
+            } else {
+              return (
+                <th key={column.name}>
+                  {column.name} {column.help && <HelpPopup id={`help-${column.name}`}>{column.help}</HelpPopup>}
+                </th>
+              );
             }
-            return (
-              <tr className={rowGroup % 2 === 0 ? style.groupedRow : ''} key={orthId}>
-                <td>
-                  <SpeciesName>{getOrthologSpeciesName(orthData)}</SpeciesName>
-                </td>
-                <td>
-                  <Link to={`/gene/${orthId}`}>
-                    <span dangerouslySetInnerHTML={{ __html: getOrthologSymbol(orthData) }} />
-                  </Link>
-                </td>
-                <td>{`${scoreNumerator} of ${scoreDemominator}`}</td>
-                <BooleanCell
-                  isTrueFunc={isBest}
-                  render={orthData.isBestScore?.name === 'Yes_Adjusted' ? () => 'Yes *' : null}
-                  value={orthData.isBestScore.name}
-                />
-                <BooleanCell isTrueFunc={isBest} value={orthData.isBestScoreReverse.name} />
-                <MethodCell
-                  predictionMethodsMatched={orthData.predictionMethodsMatched?.map((method) => method.name)}
-                  predictionMethodsNotMatched={orthData.predictionMethodsNotMatched?.map((method) => method.name)}
-                  rowKey={orthId}
-                  paralogy={false}
-                />
-              </tr>
-            );
           })}
-        </tbody>
-      </table>
-    );
-  }
-}
+        </tr>
+      </thead>
+      <tbody>
+        {sortBy(data, [
+          compareByFixedOrder(TAXON_ORDER, (o) => getOrthologSpeciesId(o)),
+          (orthDataA, orthDataB) =>
+            orthDataB.predictionMethodsMatched.length - orthDataA.predictionMethodsMatched.length,
+        ]).map((orthData, idx, orthList) => {
+          const scoreNumerator = orthData.predictionMethodsMatched?.length;
+          const scoreDemominator = scoreNumerator + (orthData.predictionMethodsNotMatched?.length || 0);
+          const orthId = getOrthologId(orthData);
+
+          if (idx > 0 && getOrthologSpeciesName(orthList[idx - 1]) !== getOrthologSpeciesName(orthData)) {
+            rowGroup += 1;
+          }
+          return (
+            <tr className={rowGroup % 2 === 0 ? style.groupedRow : ''} key={orthId}>
+              <td>
+                <SpeciesName>{getOrthologSpeciesName(orthData)}</SpeciesName>
+              </td>
+              <td>
+                <Link to={`/gene/${orthId}`}>
+                  <span dangerouslySetInnerHTML={{ __html: getOrthologSymbol(orthData) }} />
+                </Link>
+              </td>
+              <td>{`${scoreNumerator} of ${scoreDemominator}`}</td>
+              <BooleanCell
+                isTrueFunc={isBest}
+                render={orthData.isBestScore?.name === 'Yes_Adjusted' ? () => 'Yes *' : null}
+                value={orthData.isBestScore.name}
+              />
+              <BooleanCell isTrueFunc={isBest} value={orthData.isBestScoreReverse.name} />
+              <MethodCell
+                predictionMethodsMatched={orthData.predictionMethodsMatched?.map((method) => method.name)}
+                predictionMethodsNotMatched={orthData.predictionMethodsNotMatched?.map((method) => method.name)}
+                rowKey={orthId}
+                paralogy={false}
+              />
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
 
 OrthologyTable.propTypes = {
   data: PropTypes.arrayOf(

--- a/src/components/subsection.jsx
+++ b/src/components/subsection.jsx
@@ -29,19 +29,13 @@ const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isM
   );
   switch (level) {
     case 1:
-      renderTitle = (
-        <h4 className="text-break">{titleContent}</h4>
-      );
+      renderTitle = <h4 className="text-break">{titleContent}</h4>;
       break;
     case 2:
-      renderTitle = (
-        <h5>{titleContent}</h5>
-      );
+      renderTitle = <h5>{titleContent}</h5>;
       break;
     default:
-      renderTitle = (
-        <h3>{titleContent}</h3>
-      );
+      renderTitle = <h3>{titleContent}</h3>;
   }
 
   return (

--- a/src/components/subsection.jsx
+++ b/src/components/subsection.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable jsx-a11y/anchor-has-content */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import style from './style.module.scss';
@@ -10,60 +10,54 @@ import NoData from './noData.jsx';
 import ErrorBoundary from './errorBoundary.jsx';
 import HelpPopup from './helpPopup.jsx';
 
-class Subsection extends Component {
-  render() {
-    const id = this.props.title && makeId(this.props.title);
-    const target = <a className={style.target} id={id} />;
-    const helpPopup = this.props.help && (
-      <span className="small ml-3">
-        <HelpPopup id={`help-${this.props.title}`}>{this.props.help}</HelpPopup>
-      </span>
-    );
+const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isMeta, level, title }) => {
+  const id = title && makeId(title);
+  const target = <a className={style.target} id={id} />;
+  const helpPopup = help && (
+    <span className="small ml-3">
+      <HelpPopup id={`help-${title}`}>{help}</HelpPopup>
+    </span>
+  );
 
-    let renderTitle;
-    switch (this.props.level) {
-      case 1:
-        renderTitle = (
-          <h4 className="text-break">
-            {this.props.isMeta && target}
-            {this.props.title}
-            {helpPopup}
-          </h4>
-        );
-        break;
-      case 2:
-        renderTitle = (
-          <h5>
-            {this.props.isMeta && target}
-            {this.props.title}
-            {helpPopup}
-          </h5>
-        );
-        break;
-      default:
-        renderTitle = (
-          <h3>
-            {this.props.isMeta && target}
-            {this.props.title}
-            {helpPopup}
-          </h3>
-        );
-    }
-
-    return (
-      <div className={style.subsection}>
-        {!this.props.isMeta && target}
-        {this.props.hardcoded && <span className="badge badge-danger">Hardcoded Example Data</span>}
-        {this.props.title && !this.props.hideTitle && renderTitle}
-        {typeof this.props.hasData !== 'undefined' && !this.props.hasData ? (
-          <NoData />
-        ) : (
-          <ErrorBoundary>{this.props.children}</ErrorBoundary>
-        )}
-      </div>
-    );
+  let renderTitle;
+  switch (level) {
+    case 1:
+      renderTitle = (
+        <h4 className="text-break">
+          {isMeta && target}
+          {title}
+          {helpPopup}
+        </h4>
+      );
+      break;
+    case 2:
+      renderTitle = (
+        <h5>
+          {isMeta && target}
+          {title}
+          {helpPopup}
+        </h5>
+      );
+      break;
+    default:
+      renderTitle = (
+        <h3>
+          {isMeta && target}
+          {title}
+          {helpPopup}
+        </h3>
+      );
   }
-}
+
+  return (
+    <div className={style.subsection}>
+      {!isMeta && target}
+      {hardcoded && <span className="badge badge-danger">Hardcoded Example Data</span>}
+      {title && !hideTitle && renderTitle}
+      {typeof hasData !== 'undefined' && !hasData ? <NoData /> : <ErrorBoundary>{children}</ErrorBoundary>}
+    </div>
+  );
+};
 
 Subsection.propTypes = {
   children: PropTypes.node.isRequired,
@@ -74,10 +68,6 @@ Subsection.propTypes = {
   isMeta: PropTypes.bool,
   level: PropTypes.number,
   title: PropTypes.string,
-};
-
-Subsection.defaultProps = {
-  hideTitle: false,
 };
 
 export default Subsection;

--- a/src/components/subsection.jsx
+++ b/src/components/subsection.jsx
@@ -20,32 +20,27 @@ const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isM
   );
 
   let renderTitle;
+  const titleContent = (
+    <>
+      {isMeta && target}
+      {title}
+      {helpPopup}
+    </>
+  );
   switch (level) {
     case 1:
       renderTitle = (
-        <h4 className="text-break">
-          {isMeta && target}
-          {title}
-          {helpPopup}
-        </h4>
+        <h4 className="text-break">{titleContent}</h4>
       );
       break;
     case 2:
       renderTitle = (
-        <h5>
-          {isMeta && target}
-          {title}
-          {helpPopup}
-        </h5>
+        <h5>{titleContent}</h5>
       );
       break;
     default:
       renderTitle = (
-        <h3>
-          {isMeta && target}
-          {title}
-          {helpPopup}
-        </h3>
+        <h3>{titleContent}</h3>
       );
   }
 

--- a/src/components/subsection.jsx
+++ b/src/components/subsection.jsx
@@ -12,7 +12,7 @@ import HelpPopup from './helpPopup.jsx';
 
 const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isMeta, level, title }) => {
   const id = title && makeId(title);
-  const target = <a className={style.target} id={id} />;
+  const Target = () => <a className={style.target} id={id} />;
   const helpPopup = help && (
     <span className="small ml-3">
       <HelpPopup id={`help-${title}`}>{help}</HelpPopup>
@@ -22,7 +22,7 @@ const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isM
   let renderTitle;
   const titleContent = (
     <>
-      {isMeta && target}
+      {isMeta && <target />}
       {title}
       {helpPopup}
     </>
@@ -40,7 +40,7 @@ const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isM
 
   return (
     <div className={style.subsection}>
-      {!isMeta && target}
+      {!isMeta && <Target />}
       {hardcoded && <span className="badge badge-danger">Hardcoded Example Data</span>}
       {title && !hideTitle && renderTitle}
       {typeof hasData !== 'undefined' && !hasData ? <NoData /> : <ErrorBoundary>{children}</ErrorBoundary>}

--- a/src/containers/diseasePage/basicDiseaseInfo.jsx
+++ b/src/containers/diseasePage/basicDiseaseInfo.jsx
@@ -88,7 +88,9 @@ const transformSynonyms = (synonyms) => {
 const BasicDiseaseInfo = ({ disease }) => (
   <AttributeList>
     <AttributeLabel>Definition</AttributeLabel>
-    <AttributeValue><Definition disease={disease.doTerm} /></AttributeValue>
+    <AttributeValue>
+      <Definition disease={disease.doTerm} />
+    </AttributeValue>
 
     <AttributeLabel>Synonyms</AttributeLabel>
     <AttributeValue placeholder="None">
@@ -103,13 +105,19 @@ const BasicDiseaseInfo = ({ disease }) => (
     </AttributeValue>
 
     <AttributeLabel>Parent Terms</AttributeLabel>
-    <AttributeValue placeholder="None"><TermList terms={disease.parents} /></AttributeValue>
+    <AttributeValue placeholder="None">
+      <TermList terms={disease.parents} />
+    </AttributeValue>
 
     <AttributeLabel>Child Terms</AttributeLabel>
-    <AttributeValue placeholder="None"><TermList terms={disease.children} /></AttributeValue>
+    <AttributeValue placeholder="None">
+      <TermList terms={disease.children} />
+    </AttributeValue>
 
     <AttributeLabel>Sources of Associations</AttributeLabel>
-    <AttributeValue><SourceList sources={disease.sourceReferenceLinkUrls} /></AttributeValue>
+    <AttributeValue>
+      <SourceList sources={disease.sourceReferenceLinkUrls} />
+    </AttributeValue>
   </AttributeList>
 );
 

--- a/src/containers/diseasePage/basicDiseaseInfo.jsx
+++ b/src/containers/diseasePage/basicDiseaseInfo.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { UncontrolledTooltip } from 'reactstrap';
@@ -14,126 +14,104 @@ import { smartAlphaSort } from '../../lib/utils';
 import SynonymList from '../../components/synonymList.jsx';
 import { formatLink } from './utils';
 
-class BasicDiseaseInfo extends Component {
-  renderTermList(terms) {
-    return (
-      terms && (
-        <CollapsibleList>
-          {terms.sort(smartAlphaSort((term) => term.name)).map((term) => (
-            <Link key={term.curie} to={`/disease/${term.curie}`}>
-              {term.name}
-            </Link>
-          ))}
-        </CollapsibleList>
-      )
-    );
-  }
+const renderTermList = (terms) =>
+  terms && (
+    <CollapsibleList>
+      {terms.sort(smartAlphaSort((term) => term.name)).map((term) => (
+        <Link key={term.curie} to={`/disease/${term.curie}`}>
+          {term.name}
+        </Link>
+      ))}
+    </CollapsibleList>
+  );
 
-  renderSourceList(sources) {
-    return (
-      sources && (
-        <CommaSeparatedList>
-          {sources.map((source) => (
-            <ExternalLink href={source.url} key={`source-${source.source}`}>
-              {source.source}
+const renderSourceList = (sources) =>
+  sources && (
+    <CommaSeparatedList>
+      {sources.map((source) => (
+        <ExternalLink href={source.url} key={`source-${source.source}`}>
+          {source.source}
+        </ExternalLink>
+      ))}
+    </CommaSeparatedList>
+  );
+
+const renderDefinitionLinks = (links) =>
+  links && (
+    <CommaSeparatedList>
+      {links.map((link, idx) => {
+        const formatedLink = formatLink(link);
+        return (
+          <span key={link}>
+            <ExternalLink href={formatedLink} id={`definition-link-${idx}`}>
+              [{idx + 1}]
             </ExternalLink>
-          ))}
-        </CommaSeparatedList>
-      )
-    );
+            <UncontrolledTooltip
+              delay={{ show: 200, hide: 0 }}
+              innerClassName={style.urlTooltip}
+              placement="bottom"
+              target={`definition-link-${idx}`}
+            >
+              {formatedLink}
+            </UncontrolledTooltip>
+          </span>
+        );
+      })}
+    </CommaSeparatedList>
+  );
+
+const renderDefinition = (disease) =>
+  (disease.definition || (disease.definitionUrls && disease.definitionUrls.length > 0)) && (
+    <div>
+      {disease.definition} {renderDefinitionLinks(disease.definitionUrls)}
+    </div>
+  );
+
+const transformCrossReferenceLinkUrls = (crossReferenceLinkUrls) => {
+  if (!Array.isArray(crossReferenceLinkUrls)) {
+    return [];
   }
+  return crossReferenceLinkUrls.map(({ referencedCurie, url }) => ({
+    crossRefCompleteUrl: url,
+    name: referencedCurie,
+    displayName: referencedCurie,
+  }));
+};
 
-  renderDefinition(disease) {
-    return (
-      (disease.definition || (disease.definitionUrls && disease.definitionUrls.length > 0)) && (
-        <div>
-          {disease.definition} {this.renderDefinitionLinks(disease.definitionUrls)}
-        </div>
-      )
-    );
+const transformSynonyms = (synonyms) => {
+  if (!Array.isArray(synonyms)) {
+    return [];
   }
+  return synonyms.map((item) => item.name);
+};
 
-  renderDefinitionLinks(links) {
-    return (
-      links && (
-        <CommaSeparatedList>
-          {links.map((link, idx) => {
-            const formatedLink = formatLink(link);
-            return (
-              <span key={link}>
-                <ExternalLink href={formatedLink} id={`definition-link-${idx}`}>
-                  [{idx + 1}]
-                </ExternalLink>
-                <UncontrolledTooltip
-                  delay={{ show: 200, hide: 0 }}
-                  innerClassName={style.urlTooltip}
-                  placement="bottom"
-                  target={`definition-link-${idx}`}
-                >
-                  {formatedLink}
-                </UncontrolledTooltip>
-              </span>
-            );
-          })}
-        </CommaSeparatedList>
-      )
-    );
-  }
+const BasicDiseaseInfo = ({ disease }) => (
+  <AttributeList>
+    <AttributeLabel>Definition</AttributeLabel>
+    <AttributeValue>{renderDefinition(disease.doTerm)}</AttributeValue>
 
-  render() {
-    const { disease } = this.props;
+    <AttributeLabel>Synonyms</AttributeLabel>
+    <AttributeValue placeholder="None">
+      {disease.doTerm.synonyms && <SynonymList synonyms={transformSynonyms(disease.doTerm.synonyms)} />}
+    </AttributeValue>
 
-    const transformCrossReferenceLinkUrls = (crossReferenceLinkUrls) => {
-      if (!Array.isArray(crossReferenceLinkUrls)) {
-        return [];
-      }
+    <AttributeLabel>Cross References</AttributeLabel>
+    <AttributeValue>
+      {disease.crossReferenceLinkUrls && (
+        <CrossReferenceList crossReferences={transformCrossReferenceLinkUrls(disease.crossReferenceLinkUrls)} />
+      )}
+    </AttributeValue>
 
-      return crossReferenceLinkUrls.map((item) => {
-        const { referencedCurie, url } = item;
-        return {
-          crossRefCompleteUrl: url,
-          name: referencedCurie,
-          displayName: referencedCurie,
-        };
-      });
-    };
+    <AttributeLabel>Parent Terms</AttributeLabel>
+    <AttributeValue placeholder="None">{renderTermList(disease.parents)}</AttributeValue>
 
-    const transformSynonyms = (synonyms) => {
-      if (!Array.isArray(synonyms)) {
-        return [];
-      }
-      return synonyms.map((item) => item.name);
-    };
+    <AttributeLabel>Child Terms</AttributeLabel>
+    <AttributeValue placeholder="None">{renderTermList(disease.children)}</AttributeValue>
 
-    return (
-      <AttributeList>
-        <AttributeLabel>Definition</AttributeLabel>
-        <AttributeValue>{this.renderDefinition(disease.doTerm)}</AttributeValue>
-
-        <AttributeLabel>Synonyms</AttributeLabel>
-        <AttributeValue placeholder="None">
-          {disease.doTerm.synonyms && <SynonymList synonyms={transformSynonyms(disease.doTerm.synonyms)} />}
-        </AttributeValue>
-
-        <AttributeLabel>Cross References</AttributeLabel>
-        <AttributeValue>
-          {disease.crossReferenceLinkUrls && (
-            <CrossReferenceList crossReferences={transformCrossReferenceLinkUrls(disease.crossReferenceLinkUrls)} />
-          )}
-        </AttributeValue>
-
-        <AttributeLabel>Parent Terms</AttributeLabel>
-        <AttributeValue placeholder="None">{this.renderTermList(disease.parents)}</AttributeValue>
-
-        <AttributeLabel>Child Terms</AttributeLabel>
-        <AttributeValue placeholder="None">{this.renderTermList(disease.children)}</AttributeValue>
-
-        <AttributeLabel>Sources of Associations</AttributeLabel>
-        <AttributeValue>{this.renderSourceList(disease.sourceReferenceLinkUrls)}</AttributeValue>
-      </AttributeList>
-    );
-  }
-}
+    <AttributeLabel>Sources of Associations</AttributeLabel>
+    <AttributeValue>{renderSourceList(disease.sourceReferenceLinkUrls)}</AttributeValue>
+  </AttributeList>
+);
 
 BasicDiseaseInfo.propTypes = {
   disease: PropTypes.object,

--- a/src/containers/diseasePage/basicDiseaseInfo.jsx
+++ b/src/containers/diseasePage/basicDiseaseInfo.jsx
@@ -14,7 +14,7 @@ import { smartAlphaSort } from '../../lib/utils';
 import SynonymList from '../../components/synonymList.jsx';
 import { formatLink } from './utils';
 
-const renderTermList = (terms) =>
+const TermList = ({ terms }) =>
   terms && (
     <CollapsibleList>
       {terms.sort(smartAlphaSort((term) => term.name)).map((term) => (
@@ -25,7 +25,7 @@ const renderTermList = (terms) =>
     </CollapsibleList>
   );
 
-const renderSourceList = (sources) =>
+const SourceList = ({ sources }) =>
   sources && (
     <CommaSeparatedList>
       {sources.map((source) => (
@@ -36,7 +36,7 @@ const renderSourceList = (sources) =>
     </CommaSeparatedList>
   );
 
-const renderDefinitionLinks = (links) =>
+const DefinitionLinks = ({ links }) =>
   links && (
     <CommaSeparatedList>
       {links.map((link, idx) => {
@@ -60,10 +60,10 @@ const renderDefinitionLinks = (links) =>
     </CommaSeparatedList>
   );
 
-const renderDefinition = (disease) =>
+const Definition = ({ disease }) =>
   (disease.definition || (disease.definitionUrls && disease.definitionUrls.length > 0)) && (
     <div>
-      {disease.definition} {renderDefinitionLinks(disease.definitionUrls)}
+      {disease.definition} <DefinitionLinks links={disease.definitionUrls} />
     </div>
   );
 
@@ -88,7 +88,7 @@ const transformSynonyms = (synonyms) => {
 const BasicDiseaseInfo = ({ disease }) => (
   <AttributeList>
     <AttributeLabel>Definition</AttributeLabel>
-    <AttributeValue>{renderDefinition(disease.doTerm)}</AttributeValue>
+    <AttributeValue><Definition disease={disease.doTerm} /></AttributeValue>
 
     <AttributeLabel>Synonyms</AttributeLabel>
     <AttributeValue placeholder="None">
@@ -103,13 +103,13 @@ const BasicDiseaseInfo = ({ disease }) => (
     </AttributeValue>
 
     <AttributeLabel>Parent Terms</AttributeLabel>
-    <AttributeValue placeholder="None">{renderTermList(disease.parents)}</AttributeValue>
+    <AttributeValue placeholder="None"><TermList terms={disease.parents} /></AttributeValue>
 
     <AttributeLabel>Child Terms</AttributeLabel>
-    <AttributeValue placeholder="None">{renderTermList(disease.children)}</AttributeValue>
+    <AttributeValue placeholder="None"><TermList terms={disease.children} /></AttributeValue>
 
     <AttributeLabel>Sources of Associations</AttributeLabel>
-    <AttributeValue>{renderSourceList(disease.sourceReferenceLinkUrls)}</AttributeValue>
+    <AttributeValue><SourceList sources={disease.sourceReferenceLinkUrls} /></AttributeValue>
   </AttributeList>
 );
 

--- a/src/containers/genePage/basicGeneInfo.jsx
+++ b/src/containers/genePage/basicGeneInfo.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { AttributeList, AttributeLabel, AttributeValue } from '../../components/attribute';
@@ -12,63 +12,60 @@ import { HELP_AUTOMATED_GENE_DESCRIPTION } from './constants';
 import GeneSymbol from '../../components/GeneSymbol.jsx';
 import SpeciesName from '../../components/SpeciesName.jsx';
 
-class BasicGeneInfo extends Component {
-  render() {
-    const { gene } = this.props;
-    const synopsisProvider = getSpecies(gene.species.taxonId).geneSynopsisProvider || gene.dataProvider;
-    return (
-      <AttributeList>
-        <AttributeLabel>Species</AttributeLabel>
-        <AttributeValue>
-          <SpeciesName>{gene.species.name}</SpeciesName>
-        </AttributeValue>
+const BasicGeneInfo = ({ gene }) => {
+  const synopsisProvider = getSpecies(gene.species.taxonId).geneSynopsisProvider || gene.dataProvider;
+  return (
+    <AttributeList>
+      <AttributeLabel>Species</AttributeLabel>
+      <AttributeValue>
+        <SpeciesName>{gene.species.name}</SpeciesName>
+      </AttributeValue>
 
-        <AttributeLabel>Symbol</AttributeLabel>
-        <AttributeValue>
-          <GeneSymbol gene={gene} />
-        </AttributeValue>
+      <AttributeLabel>Symbol</AttributeLabel>
+      <AttributeValue>
+        <GeneSymbol gene={gene} />
+      </AttributeValue>
 
-        <AttributeLabel>Name</AttributeLabel>
-        <AttributeValue>{gene.name}</AttributeValue>
+      <AttributeLabel>Name</AttributeLabel>
+      <AttributeValue>{gene.name}</AttributeValue>
 
-        <AttributeLabel>Synonyms</AttributeLabel>
-        <AttributeValue placeholder="None">
-          {gene.synonyms && gene.synonyms.length && <SynonymList synonyms={gene.synonyms} />}
-        </AttributeValue>
+      <AttributeLabel>Synonyms</AttributeLabel>
+      <AttributeValue placeholder="None">
+        {gene.synonyms && gene.synonyms.length && <SynonymList synonyms={gene.synonyms} />}
+      </AttributeValue>
 
-        <AttributeLabel>Biotype</AttributeLabel>
-        <AttributeValue>{gene.soTerm.name.replace(/_/g, ' ')}</AttributeValue>
+      <AttributeLabel>Biotype</AttributeLabel>
+      <AttributeValue>{gene.soTerm.name.replace(/_/g, ' ')}</AttributeValue>
 
-        <AttributeLabel>
-          Automated Description{' '}
-          {HELP_AUTOMATED_GENE_DESCRIPTION && (
-            <HelpPopup id={'help-gene-auto-desc'}>{HELP_AUTOMATED_GENE_DESCRIPTION}</HelpPopup>
-          )}
-        </AttributeLabel>
-        <AttributeValue>{gene.automatedGeneSynopsis}</AttributeValue>
+      <AttributeLabel>
+        Automated Description{' '}
+        {HELP_AUTOMATED_GENE_DESCRIPTION && (
+          <HelpPopup id={'help-gene-auto-desc'}>{HELP_AUTOMATED_GENE_DESCRIPTION}</HelpPopup>
+        )}
+      </AttributeLabel>
+      <AttributeValue>{gene.automatedGeneSynopsis}</AttributeValue>
 
-        <AttributeLabel>{synopsisProvider} Description</AttributeLabel>
-        <AttributeValue>
-          {(gene.geneSynopsis || gene.geneSynopsisUrl) && (
-            <ModGeneDescription description={gene.geneSynopsis} url={gene.geneSynopsisUrl} />
-          )}
-        </AttributeValue>
+      <AttributeLabel>{synopsisProvider} Description</AttributeLabel>
+      <AttributeValue>
+        {(gene.geneSynopsis || gene.geneSynopsisUrl) && (
+          <ModGeneDescription description={gene.geneSynopsis} url={gene.geneSynopsisUrl} />
+        )}
+      </AttributeValue>
 
-        <AttributeLabel>Cross References</AttributeLabel>
-        <AttributeValue>
-          {gene.crossReferenceMap.other && <CrossReferenceList crossReferences={gene.crossReferenceMap.other} />}
-        </AttributeValue>
+      <AttributeLabel>Cross References</AttributeLabel>
+      <AttributeValue>
+        {gene.crossReferenceMap.other && <CrossReferenceList crossReferences={gene.crossReferenceMap.other} />}
+      </AttributeValue>
 
-        <AttributeLabel>Additional Information</AttributeLabel>
-        <AttributeValue>
-          {gene.crossReferenceMap.references && (
-            <DataSourceLink reference={gene.crossReferenceMap.references}>Literature</DataSourceLink>
-          )}
-        </AttributeValue>
-      </AttributeList>
-    );
-  }
-}
+      <AttributeLabel>Additional Information</AttributeLabel>
+      <AttributeValue>
+        {gene.crossReferenceMap.references && (
+          <DataSourceLink reference={gene.crossReferenceMap.references}>Literature</DataSourceLink>
+        )}
+      </AttributeValue>
+    </AttributeList>
+  );
+};
 
 BasicGeneInfo.propTypes = {
   gene: PropTypes.object,

--- a/src/containers/layout/navigation/menuItems.jsx
+++ b/src/containers/layout/navigation/menuItems.jsx
@@ -1,26 +1,21 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'reactstrap';
 
 import { NAV_MENU } from '../../../constants';
 import MenuItem from './MenuItem.jsx';
 
-class MenuItems extends Component {
-  render() {
-    const { currentRoute, menuOpen, onItemClick } = this.props;
-    return (
-      <nav className="navbar navbar-expand-md navbar-dark bg-primary p-0">
-        <Collapse isOpen={menuOpen} navbar>
-          <ul className="navbar-nav m-3 m-md-1">
-            {NAV_MENU.map((page) => (
-              <MenuItem currentRoute={currentRoute} key={page.label} onClick={onItemClick} page={page} />
-            ))}
-          </ul>
-        </Collapse>
-      </nav>
-    );
-  }
-}
+const MenuItems = ({ currentRoute, menuOpen, onItemClick }) => (
+  <nav className="navbar navbar-expand-md navbar-dark bg-primary p-0">
+    <Collapse isOpen={menuOpen} navbar>
+      <ul className="navbar-nav m-3 m-md-1">
+        {NAV_MENU.map((page) => (
+          <MenuItem currentRoute={currentRoute} key={page.label} onClick={onItemClick} page={page} />
+        ))}
+      </ul>
+    </Collapse>
+  </nav>
+);
 
 MenuItems.propTypes = {
   currentRoute: PropTypes.string,

--- a/src/containers/search/detailList.jsx
+++ b/src/containers/search/detailList.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import style from './style.module.scss';
@@ -12,69 +12,66 @@ const COLLAPSIBLE_FIELDS = ['collapsible_synonyms', 'variants'];
 
 const JOIN_CHAR = ', ';
 
-class DetailList extends Component {
-  render() {
-    let d = this.props.data;
-    let nodes = this.props.fields.map((field) => {
-      let valueNode;
-      let value = d[field];
+const DetailList = ({ data, fields }) => {
+  const nodes = fields.map((field) => {
+    let valueNode;
+    let value = data[field];
 
-      if (Array.isArray(value)) {
-        if (COLLAPSIBLE_FIELDS.includes(field)) {
-          //special handling to make cross references collapsible
-          valueNode = (
-            <CollapsibleList>
-              {value.sort().map((val) => (
-                <span dangerouslySetInnerHTML={{ __html: val }} key={val} />
-              ))}
-            </CollapsibleList>
-          );
-        } else {
-          //everything else just gets joined
-          valueNode = <span dangerouslySetInnerHTML={{ __html: value.join(JOIN_CHAR) }} />;
-        }
+    if (Array.isArray(value)) {
+      if (COLLAPSIBLE_FIELDS.includes(field)) {
+        //special handling to make cross references collapsible
+        valueNode = (
+          <CollapsibleList>
+            {value.sort().map((val) => (
+              <span dangerouslySetInnerHTML={{ __html: val }} key={val} />
+            ))}
+          </CollapsibleList>
+        );
       } else {
-        if (value && field.toLowerCase() === 'species') {
-          valueNode = <SpeciesName dangerouslySetInnerHTML={{ __html: value }} />;
-        } else {
-          valueNode = <span dangerouslySetInnerHTML={{ __html: value }} />;
-        }
+        //everything else just gets joined
+        valueNode = <span dangerouslySetInnerHTML={{ __html: value.join(JOIN_CHAR) }} />;
       }
-
-      if (field.toLocaleString() === 'summary') {
-        return (
-          <div key={`sumField.${field}`}>
-            <CollapsibleBox>
-              <strong>{makeFieldDisplayName(field)}:</strong> <span className={style.detailValue}>{valueNode}</span>
-            </CollapsibleBox>
-          </div>
-        );
+    } else {
+      if (value && field.toLowerCase() === 'species') {
+        valueNode = <SpeciesName dangerouslySetInnerHTML={{ __html: value }} />;
+      } else {
+        valueNode = <span dangerouslySetInnerHTML={{ __html: value }} />;
       }
+    }
 
-      if (field.toLocaleString() === 'dataProviderNote') {
-        return (
-          <div className={style.detailLineContainer} key={`srField.${field}`}>
-            <span className={style.detailValue}>{valueNode}</span>
-          </div>
-        );
-      }
+    if (field.toLocaleString() === 'summary') {
+      return (
+        <div key={`sumField.${field}`}>
+          <CollapsibleBox>
+            <strong>{makeFieldDisplayName(field)}:</strong> <span className={style.detailValue}>{valueNode}</span>
+          </CollapsibleBox>
+        </div>
+      );
+    }
 
-      if (!value) {
-        valueNode = <NoData>Not Available</NoData>;
-      }
-
+    if (field.toLocaleString() === 'dataProviderNote') {
       return (
         <div className={style.detailLineContainer} key={`srField.${field}`}>
-          <span className={style.detailLabel}>
-            <strong>{makeFieldDisplayName(field)}:</strong>{' '}
-          </span>
           <span className={style.detailValue}>{valueNode}</span>
         </div>
       );
-    });
-    return <div className={style.detailContainer}>{nodes}</div>;
-  }
-}
+    }
+
+    if (!value) {
+      valueNode = <NoData>Not Available</NoData>;
+    }
+
+    return (
+      <div className={style.detailLineContainer} key={`srField.${field}`}>
+        <span className={style.detailLabel}>
+          <strong>{makeFieldDisplayName(field)}:</strong>{' '}
+        </span>
+        <span className={style.detailValue}>{valueNode}</span>
+      </div>
+    );
+  });
+  return <div className={style.detailContainer}>{nodes}</div>;
+};
 
 DetailList.propTypes = {
   collapsible: PropTypes.bool,

--- a/src/containers/search/explainNode.jsx
+++ b/src/containers/search/explainNode.jsx
@@ -1,29 +1,27 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import style from './style.module.scss';
 
-class ExplainNode extends Component {
-  render() {
-    if (!this.props.explanation || this.props.explanation === null) {
-      return null;
-    }
-
-    return (
-      <ul className={style.explanationList}>
-        <li>
-          {' '}
-          <strong>{this.props.explanation.value}</strong>: {this.props.explanation.match || ''}
-          {this.props.explanation.description}
-        </li>
-        <li>
-          {this.props.explanation.details.map(function (detail, i) {
-            return <ExplainNode explanation={detail} key={i} />;
-          })}
-        </li>
-      </ul>
-    );
+const ExplainNode = ({ explanation }) => {
+  if (!explanation) {
+    return null;
   }
-}
+
+  return (
+    <ul className={style.explanationList}>
+      <li>
+        {' '}
+        <strong>{explanation.value}</strong>: {explanation.match || ''}
+        {explanation.description}
+      </li>
+      <li>
+        {explanation.details.map((detail, i) => (
+          <ExplainNode explanation={detail} key={i} />
+        ))}
+      </li>
+    </ul>
+  );
+};
 
 ExplainNode.propTypes = {
   explanation: PropTypes.object,

--- a/src/containers/search/filterSelector/filterSelector.jsx
+++ b/src/containers/search/filterSelector/filterSelector.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -14,17 +14,16 @@ import CollapsibleFacet from './collapsibleFacet.jsx';
 import { selectActiveCategory, selectAggregations } from '../../../selectors/searchSelectors';
 import { selectPageLoading } from '../../../selectors/loadingSelector';
 
-class FilterSelectorComponent extends Component {
-  renderFilters() {
-    let aggs = this.props.aggregations;
-    if (aggs.length === 0) {
+const FilterSelectorComponent = ({ activeCategory, aggregations, isPending, queryParams }) => {
+  const renderFilters = () => {
+    if (aggregations.length === 0) {
       return <p>No filters available.</p>;
     }
     // if on cat selector and pending, render nothing
-    if (this.props.activeCategory === 'none' && this.props.isPending) {
+    if (activeCategory === 'none' && isPending) {
       return null;
     }
-    return aggs.map((d) => {
+    return aggregations.map((d) => {
       let isShowMore = false;
       //This is the "always show all of the values for __ facet" setting, right now
       //species facets are the only ones that get this special honor.  Also, 'all'
@@ -35,23 +34,22 @@ class FilterSelectorComponent extends Component {
 
       return (
         <div key={`filter${d.name}`}>
-          <SingleFilterSelector {...d} isShowMore={isShowMore} queryParams={this.props.queryParams} />
+          <SingleFilterSelector {...d} isShowMore={isShowMore} queryParams={queryParams} />
         </div>
       );
     });
-  }
+  };
 
-  renderCatSelector() {
-    let cat = this.props.activeCategory;
-    if (cat === 'none') {
+  const renderCatSelector = () => {
+    if (activeCategory === 'none') {
       return null;
     }
-    let newQp = getQueryParamWithValueChanged('category', [], this.props.queryParams, true);
-    let newHref = { pathname: '/search', search: stringifyQuery(newQp) };
+    const newQp = getQueryParamWithValueChanged('category', [], queryParams, true);
+    const newHref = { pathname: '/search', search: stringifyQuery(newQp) };
     return (
       <div>
         <p>
-          <CategoryLabel category={this.props.activeCategory} />
+          <CategoryLabel category={activeCategory} />
         </p>
         <p>
           <Link to={newHref}>
@@ -60,27 +58,25 @@ class FilterSelectorComponent extends Component {
         </p>
       </div>
     );
-  }
+  };
 
-  render() {
-    return (
-      <div>
-        <div className="d-none d-md-block">
-          {this.renderCatSelector()}
-          {this.renderFilters()}
-        </div>
-        <div className="d-block d-md-none">
-          <CollapsibleFacet label="Filter">
-            <div className={style.mobileFacetList}>
-              {this.renderCatSelector()}
-              {this.renderFilters()}
-            </div>
-          </CollapsibleFacet>
-        </div>
+  return (
+    <div>
+      <div className="d-none d-md-block">
+        {renderCatSelector()}
+        {renderFilters()}
       </div>
-    );
-  }
-}
+      <div className="d-block d-md-none">
+        <CollapsibleFacet label="Filter">
+          <div className={style.mobileFacetList}>
+            {renderCatSelector()}
+            {renderFilters()}
+          </div>
+        </CollapsibleFacet>
+      </div>
+    </div>
+  );
+};
 
 FilterSelectorComponent.propTypes = {
   activeCategory: PropTypes.string,

--- a/src/containers/search/resultsList.jsx
+++ b/src/containers/search/resultsList.jsx
@@ -16,7 +16,7 @@ import SpeciesName from '../../components/SpeciesName.jsx';
 
 const DEFAULT_FIELDS = ['symbol', 'name', 'synonyms', 'sourceHref', 'id', 'type'];
 
-const HighlightedValues = ({highlight, fields}) => {
+const HighlightedValues = ({ highlight, fields }) => {
   const _data = highlight;
   const _fields = Object.keys(_data).filter(
     (d) => (fields || DEFAULT_FIELDS).indexOf(d) < 0 && NON_HIGHLIGHTED_FIELDS.indexOf(d) < 0
@@ -24,7 +24,7 @@ const HighlightedValues = ({highlight, fields}) => {
   return <DetailList data={_data} fields={_fields} />;
 };
 
-const Header = ({d}) => (
+const Header = ({ d }) => (
   <div className="row">
     <div className="col-sm-10">
       <h4 className={style.resultLinkLabel}>{getLinkForEntry(d)}</h4>
@@ -42,9 +42,9 @@ const Header = ({d}) => (
   </div>
 );
 
-const DetailFromFields = ({d, fields}) => <DetailList data={d} fields={fields} />;
+const DetailFromFields = ({ d, fields }) => <DetailList data={d} fields={fields} />;
 
-const MissingTerms = ({d}) => {
+const MissingTerms = ({ d }) => {
   if (!d.missing || d.missing.length === 0 || d.missing[0] === '') {
     return null;
   }
@@ -55,7 +55,7 @@ const MissingTerms = ({d}) => {
   );
 };
 
-const RelatedData = ({d}) => {
+const RelatedData = ({ d }) => {
   if (!d.relatedData || d.relatedData.length === 0 || d.relatedData[0] === '') {
     return null;
   }
@@ -96,12 +96,12 @@ const RelatedData = ({d}) => {
   );
 };
 
-const Entry = ({d, i, fields}) => (
+const Entry = ({ d, i, fields }) => (
   <div className={style.resultContainer}>
     <Header d={d} />
     <SpeciesIcon iconClass={style.resultSpeciesIcon} species={d.speciesKey} />
     <DetailFromFields d={d} fields={fields} />
-    <HighlightedValues highlight={d.highlight}/>
+    <HighlightedValues highlight={d.highlight} />
     <RelatedData d={d} />
     <MissingTerms d={d} />
     {d.explanation && <ResultExplanation explanation={d.explanation} score={d.score} />}
@@ -109,7 +109,7 @@ const Entry = ({d, i, fields}) => (
   </div>
 );
 
-const GeneEntry = ({d, i}) => {
+const GeneEntry = ({ d, i }) => {
   const fields = CATEGORIES.find((cat) => cat.name === d.category).displayFields;
   return (
     <div className={style.resultContainer}>

--- a/src/containers/search/resultsList.jsx
+++ b/src/containers/search/resultsList.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import style from './style.module.scss';
@@ -16,156 +16,128 @@ import SpeciesName from '../../components/SpeciesName.jsx';
 
 const DEFAULT_FIELDS = ['symbol', 'name', 'synonyms', 'sourceHref', 'id', 'type'];
 
-class ResultsList extends Component {
-  renderHighlightedValues(highlight, fields) {
-    let _data = highlight;
-    if (!fields) {
-      fields = DEFAULT_FIELDS;
-    }
-    let _fields = Object.keys(_data).filter((d) => {
-      return fields.indexOf(d) < 0 && NON_HIGHLIGHTED_FIELDS.indexOf(d) < 0;
-    });
-    return <DetailList data={_data} fields={_fields} />;
+const renderHighlightedValues = (highlight, fields) => {
+  const _data = highlight;
+  const _fields = Object.keys(_data).filter(
+    (d) => (fields || DEFAULT_FIELDS).indexOf(d) < 0 && NON_HIGHLIGHTED_FIELDS.indexOf(d) < 0
+  );
+  return <DetailList data={_data} fields={_fields} />;
+};
+
+const renderHeader = (d) => (
+  <div className="row">
+    <div className="col-sm-10">
+      <h4 className={style.resultLinkLabel}>{getLinkForEntry(d)}</h4>
+      {d.species && (
+        <span className="ml-3">
+          (<SpeciesName dangerouslySetInnerHTML={{ __html: d.species }} />)
+        </span>
+      )}
+    </div>
+    <div className="col-sm-2">
+      <span className={style.resultCatLabel}>
+        <CategoryLabel category={d.category} />
+      </span>
+    </div>
+  </div>
+);
+
+const renderDetailFromFields = (d, fields) => <DetailList data={d} fields={fields} />;
+
+const renderMissingTerms = (d) => {
+  if (!d.missing || d.missing.length === 0 || d.missing[0] === '') {
+    return '';
+  }
+  return (
+    <div className={style.missingTerms}>
+      <DetailList data={d} fields={['missing']} />
+    </div>
+  );
+};
+
+const renderRelatedData = (d) => {
+  if (!d.relatedData || d.relatedData.length === 0 || d.relatedData[0] === '') {
+    return '';
   }
 
-  renderHeader(d) {
-    return (
-      <div className="row">
-        <div className="col-sm-10">
-          <h4 className={style.resultLinkLabel}>{getLinkForEntry(d)}</h4>
-          {d.species && (
-            <span className="ml-3">
-              (<SpeciesName dangerouslySetInnerHTML={{ __html: d.species }} />)
-            </span>
-          )}
-        </div>
-        <div className="col-sm-2">
-          <span className={style.resultCatLabel}>
-            <CategoryLabel category={d.category} />
-          </span>
-        </div>
-      </div>
-    );
-  }
+  const _links = d.relatedData.map((x) => {
+    const queryParams = {
+      category: x.category,
+      [x.targetField]: x.sourceName,
+    };
+    const catMatch = CATEGORIES.find((cat) => cat.name === x.category);
+    const label = x.label || (catMatch ? catMatch.displayName : x.category);
+    const href = { pathname: '/search', search: stringifyQuery(queryParams) };
+    const id = 'X' + hash(x);
 
-  renderDetailFromFields(d, fields) {
-    return <DetailList data={d} fields={fields} />;
-  }
-
-  renderMissingTerms(d) {
-    if (!d.missing || d.missing.length === 0 || d.missing[0] === '') {
-      return '';
-    }
-    return (
-      <div className={style.missingTerms}>
-        <DetailList data={d} fields={['missing']} />
-      </div>
-    );
-  }
-
-  renderRelatedData(d) {
-    if (!d.relatedData || d.relatedData.length === 0 || d.relatedData[0] === '') {
-      return '';
-    }
-
-    const _links = d.relatedData.map((x) => {
-      const queryParams = {
-        category: x.category,
-        [x.targetField]: x.sourceName,
-      };
-      const catMatch = CATEGORIES.find((cat) => cat.name === x.category);
-      const label = x.label || (catMatch ? catMatch.displayName : x.category);
-      const href = { pathname: '/search', search: stringifyQuery(queryParams) };
-      const id = 'X' + hash(x);
-
-      let tip = '';
-      if (d.category === GO_CATEGORY && x.category === GENE_CATEGORY) {
-        tip = (
-          <UncontrolledTooltip delay={{ hide: 150, show: 300 }} placement="top" target={id}>
-            Includes direct and child annotations
-          </UncontrolledTooltip>
-        );
-      }
-
-      return (
-        <li className="list-inline-item" id={id} key={label}>
-          <Link to={href}>
-            {label} ({x.count})
-          </Link>
-          {tip}
-        </li>
+    let tip = '';
+    if (d.category === GO_CATEGORY && x.category === GENE_CATEGORY) {
+      tip = (
+        <UncontrolledTooltip delay={{ hide: 150, show: 300 }} placement="top" target={id}>
+          Includes direct and child annotations
+        </UncontrolledTooltip>
       );
-    });
+    }
 
     return (
-      <div className={style.relatedDataLinks}>
-        <ul className="list-unstyled list-inline">{_links}</ul>
-      </div>
+      <li className="list-inline-item" id={id} key={label}>
+        <Link to={href}>
+          {label} ({x.count})
+        </Link>
+        {tip}
+      </li>
     );
-  }
+  });
 
-  renderDatasetEntry(d, i) {
-    let fields = CATEGORIES.find((cat) => cat.name === d.category).displayFields;
-    return (
-      <div className={style.resultContainer} key={`sr${i}`}>
-        {this.renderHeader(d)}
-        {this.renderDetailFromFields(d, fields)}
-        {this.renderHighlightedValues(d.highlight, fields)}
-        {this.renderRelatedData(d)}
-        {this.renderMissingTerms(d)}
-      </div>
-    );
-  }
+  return (
+    <div className={style.relatedDataLinks}>
+      <ul className="list-unstyled list-inline">{_links}</ul>
+    </div>
+  );
+};
 
-  renderEntry(d, i, fields) {
-    return (
-      <div className={style.resultContainer} key={`sr${i}`}>
-        {this.renderHeader(d)}
-        <SpeciesIcon iconClass={style.resultSpeciesIcon} species={d.speciesKey} />
-        {this.renderDetailFromFields(d, fields)}
-        {this.renderHighlightedValues(d.highlight)}
-        {this.renderRelatedData(d)}
-        {this.renderMissingTerms(d)}
-        {d.explanation && <ResultExplanation explanation={d.explanation} score={d.score} />}
-        <hr />
-      </div>
-    );
-  }
+const renderEntry = (d, i, fields) => (
+  <div className={style.resultContainer} key={`sr${i}`}>
+    {renderHeader(d)}
+    <SpeciesIcon iconClass={style.resultSpeciesIcon} species={d.speciesKey} />
+    {renderDetailFromFields(d, fields)}
+    {renderHighlightedValues(d.highlight)}
+    {renderRelatedData(d)}
+    {renderMissingTerms(d)}
+    {d.explanation && <ResultExplanation explanation={d.explanation} score={d.score} />}
+    <hr />
+  </div>
+);
 
-  renderGeneEntry(d, i) {
-    let fields = CATEGORIES.find((cat) => cat.name === d.category).displayFields;
-    return (
-      <div className={style.resultContainer} key={`sr${i}`}>
-        {this.renderHeader(d)}
-        <SpeciesIcon iconClass={style.resultSpeciesIcon} species={d.speciesKey} />
-        {this.renderDetailFromFields(d, fields)}
-        {this.renderHighlightedValues(d.highlight)}
-        {this.renderRelatedData(d)}
-        {this.renderMissingTerms(d)}
-        {d.explanation && <ResultExplanation explanation={d.explanation} score={d.score} />}
-        <hr />
-      </div>
-    );
-  }
+const renderGeneEntry = (d, i) => {
+  const fields = CATEGORIES.find((cat) => cat.name === d.category).displayFields;
+  return (
+    <div className={style.resultContainer} key={`sr${i}`}>
+      {renderHeader(d)}
+      <SpeciesIcon iconClass={style.resultSpeciesIcon} species={d.speciesKey} />
+      {renderDetailFromFields(d, fields)}
+      {renderHighlightedValues(d.highlight)}
+      {renderRelatedData(d)}
+      {renderMissingTerms(d)}
+      {d.explanation && <ResultExplanation explanation={d.explanation} score={d.score} />}
+      <hr />
+    </div>
+  );
+};
 
-  renderRows() {
-    return (
-      this.props.entries?.map((d, i) => {
-        if (d.category === GENE_CATEGORY) {
-          return this.renderGeneEntry(d, i);
-        } else {
-          let catMatch = CATEGORIES.find((cat) => cat.name === d.category);
-          let fields = catMatch ? catMatch.displayFields || ['id', 'synonyms'] : ['id', 'synonyms'];
-          return this.renderEntry(d, i, fields);
-        }
-      }) || []
-    );
-  }
-
-  render() {
-    return <div className={style.resultsListParent}>{this.renderRows()}</div>;
-  }
-}
+const ResultsList = ({ entries }) => {
+  const rows =
+    entries?.map((d, i) => {
+      if (d.category === GENE_CATEGORY) {
+        return renderGeneEntry(d, i);
+      } else {
+        const catMatch = CATEGORIES.find((cat) => cat.name === d.category);
+        const fields = catMatch ? catMatch.displayFields || ['id', 'synonyms'] : ['id', 'synonyms'];
+        return renderEntry(d, i, fields);
+      }
+    }) || [];
+  return <div className={style.resultsListParent}>{rows}</div>;
+};
 
 ResultsList.propTypes = {
   entries: PropTypes.array,

--- a/src/containers/search/resultsList.jsx
+++ b/src/containers/search/resultsList.jsx
@@ -16,7 +16,7 @@ import SpeciesName from '../../components/SpeciesName.jsx';
 
 const DEFAULT_FIELDS = ['symbol', 'name', 'synonyms', 'sourceHref', 'id', 'type'];
 
-const renderHighlightedValues = (highlight, fields) => {
+const HighlightedValues = ({highlight, fields}) => {
   const _data = highlight;
   const _fields = Object.keys(_data).filter(
     (d) => (fields || DEFAULT_FIELDS).indexOf(d) < 0 && NON_HIGHLIGHTED_FIELDS.indexOf(d) < 0
@@ -24,7 +24,7 @@ const renderHighlightedValues = (highlight, fields) => {
   return <DetailList data={_data} fields={_fields} />;
 };
 
-const renderHeader = (d) => (
+const Header = ({d}) => (
   <div className="row">
     <div className="col-sm-10">
       <h4 className={style.resultLinkLabel}>{getLinkForEntry(d)}</h4>
@@ -42,11 +42,11 @@ const renderHeader = (d) => (
   </div>
 );
 
-const renderDetailFromFields = (d, fields) => <DetailList data={d} fields={fields} />;
+const DetailFromFields = ({d, fields}) => <DetailList data={d} fields={fields} />;
 
-const renderMissingTerms = (d) => {
+const MissingTerms = ({d}) => {
   if (!d.missing || d.missing.length === 0 || d.missing[0] === '') {
-    return '';
+    return null;
   }
   return (
     <div className={style.missingTerms}>
@@ -55,9 +55,9 @@ const renderMissingTerms = (d) => {
   );
 };
 
-const renderRelatedData = (d) => {
+const RelatedData = ({d}) => {
   if (!d.relatedData || d.relatedData.length === 0 || d.relatedData[0] === '') {
-    return '';
+    return null;
   }
 
   const _links = d.relatedData.map((x) => {
@@ -96,29 +96,29 @@ const renderRelatedData = (d) => {
   );
 };
 
-const renderEntry = (d, i, fields) => (
-  <div className={style.resultContainer} key={`sr${i}`}>
-    {renderHeader(d)}
+const Entry = ({d, i, fields}) => (
+  <div className={style.resultContainer}>
+    <Header d={d} />
     <SpeciesIcon iconClass={style.resultSpeciesIcon} species={d.speciesKey} />
-    {renderDetailFromFields(d, fields)}
-    {renderHighlightedValues(d.highlight)}
-    {renderRelatedData(d)}
-    {renderMissingTerms(d)}
+    <DetailFromFields d={d} fields={fields} />
+    <HighlightedValues highlight={d.highlight}/>
+    <RelatedData d={d} />
+    <MissingTerms d={d} />
     {d.explanation && <ResultExplanation explanation={d.explanation} score={d.score} />}
     <hr />
   </div>
 );
 
-const renderGeneEntry = (d, i) => {
+const GeneEntry = ({d, i}) => {
   const fields = CATEGORIES.find((cat) => cat.name === d.category).displayFields;
   return (
-    <div className={style.resultContainer} key={`sr${i}`}>
-      {renderHeader(d)}
+    <div className={style.resultContainer}>
+      <Header d={d} />
       <SpeciesIcon iconClass={style.resultSpeciesIcon} species={d.speciesKey} />
-      {renderDetailFromFields(d, fields)}
-      {renderHighlightedValues(d.highlight)}
-      {renderRelatedData(d)}
-      {renderMissingTerms(d)}
+      <DetailFromFields d={d} fields={fields} />
+      <HighlightedValues highlight={d.highlight} />
+      <RelatedData d={d} />
+      <MissingTerms d={d} />
       {d.explanation && <ResultExplanation explanation={d.explanation} score={d.score} />}
       <hr />
     </div>
@@ -129,11 +129,11 @@ const ResultsList = ({ entries }) => {
   const rows =
     entries?.map((d, i) => {
       if (d.category === GENE_CATEGORY) {
-        return renderGeneEntry(d, i);
+        return <GeneEntry key={`sr${i}`} d={d} i={i} />;
       } else {
         const catMatch = CATEGORIES.find((cat) => cat.name === d.category);
         const fields = catMatch ? catMatch.displayFields || ['id', 'synonyms'] : ['id', 'synonyms'];
-        return renderEntry(d, i, fields);
+        return <Entry key={`sr${i}`} d={d} i={i} fields={fields} />;
       }
     }) || [];
   return <div className={style.resultsListParent}>{rows}</div>;

--- a/src/containers/search/resultsTable.jsx
+++ b/src/containers/search/resultsTable.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import style from './style.module.scss';
@@ -10,112 +10,102 @@ import SpeciesName from '../../components/SpeciesName.jsx';
 const MATCH_LABEL = 'match_by';
 const MAX_CHAR = 100;
 
-class ResultsTable extends Component {
-  getFields() {
-    let fields;
-    switch (this.props.activeCategory) {
-      case GENE_CATEGORY:
-        fields = ['species', 'display_name', 'name', 'synonyms', 'source', 'biotype'];
-        break;
-      case GO_CATEGORY:
-        fields = ['display_name', 'id', 'synonyms', 'go_branch'];
-        break;
-      case DISEASE_CATEGORY:
-        fields = ['display_name', 'id'];
-        break;
-      default:
-        fields = ['display_name', 'synonyms'];
-    }
-    fields.push(MATCH_LABEL);
-    return fields;
+const getFields = (activeCategory) => {
+  let fields;
+  switch (activeCategory) {
+    case GENE_CATEGORY:
+      fields = ['species', 'display_name', 'name', 'synonyms', 'source', 'biotype'];
+      break;
+    case GO_CATEGORY:
+      fields = ['display_name', 'id', 'synonyms', 'go_branch'];
+      break;
+    case DISEASE_CATEGORY:
+      fields = ['display_name', 'id'];
+      break;
+    default:
+      fields = ['display_name', 'synonyms'];
   }
+  fields.push(MATCH_LABEL);
+  return fields;
+};
 
-  renderHeader() {
-    let fields = this.getFields();
-    let nodes = fields.map((d) => {
-      let processedName;
-      if (this.props.activeCategory === GENE_CATEGORY && d === 'display_name') {
-        processedName = 'symbol';
-      } else if (d === 'display_name') {
-        processedName = 'name';
-      } else {
-        processedName = d;
-      }
-      return (
-        <th className={style.tableHeadCell} key={`srH.${d}`}>
-          {makeFieldDisplayName(processedName)}
-        </th>
-      );
-    });
-    return <tr>{nodes}</tr>;
+const renderTruncatedContent = (original) => {
+  let value = original || '';
+  if (Array.isArray(value)) {
+    value = value.join(', ');
   }
+  if (value.length > MAX_CHAR) {
+    return value.slice(0, MAX_CHAR) + '...';
+  }
+  return value;
+};
 
-  renderTruncatedContent(original) {
-    original = original || '';
-    if (Array.isArray(original)) {
-      original = original.join(', ');
-    }
-    if (original.length > MAX_CHAR) {
-      return original.slice(0, MAX_CHAR) + '...';
+const renderHighlight = (highlight) => {
+  const _data = highlight;
+  const _fields = Object.keys(_data).filter((d) => NON_HIGHLIGHTED_FIELDS.indexOf(d) < 0);
+  return <DetailList data={_data} fields={_fields} />;
+};
+
+const ResultsTable = ({ activeCategory, entries }) => {
+  const fields = getFields(activeCategory);
+
+  const headerNodes = fields.map((d) => {
+    let processedName;
+    if (activeCategory === GENE_CATEGORY && d === 'display_name') {
+      processedName = 'symbol';
+    } else if (d === 'display_name') {
+      processedName = 'name';
     } else {
-      return original;
+      processedName = d;
     }
-  }
-
-  renderRows() {
-    let entries = this.props.entries;
-    let fields = this.getFields();
-    let rowNodes = entries.map((d, i) => {
-      let nodes = fields.map((field) => {
-        let _key = `srtc.${i}.${field}`;
-        switch (field) {
-          case 'display_name':
-          case 'symbol':
-            return <td key={_key}>{getLinkForEntry(d)}</td>;
-          case 'source':
-            return (
-              <td key={_key}>
-                <a dangerouslySetInnerHTML={{ __html: d.id }} href={d.href} target="_new" />
-              </td>
-            );
-          case MATCH_LABEL:
-            return <td key={_key}>{this.renderHighlight(d.highlight, d.homologs)}</td>;
-          case 'species':
-            return (
-              <td key={_key}>
-                <SpeciesName dangerouslySetInnerHTML={{ __html: d.species }} />
-              </td>
-            );
-          default:
-            return <td dangerouslySetInnerHTML={{ __html: this.renderTruncatedContent(d[field]) }} key={_key} />;
-        }
-      });
-      return <tr key={`tr${i}`}>{nodes}</tr>;
-    });
-    return <tbody>{rowNodes}</tbody>;
-  }
-
-  renderHighlight(highlight) {
-    let _data = highlight;
-    let _fields = Object.keys(_data).filter((d) => {
-      return NON_HIGHLIGHTED_FIELDS.indexOf(d) < 0;
-    });
-    return <DetailList data={_data} fields={_fields} />;
-  }
-
-  render() {
-    let emptyNode = this.props.entries.length === 0 ? <p className={style.tableEmpty}>No results</p> : null;
     return (
-      <div className={style.tableContainer}>
-        <table className="table">
-          <thead className="thead-default">{this.renderHeader()}</thead>
-          {this.renderRows()}
-        </table>
-        {emptyNode}
-      </div>
+      <th className={style.tableHeadCell} key={`srH.${d}`}>
+        {makeFieldDisplayName(processedName)}
+      </th>
     );
-  }
-}
+  });
+
+  const rowNodes = entries.map((d, i) => {
+    const nodes = fields.map((field) => {
+      const _key = `srtc.${i}.${field}`;
+      switch (field) {
+        case 'display_name':
+        case 'symbol':
+          return <td key={_key}>{getLinkForEntry(d)}</td>;
+        case 'source':
+          return (
+            <td key={_key}>
+              <a dangerouslySetInnerHTML={{ __html: d.id }} href={d.href} target="_new" />
+            </td>
+          );
+        case MATCH_LABEL:
+          return <td key={_key}>{renderHighlight(d.highlight, d.homologs)}</td>;
+        case 'species':
+          return (
+            <td key={_key}>
+              <SpeciesName dangerouslySetInnerHTML={{ __html: d.species }} />
+            </td>
+          );
+        default:
+          return <td dangerouslySetInnerHTML={{ __html: renderTruncatedContent(d[field]) }} key={_key} />;
+      }
+    });
+    return <tr key={`tr${i}`}>{nodes}</tr>;
+  });
+
+  const emptyNode = entries.length === 0 ? <p className={style.tableEmpty}>No results</p> : null;
+  return (
+    <div className={style.tableContainer}>
+      <table className="table">
+        <thead className="thead-default">
+          <tr>{headerNodes}</tr>
+        </thead>
+        <tbody>{rowNodes}</tbody>
+      </table>
+      {emptyNode}
+    </div>
+  );
+};
 
 ResultsTable.propTypes = {
   activeCategory: PropTypes.string,

--- a/src/containers/wordpress/secondaryNav.jsx
+++ b/src/containers/wordpress/secondaryNav.jsx
@@ -1,70 +1,66 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import style from './style.module.scss';
 
-class SecondaryNav extends Component {
-  getStyle(menuCat) {
-    switch (menuCat) {
-      // magic numbers are wordpress parent IDs
-      case 16:
-        return style.homeMenuContainer;
-      case 2:
-        return style.aboutMenuContainer;
-      case 3:
-        return style.contactMenuContainer;
-      case 1184:
-        return style.workingGroupsMenuContainer;
-      case 473:
-        return style.postMenuContainer;
-      case 179:
-        return style.helpMenuContainer;
-      case 2493:
-        return style.citeMenuContainer;
-      case 'post':
-        return style.postMenuContainer;
-      default:
-        return;
-    }
+const getStyle = (menuCat) => {
+  switch (menuCat) {
+    // magic numbers are wordpress parent IDs
+    case 16:
+      return style.homeMenuContainer;
+    case 2:
+      return style.aboutMenuContainer;
+    case 3:
+      return style.contactMenuContainer;
+    case 1184:
+      return style.workingGroupsMenuContainer;
+    case 473:
+      return style.postMenuContainer;
+    case 179:
+      return style.helpMenuContainer;
+    case 2493:
+      return style.citeMenuContainer;
+    case 'post':
+      return style.postMenuContainer;
+    default:
+      return;
+  }
+};
+
+const SecondaryNav = ({ parent, slug, title, type }) => {
+  const menuCat = type === 'post' ? 'post' : parent;
+  const menuContainer = getStyle(menuCat);
+
+  // background image is typically decided by the parent page, but this one
+  // is a special case for now.
+  // TODO: should all banner images be determined by slug instead of parent? can it come from wordpress instead of hardcoded?
+  // would like to refer to backgroundImage via relative path
+  //  backgroundImage: 'url(\'../../../../../libs/shared-assets/src/lib/assets/banner_covid19.png\')'
+  // but something converts the path in the .scss to something with an extension at the root level
+  // (e.g. /banner_bacteria.ff1e68d.jpg ) and so cannot set that in the javascript here, but it
+  // needs to be slug-based, so cannot use the style.scss either.  Maybe css-in-js would help.
+  let menuStyle;
+  if (slug === 'coronavirus-resources') {
+    menuStyle = {
+      backgroundImage: "url('https://alliancegenome.files.wordpress.com/2020/05/covid19.png')",
+    };
   }
 
-  render() {
-    const { parent, slug, title, type } = this.props;
-
-    let menuCat = type === 'post' ? 'post' : parent;
-    let menuContainer = this.getStyle(menuCat);
-
-    // background image is typically decided by the parent page, but this one
-    // is a special case for now.
-    // TODO: should all banner images be determined by slug instead of parent? can it come from wordpress instead of hardcoded?
-    // would like to refer to backgroundImage via relative path
-    //  backgroundImage: 'url(\'../../../../../libs/shared-assets/src/lib/assets/banner_covid19.png\')'
-    // but something converts the path in the .scss to something with an extension at the root level
-    // (e.g. /banner_bacteria.ff1e68d.jpg ) and so cannot set that in the javascript here, but it
-    // needs to be slug-based, so cannot use the style.scss either.  Maybe css-in-js would help.
-    let menuStyle;
-    if (slug === 'coronavirus-resources') {
-      menuStyle = {
-        backgroundImage: "url('https://alliancegenome.files.wordpress.com/2020/05/covid19.png')",
-      };
-    }
-
-    return (
-      <div>
-        <div className={menuContainer} style={menuStyle}>
-          <div className="container-fluid">
-            <div className={style.secondaryNavEmptyRow} />
-            <div className={`row ${style.secondaryNav}`}>
-              <div className="container">
-                <h1 dangerouslySetInnerHTML={{ __html: title }} />
-              </div>
+  return (
+    <div>
+      <div className={menuContainer} style={menuStyle}>
+        <div className="container-fluid">
+          <div className={style.secondaryNavEmptyRow} />
+          <div className={`row ${style.secondaryNav}`}>
+            <div className="container">
+              <h1 dangerouslySetInnerHTML={{ __html: title }} />
             </div>
           </div>
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 SecondaryNav.propTypes = {
   parent: PropTypes.number,

--- a/src/reactApplication.jsx
+++ b/src/reactApplication.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from './lib/configureStore';
 import { BrowserRouter } from 'react-router-dom';
@@ -22,28 +22,26 @@ const queryClient = new QueryClient({
   },
 });
 
-class ReactApp extends Component {
-  render() {
-    const Router = this.props.router || BrowserRouter;
-    return (
-      <Provider store={store}>
-        <QueryClientProvider client={queryClient}>
-          <ReleaseContextProvider>
-            <Router>
-              {isBrowser ? (
-                <RouteListener onRouteChange={logPageView}>
-                  <LayoutWithRoutes />
-                </RouteListener>
-              ) : (
+const ReactApp = ({ router }) => {
+  const Router = router || BrowserRouter;
+  return (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <ReleaseContextProvider>
+          <Router>
+            {isBrowser ? (
+              <RouteListener onRouteChange={logPageView}>
                 <LayoutWithRoutes />
-              )}
-            </Router>
-          </ReleaseContextProvider>
-        </QueryClientProvider>
-      </Provider>
-    );
-  }
-}
+              </RouteListener>
+            ) : (
+              <LayoutWithRoutes />
+            )}
+          </Router>
+        </ReleaseContextProvider>
+      </QueryClientProvider>
+    </Provider>
+  );
+};
 
 ReactApp.propTypes = {
   router: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),

--- a/src/reactApplication.jsx
+++ b/src/reactApplication.jsx
@@ -22,8 +22,7 @@ const queryClient = new QueryClient({
   },
 });
 
-const ReactApp = ({ router }) => {
-  const Router = router || BrowserRouter;
+const ReactApp = ({ router: Router = BrowserRouter }) => {
   return (
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Guard Reference cells against missing pubModIds:
- utils.getSingleReferenceUrl: return {pubModId, url: null} when pubModId is falsy
- utils.getMultipleReferencesUrls: return [] for non-array input, filter(Boolean) before sort
- referencesCellCuration: short-circuit with null when pubModIds is missing/empty
- singleReferenceCellCuration.getSingleReferencePubModId: fall back to reference.curie
  when pubModIds is not an array
Fixes 'Cannot read properties of undefined (reading sort/includes)' errors on the
Disease Associations and Phenotypes sections of the gene page.

Hide the "Your Input Welcome" button on scroll:
- YourInputWelcome.jsx: scroll listener toggles .hidden past 200px
- YourInputWelcome.module.scss: .hidden slides the button up with opacity fade and
  pointer-events: none so it doesn't overlap page content when scrolled