### PR TITLE
fix(referencePage): render references with missing/null fields (KANBAN-1328)

### DIFF
--- a/src/containers/referencePage/ReferenceSummary.jsx
+++ b/src/containers/referencePage/ReferenceSummary.jsx
@@ -29,8 +29,8 @@ const CommaSeparatedSourceList = ({ sources }) => {
 const PubSourceLink = ({ ref }) => {
   const publisher = ref.resource_title;
   // this should not need to be done here; talk to Blue Team about fixing these date formats (e.g. "1999.7.30")
-  // date_published may be missing entirely (e.g. internal_process_reference)
-  const date_pub_fixed = ref.date_published ? ref.date_published.replace(/\b(\d)\b/g, '0$1').replace(/\.+/g, '-') : '';
+  // date_published may be missing entirely (e.g. internal_process_reference); ?. leaves it undefined (falsy) then
+  const date_pub_fixed = ref.date_published?.replace(/\b(\d)\b/g, '0$1').replace(/\.+/g, '-');
   if (!publisher && !date_pub_fixed) return <NoData>Not Available</NoData>;
   // date_published may be a full date ("1999-07-30") or year-only ("2018"); only reformat when it parses,
   // otherwise show the raw value (a year-only string produces an Invalid Date that formatToParts throws on)

--- a/src/containers/referencePage/ReferenceSummary.jsx
+++ b/src/containers/referencePage/ReferenceSummary.jsx
@@ -29,22 +29,29 @@ const CommaSeparatedSourceList = ({ sources }) => {
 const PubSourceLink = ({ ref }) => {
   const publisher = ref.resource_title;
   // this should not need to be done here; talk to Blue Team about fixing these date formats (e.g. "1999.7.30")
-  const date_pub_fixed = ref.date_published.replace(/\b(\d)\b/g, '0$1').replace(/\.+/g, '-');
+  // date_published may be missing entirely (e.g. internal_process_reference)
+  const date_pub_fixed = ref.date_published ? ref.date_published.replace(/\b(\d)\b/g, '0$1').replace(/\.+/g, '-') : '';
   if (!publisher && !date_pub_fixed) return <NoData>Not Available</NoData>;
+  // date_published may be a full date ("1999-07-30") or year-only ("2018"); only reformat when it parses,
+  // otherwise show the raw value (a year-only string produces an Invalid Date that formatToParts throws on)
   const pubDate = new Date(date_pub_fixed + 'T00:00:00'); // must add a time, or Date assumes midnight in Greenwich, which usually (i.e. in the US) means you see the previous day instead
-  const dateOptions = { year: 'numeric', month: 'short', day: 'numeric' };
-  const dateParts = new Intl.DateTimeFormat('en-US', dateOptions).formatToParts(pubDate);
-  const datePartValues = dateParts.map((p) => p.value);
-  const dateString = datePartValues[4] + ' ' + datePartValues[0] + ' ' + datePartValues[2];
-  const pubVol = ref.volume;
+  let dateString = date_pub_fixed;
+  if (date_pub_fixed && !isNaN(pubDate.getTime())) {
+    const dateOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+    const dateParts = new Intl.DateTimeFormat('en-US', dateOptions).formatToParts(pubDate);
+    const datePartValues = dateParts.map((p) => p.value);
+    dateString = datePartValues[4] + ' ' + datePartValues[0] + ' ' + datePartValues[2];
+  }
+  const pubVol = ref.volume || '';
   const pubIss = ref.issue_name ? `(${ref.issue_name})` : '';
-  const pubRng = ref.page_range;
+  const pubRng = ref.page_range || '';
   // extract DOI cross-reference (already enriched with resourceDescriptorPage in index.jsx)
   const doiXref = [...(ref.extXrefs || []), ...(ref.modXrefs || [])].find(
     (xr) => xr.curie && xr.curie.match(/^doi\:/i)
   );
-  // build link text string
-  const pubsrc = `${publisher}. ${dateString}; ${pubVol} ${pubIss}:${pubRng}`;
+  // build link text string, omitting empty segments so missing fields don't render as "undefined"
+  const volIssRng = `${pubVol} ${pubIss}:${pubRng}`.replace(/^\s*:\s*$/, '').trim();
+  const pubsrc = [publisher, dateString].filter(Boolean).join('. ') + (volIssRng ? `; ${volIssRng}` : '');
   if (doiXref)
     return (
       <ExternalLink href={buildUrlFromTemplate(doiXref)} key={`source-${doiXref.curie}`}>
@@ -118,7 +125,7 @@ const ReferenceSummary = ({ ref }) => {
         <MODidentifiers xrefs={ref.modXrefs} />
       </AttributeValue>
       <AttributeLabel>Alliance Publication Type</AttributeLabel>
-      <AttributeValue>{ref.category.replace(/_/g, ' ')}</AttributeValue>
+      <AttributeValue>{ref.category ? ref.category.replace(/_/g, ' ') : <NoData>Not Available</NoData>}</AttributeValue>
       <AttributeLabel>AGRKB ID</AttributeLabel>
       <AttributeValue>{ref.curie}</AttributeValue>
     </AttributeList>

--- a/src/containers/referencePage/index.jsx
+++ b/src/containers/referencePage/index.jsx
@@ -158,7 +158,8 @@ const ReferencePage = () => {
   // Split into MOD xrefs (FB/MGI/RGD/SGD/WB/Xenbase/ZFIN) and external xrefs by curie prefix.
   ref.modXrefs = [];
   ref.extXrefs = [];
-  for (const entry of ref.cross_references) {
+  // cross_references may be missing entirely (e.g. internal_process_reference), so default to []
+  for (const entry of ref.cross_references || []) {
     const prefix = entry.curie.substring(0, entry.curie.indexOf(':'));
     (speciesMap[prefix] ? ref.modXrefs : ref.extXrefs).push(entry);
   }


### PR DESCRIPTION
## KANBAN-1328 — Reference page not rendering for `AGRKB:101000000828456`

The reference is an `internal_process_reference` whose API `literatureSummary` omits many fields entirely (`cross_references`, `resource_title`, `volume`, `issue_name`, `page_range`). The rendering code accessed these unguarded, so the page threw before rendering — the reported blank page + console error `Uncaught TypeError: Cannot read properties of undefined (reading 'length')`.

### Changes

**`src/containers/referencePage/index.jsx`**
- Guard the MOD/external xref split loop with `cross_references || []` (this was the first crash / cause of the blank page).

**`src/containers/referencePage/ReferenceSummary.jsx`**
- Guard `date_published` before `.replace()`.
- Only run `Intl…formatToParts` when the date actually parses; year-only/invalid dates fall back to the raw value (avoids a `RangeError`).
- Default `volume`/`page_range` to `''` and omit empty citation segments so missing fields no longer render as literal `undefined`.
- Guard `category.replace()` → "Not Available" when absent.

### Verification
Ran the dev server against the stage API and loaded `/reference/AGRKB:101000000828456`:
- Page renders fully with **zero console errors**.
- Missing fields show "Not Available"; data tables degrade to "No data available".
- Publication Source renders cleanly with no leading `undefined.`

Context: per Chris Grove, this reference will be linked from all predicted disease annotations (via_orthology) on disease pages in 9.1.0, so it needs to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)