### PR TITLE
KANBAN-1322 ontology browser: reliable deep-link scroll, no-jump tree clicks

### DIFF
--- a/src/containers/ontologyBrowser/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/OntologyTree.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight, faChevronDown } from '@fortawesome/free-solid-svg-icons';
-import { Link } from 'react-router-dom';
 import CountBadge from './CountBadge.jsx';
 import { ANNOTATION_TYPES } from './annotationTypes.js';
 import { useDiseaseTerm } from './useDiseaseTerms.jsx';
@@ -17,7 +16,7 @@ const OntologyTree = ({
   focusedCurie,
   onSelect,
   scrollOnFocus = true,
-  nodeHref,
+  onFocusMounted,
 }) => {
   const [open, setOpen] = useState(false);
   const rowRef = useRef(null);
@@ -30,16 +29,38 @@ const OntologyTree = ({
     if (forceExpanded.has(curie)) setOpen(true);
   }, [forceExpanded, curie]);
 
-  // Ancestor rows load their children asynchronously via the batched fetch,
-  // and each arrival shifts the focused row further down the tree. Re-anchor
-  // a few times so late layout shifts get corrected.
+  // Deep-link nav can shift the focused row multiple times while ancestor
+  // batches arrive. Re-anchor a few times so late layout shifts still land the
+  // row in view. Anchoring is strictly opt-in (scrollOnFocus) AND only fires
+  // when the row is currently outside its scroll parent's viewport, so an
+  // in-tree click never yanks the pane away from the user's cursor.
   useEffect(() => {
     if (!scrollOnFocus || focusedCurie !== curie) return;
-    const anchor = () => rowRef.current?.scrollIntoView({ block: 'center', behavior: 'auto' });
+    onFocusMounted?.();
+    const findScrollParent = (el) => {
+      let p = el.parentElement;
+      while (p) {
+        const s = window.getComputedStyle(p);
+        if (/(auto|scroll)/.test(s.overflow) || /(auto|scroll)/.test(s.overflowY)) return p;
+        p = p.parentElement;
+      }
+      return document.scrollingElement;
+    };
+    const anchor = () => {
+      const el = rowRef.current;
+      if (!el) return;
+      const scrollParent = findScrollParent(el);
+      if (scrollParent) {
+        const rowRect = el.getBoundingClientRect();
+        const parentRect = scrollParent.getBoundingClientRect();
+        if (rowRect.top >= parentRect.top && rowRect.bottom <= parentRect.bottom) return;
+      }
+      el.scrollIntoView({ block: 'center', behavior: 'auto' });
+    };
     anchor();
     const timers = [100, 300, 700, 1200].map((ms) => setTimeout(anchor, ms));
     return () => timers.forEach(clearTimeout);
-  }, [focusedCurie, curie, scrollOnFocus]);
+  }, [focusedCurie, curie, scrollOnFocus, onFocusMounted]);
 
   const childTerms = data?.children || [];
   // Only show the toggle once the term doc confirms children exist. This
