### PR TITLE
SCRUM-6352 read gene assembly from species.genomeAssembly

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -155,13 +155,15 @@ export function getSingleGenomeLocation(genomeLocations) {
 }
 
 export function getGenomicLocations(gene) {
+  // Species-level canonical assembly; identical for every location of a gene.
+  const assembly = gene.taxon?.species?.genomeAssembly?.primaryExternalId;
   return (
     gene.geneGenomicLocationAssociations?.map((loc) => ({
       chromosome: loc.geneGenomicLocationAssociationObject?.name,
       start: loc.start,
       end: loc.end,
       strand: loc.strand,
-      assembly: gene.taxon?.species?.assembly_curie,
+      assembly,
     })) || []
   );
 }


### PR DESCRIPTION
This fixes a bug caused by The 9.1.0 curation model replacement of the free-text Species.assembly scalar with a GenomeAssembly entity (agr_curation ea744a925)