### PR TITLE
KANBAN-1322 ontology browser: hide obsolete, closer-match ranking, tidy detail view

### DIFF
--- a/src/containers/ontologyBrowser/OntologySearchBox.jsx
+++ b/src/containers/ontologyBrowser/OntologySearchBox.jsx
@@ -9,6 +9,31 @@ const ENDPOINT = '/api/search_autocomplete';
 const SEARCH_ENDPOINT = '/api/search';
 const FULL_RESULTS_LIMIT = 200;
 
+// Re-rank hits so the closest name match floats to the top. ES scores can
+// bury an unnumbered parent term ("Parkinson's disease") under its numbered
+// subtypes ("Parkinson's disease 1", "…2", …); tier by match strength, then
+// prefer shorter names within a tier so the parent wins the tie.
+const rankByCloseness = (query, results) => {
+  const q = (query || '').trim().toLowerCase();
+  if (!q || !results?.length) return results || [];
+  const tier = (r) => {
+    const n = (r.name || r.nameKey || '').toLowerCase();
+    if (n === q) return 0;
+    if (n.startsWith(q)) return 1;
+    if (new RegExp(`\\b${q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(n)) return 2;
+    if (n.includes(q)) return 3;
+    return 4;
+  };
+  return [...results].sort((a, b) => {
+    const ta = tier(a);
+    const tb = tier(b);
+    if (ta !== tb) return ta - tb;
+    const la = (a.name || a.nameKey || '').length;
+    const lb = (b.name || b.nameKey || '').length;
+    return la - lb;
+  });
+};
+
 const AUTOSUGGEST_THEME = {
   container: { position: 'relative' },
   suggestionsContainer: {
@@ -37,7 +62,10 @@ const FullResultsModal = ({ isOpen, query, category, onSelect, onClose }) => {
     setError(false);
     const url = `${SEARCH_ENDPOINT}?q=${encodeURIComponent(query)}&category=${category}&limit=${FULL_RESULTS_LIMIT}`;
     fetchData(url)
-      .then((data) => setResults(data?.results || []))
+      .then((data) => {
+        const filtered = (data?.results || []).filter((r) => !/^obsolete/i.test(r.name || r.nameKey || ''));
+        setResults(rankByCloseness(query, filtered));
+      })
       .catch(() => setError(true));
   }, [isOpen, query, category]);
 
@@ -128,7 +156,8 @@ const OntologySearchBox = ({ onSelect, category, placeholder }) => {
     const url = `${ENDPOINT}?q=${encodeURIComponent(q)}&category=${category}`;
     fetchData(url, { signal: controller.signal })
       .then((data) => {
-        setSuggestions(data?.results || []);
+        const filtered = (data?.results || []).filter((r) => !/^obsolete/i.test(r.name || r.nameKey || ''));
+        setSuggestions(rankByCloseness(q, filtered));
       })
       .catch(() => {
         // aborted or failed; leave existing suggestions

--- a/src/containers/ontologyBrowser/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/OntologyTree.jsx
@@ -62,7 +62,7 @@ const OntologyTree = ({
     return () => timers.forEach(clearTimeout);
   }, [focusedCurie, curie, scrollOnFocus, onFocusMounted]);
 
-  const childTerms = data?.children || [];
+  const childTerms = (data?.children || []).filter((c) => !/^obsolete/i.test(c.name || ''));
   // Only show the toggle once the term doc confirms children exist. This
   // avoids the flash where every node briefly renders a chevron and then
   // loses it a moment later when the batched fetch reports zero children.

--- a/src/containers/ontologyBrowser/TermDetailPanel.jsx
+++ b/src/containers/ontologyBrowser/TermDetailPanel.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
 import fetchData from '../../lib/fetchData';
 import { CollapsibleList } from '../../components/collapsibleList';
 import ExternalLink from '../../components/ExternalLink.jsx';
@@ -46,7 +44,7 @@ const TermDetailPanel = ({ curie }) => {
 
       <div className={style.detailSection}>
         <Link to={`/disease/${curie}`} className={`btn btn-primary ${style.viewPageButton}`}>
-          View disease page <FontAwesomeIcon icon={faArrowRight} />
+          View disease page
         </Link>
         {portalSlug && (
           <Link to={`/disease-portal/${portalSlug}`} className={`btn btn-outline-primary ${style.viewPageButton}`}>

--- a/src/containers/ontologyBrowser/index.jsx
+++ b/src/containers/ontologyBrowser/index.jsx
@@ -105,11 +105,6 @@ const OntologyBrowser = () => {
             </select>
           </div>
 
-          <p className={style.explainer}>
-            Browsing <strong>{ontology.label}</strong> starting at <strong>{ontology.rootName}</strong> (
-            {ontology.rootCurie}). Use the search box to jump to any term.
-          </p>
-
           <div className={style.searchRow}>
             <OntologySearchBox
               onSelect={handleSelect}

--- a/src/containers/ontologyBrowser/index.jsx
+++ b/src/containers/ontologyBrowser/index.jsx
@@ -109,7 +109,7 @@ const OntologyBrowser = () => {
             <OntologySearchBox
               onSelect={handleSelect}
               category={ontology.searchCategory}
-              placeholder={`Search ${ontology.label} terms`}
+              placeholder={`Search ${ontology.label} terms or IDs`}
             />
           </div>
 


### PR DESCRIPTION
## Summary
Follow-up polish on the ontology browser, on top of PR #1834:

- **Hide obsolete terms** in the tree children and in both autocomplete + full-results modal (case-insensitive, matches names/nameKeys starting with `obsolete`)
- **Rank closer matches first** in the autocomplete and modal. Results are tiered by match strength (exact -> prefix -> whole-word -> contains), then sorted by name length within a tier so an unnumbered parent floats above its numbered subtypes. Fixes cases like "Parkinson's disease" being buried under "Parkinson's disease 1..N" when it is present in the response
- **Search by ontology ID** — placeholder now reads *"Search Disease (DO) terms or IDs"*. Pairs with agr_java_software PR #1655, which adds `curie` (weight 10) and `secondaryIds` (weight 6) to the `search_autocomplete` multi-match so typing e.g. `DOID:14330` surfaces the term directly
- **Drop the "Browsing X starting at Y (DOID:4)" explainer paragraph** at the top of the page
- **Remove the trailing arrow** on the *View disease page* button so it matches the sibling *View disease portal* button

Includes the earlier `513e3fb8` (from PR #1834) so this branch reproduces the reliable deep-link scroll + DNA loader behavior on top of stage.

### Depends on
- Backend PR alliance-genome/agr_java_software#1655 for the ID-based autocomplete. Frontend still works without it, but the ID search itself won't return hits until #1655 is deployed.

## Test plan
- [ ] Load `/ontology/disease/DOID:10927` on a fresh session — tree opens through the ancestor chain, focused row is centered in the tree pane, DNA loader shows only during load
- [ ] Type "Parkinson" in the search box; "Parkinson's disease" is not buried below its numbered subtypes when it appears in the results
- [ ] Type `DOID:14330` in the search box (requires backend PR #1655) — "Parkinson's disease" is returned
- [ ] Clicking a term inside the tree does not re-scroll the tree pane
- [ ] No child rows start with "obsolete" for any expanded term
- [ ] The old explainer paragraph is gone; the "View disease page" button has no arrow
- [ ] Search-box placeholder reads "Search Disease (DO) terms or IDs"