@@ -47,10 +68,6 @@ const OntologyTree = ({
   // loses it a moment later when the batched fetch reports zero children.
   const hasChildren = childTerms.length > 0 || (data?.doTerm?.descendantCount || 0) > 0;
   const isFocused = focusedCurie === curie;
-  // When the consumer supplies nodeHref, every term label (leaf or not) becomes
-  // a link to that URL. Drill-down stays on the separate chevron control, so
-  // linking the label doesn't interfere with exploring children in place.
-  const nodeUrl = nodeHref ? nodeHref(curie) : null;
 
   const toggle = (e) => {
     e.stopPropagation();
@@ -77,13 +94,7 @@ const OntologyTree = ({
         ) : (
           <span className={style.toggleSpacer} />
         )}
-        {nodeUrl ? (
-          <Link to={nodeUrl} onClick={(e) => e.stopPropagation()}>
-            {name}
-          </Link>
-        ) : (
-          <span>{name}</span>
-        )}
+        <span>{name}</span>
         <span className={style.curie}>&nbsp;{curie}</span>
         <span className={style.badgeRow}>
           {ANNOTATION_TYPES.map((t) => (
@@ -94,7 +105,7 @@ const OntologyTree = ({
       {open && childTerms.length > 0 && (
         <div className={style.children}>
           {[...childTerms]
-            .sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { numeric: true }))
+            .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
             .map((c) => (
               <OntologyTree
                 key={c.curie}
@@ -105,7 +116,7 @@ const OntologyTree = ({
                 focusedCurie={focusedCurie}
                 onSelect={onSelect}
                 scrollOnFocus={scrollOnFocus}
-                nodeHref={nodeHref}
+                onFocusMounted={onFocusMounted}
               />
             ))}
         </div>
@@ -122,7 +133,7 @@ OntologyTree.propTypes = {
   focusedCurie: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   scrollOnFocus: PropTypes.bool,
-  nodeHref: PropTypes.func,
+  onFocusMounted: PropTypes.func,
 };
 
 export default OntologyTree;

--- a/src/containers/ontologyBrowser/annotationTypes.js
+++ b/src/containers/ontologyBrowser/annotationTypes.js
@@ -12,19 +12,19 @@ export const ANNOTATION_TYPES = [
     fg: '#084298',
   },
   {
-    id: 'models',
-    label: 'Models',
-    endpoint: 'models_counts',
-    hash: 'associated-models',
-    bg: '#d1e7dd',
-    fg: '#0f5132',
-  },
-  {
     id: 'alleles',
     label: 'Alleles',
     endpoint: 'alleles_counts',
     hash: 'associated-alleles',
     bg: '#fff3cd',
     fg: '#664d03',
+  },
+  {
+    id: 'models',
+    label: 'Models',
+    endpoint: 'models_counts',
+    hash: 'associated-models',
+    bg: '#d1e7dd',
+    fg: '#0f5132',
   },
 ];

--- a/src/containers/ontologyBrowser/index.jsx
+++ b/src/containers/ontologyBrowser/index.jsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faDna } from '@fortawesome/free-solid-svg-icons';
 import HeadMetaTags from '../../components/headMetaTags.jsx';
 import fetchData from '../../lib/fetchData';
 import OntologyTree from './OntologyTree.jsx';
@@ -17,13 +19,15 @@ const PAGE_TITLE = 'Ontology Browser';
 const OntologyBrowser = () => {
   const { ontology: ontologyParam, id } = useParams();
   const navigate = useNavigate();
-  const location = useLocation();
   const ontology = getOntology(ontologyParam);
   const focusedCurie = id || null;
-  // When the user clicks a term inside the tree we set fromTree=true so we
-  // skip re-anchoring the tree to the canonical ancestor chain (which can
-  // belong to a different parent for DAG terms) and skip scrolling.
-  const fromTree = !!location.state?.fromTree;
+  // Ref latches synchronously to the curie the user just clicked in the tree.
+  // Using a ref (not state) avoids any render-timing race between the state
+  // update and the router URL change — by the time focusedCurie flips to the
+  // new curie, the ref already reflects the same value, so fromTree is
+  // guaranteed correct on the very first render after the click.
+  const treeClickRef = useRef(null);
+  const fromTree = !!focusedCurie && treeClickRef.current === focusedCurie;
 
   const { data: ancestors } = useQuery({
     queryKey: ['ontology-ancestors', ontology.id, focusedCurie],
@@ -48,11 +52,33 @@ const OntologyBrowser = () => {
     setForceExpanded(next);
   }, [ancestors, focusedCurie, ontology.rootCurie, fromTree]);
 
-  const handleSelect = (curie, opts = {}) =>
-    navigate(`/ontology/${ontology.id}/${curie}`, opts.fromTree ? { state: { fromTree: true } } : undefined);
+  const handleSelect = (curie, opts = {}) => {
+    if (opts.fromTree) treeClickRef.current = curie;
+    navigate(`/ontology/${ontology.id}/${curie}`);
+  };
   const handleTreeSelect = (curie) => handleSelect(curie, { fromTree: true });
 
   const detailCurie = useMemo(() => focusedCurie || ontology.rootCurie || null, [focusedCurie, ontology.rootCurie]);
+
+  // Batched fetches cascade down the ancestor chain, so the tree layout shifts
+  // multiple times before it settles. Keep the tree pane visually blank until
+  // the focused row has actually mounted, then reveal in one go.
+  const shouldHideTree = !!focusedCurie && !fromTree;
+  const [treeRevealed, setTreeRevealed] = useState(!shouldHideTree);
+  useEffect(() => {
+    setTreeRevealed(!shouldHideTree);
+  }, [shouldHideTree, focusedCurie]);
+  // Safety net: if the focused row never mounts (bad curie, empty ancestor
+  // chain, upstream failure) reveal after a short timeout so the user isn't
+  // stuck watching a spinner forever.
+  useEffect(() => {
+    if (!shouldHideTree) return undefined;
+    const t = setTimeout(() => setTreeRevealed(true), 3000);
+    return () => clearTimeout(t);
+  }, [shouldHideTree, focusedCurie]);
+  const handleFocusMounted = useCallback(() => {
+    requestAnimationFrame(() => setTreeRevealed(true));
+  }, []);
 
   return (
     <CountsProvider>
@@ -103,14 +129,23 @@ const OntologyBrowser = () => {
 
           <div className={style.layout}>
             <div className={style.treePane}>
-              <OntologyTree
-                curie={ontology.rootCurie}
-                name={ontology.rootName}
-                forceExpanded={forceExpanded}
-                focusedCurie={focusedCurie}
-                onSelect={handleTreeSelect}
-                scrollOnFocus={!fromTree}
-              />
+              {!treeRevealed && (
+                <div className={style.treeLoading}>
+                  <FontAwesomeIcon icon={faDna} spin size="2x" className={style.treeLoadingIcon} />
+                  <span className={style.treeLoadingText}>Loading…</span>
+                </div>
+              )}
+              <div style={{ visibility: treeRevealed ? 'visible' : 'hidden' }}>
+                <OntologyTree
+                  curie={ontology.rootCurie}
+                  name={ontology.rootName}
+                  forceExpanded={forceExpanded}
+                  focusedCurie={focusedCurie}
+                  onSelect={handleTreeSelect}
+                  scrollOnFocus={!fromTree}
+                  onFocusMounted={handleFocusMounted}
+                />
+              </div>
             </div>
             <div className={style.detailPane}>
               <TermDetailPanel curie={detailCurie} />

--- a/src/containers/ontologyBrowser/style.module.scss
+++ b/src/containers/ontologyBrowser/style.module.scss
@@ -27,6 +27,28 @@
   padding: 0.75rem 0.5rem;
   max-height: 70vh;
   overflow: auto;
+  position: relative;
+}
+
+.treeLoading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: $gray-600;
+  pointer-events: none;
+}
+
+.treeLoadingIcon {
+  color: $primary;
+}
+
+.treeLoadingText {
+  font-style: italic;
+  font-size: 0.9rem;
 }
 
 .detailPane {

--- a/src/containers/ontologyBrowser/useDiseaseTerms.jsx
+++ b/src/containers/ontologyBrowser/useDiseaseTerms.jsx
@@ -9,7 +9,9 @@ import fetchData from '../../lib/fetchData';
 
 const Ctx = createContext(null);
 const DEBOUNCE_MS = 40;
-const MAX_BATCH = 200;
+// Keep the batch URL short enough that the stage WAF doesn't 403 us — each
+// curie takes ~17 encoded chars, and requests over ~1800 chars start failing.
+const MAX_BATCH = 80;
 
 export const TermsProvider = ({ children }) => {
   const [terms, setTerms] = useState({});


### PR DESCRIPTION
## Summary
Follow-up polish for the ontology browser, all scoped to `src/containers/ontologyBrowser/`.

- **Batch fetcher URL length.** `/api/disease/batch` requests now cap at 80 curies per URL. Stage's WAF was returning 403 on batches large enough to push the URL past ~1800 chars, which dropped the term docs needed to expand deeper ancestor chains.
- **No-jump in-tree clicks.** `fromTree` is now tracked in a ref that updates synchronously inside the click handler, so it is guaranteed correct on the very first render after the click (no batching race with router state updates). The anchor scroll additionally skips when the focused row is already visible inside its scroll ancestor, so an in-tree click never moves the pane away from the user's cursor.
- **Steadier deep-link load.** Tree stays hidden behind a DNA loading indicator until the focused row mounts, then reveals in one paint instead of jumping while ancestor batches trickle in. A 3s fallback reveals the tree if the curie is invalid / has no ancestors.
- **Badge order.** Annotation-available badges reordered to **Genes / Alleles / Models**.

## Test plan
- [ ] Load a deep term URL (e.g. `/ontology/disease/DOID:0111251`) and confirm the tree reveals with the term centered and highlighted.
- [ ] Load an invalid curie (e.g. `/ontology/disease/DOID:0060906`) and confirm the tree reveals to the root after ~3s.
- [ ] Expand many ancestors, scroll the tree pane, click a deep term — the row should stay put, no upward jump.
- [ ] Confirm annotation badges render in Genes → Alleles → Models order in the legend and per-row.