### PR TITLE
SCRUM-6204: use pubModID for via-orthology References column

### DIFF
--- a/src/containers/diseasePage/DiseaseToGeneTable.jsx
+++ b/src/containers/diseasePage/DiseaseToGeneTable.jsx
@@ -165,10 +165,10 @@ const DiseaseToGeneTable = ({ id }) => {
       formatter: (pubmedPublications, row) => {
         if (getIsViaOrthology(row)) {
           const xrefs = (row.references || []).flatMap((ref) => {
-            const refId = ref?.referenceID || ref?.curie;
-            if (!refId) return [];
-            const xref = ref.crossReferences?.find((x) => x.referencedCurie === refId);
-            return [xref || { referencedCurie: refId }];
+            const modId = ref?.pubModID;
+            if (!modId) return [];
+            const match = (ref.crossReferences || []).find((x) => x.referencedCurie === modId);
+            return [match || { referencedCurie: modId }];
           });
           return xrefs.length ? <ReferencesCellCuration pubmedPublications={xrefs} /> : null;
         }


### PR DESCRIPTION
Ortho rows resolved identity via referenceID (PubMed-first), so after the indexer-side fix they rendered a PMID linkout instead of the MOD-native identity users saw pre-6204. Switch to ref.pubModID so each ortho row links to its underlying MOD publication.