### PR TITLE
KANBAN-1151 reference page: show the AGRKB ID in the sidebar under the MOD IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ test-npm-github/
 
 # Development tools and temporary files
 .serena/
+.playwright-mcp/
 bfg.jar
 *.jar
 .bfg-report/

--- a/src/containers/referencePage/index.jsx
+++ b/src/containers/referencePage/index.jsx
@@ -194,6 +194,8 @@ const ReferencePage = () => {
         <div>
           <PageNavEntity entityName={ref.short_citation || ref.citation}>
             <SourceList sources={ref.modXrefs} />
+            {/* AGRKB ID sits below the MOD IDs, outside the collapsible list so it is always visible */}
+            {ref.curie && <div style={{ textIndent: 8, marginTop: 6 }}>{ref.curie}</div>}
           </PageNavEntity>
         </div>
       </PageNav>


### PR DESCRIPTION
## Summary

[KANBAN-1151](https://agr-jira.atlassian.net/browse/KANBAN-1151) — show the AGRKB ID in the reference page sidebar, underneath the MOD IDs.

Two lines in `src/containers/referencePage/index.jsx`, inside the existing `PageNavEntity`:

```jsx
<PageNavEntity entityName={ref.short_citation || ref.citation}>
  <SourceList sources={ref.modXrefs} />
  {/* AGRKB ID sits below the MOD IDs, outside the collapsible list so it is always visible */}
  {ref.curie && <div style={{ textIndent: 8, marginTop: 6 }}>{ref.curie}</div>}
</PageNavEntity>
```

Three choices worth calling out:

- **Outside the `CollapsibleList`.** `SourceList` collapses at 3 items, so putting the AGRKB ID inside would hide it behind "show all" on references with 4+ MOD IDs.
- **Plain text, not a link.** The AGRKB ID identifies the page you are already on, so linking it would be a self-link. An *external* registry link would need AGRKB registered in bioregistry first — see Ceri's comment on the ticket.
- **`textIndent: 8, marginTop: 6`** matches `SourceList`'s own inline style so the ID lines up with the MOD IDs above it.

## Note: the AGRKB ID now appears twice on the page

`ReferenceSummary.jsx` already renders an "AGRKB ID" row in the Summary attribute list. The ticket asks specifically for the sidebar, so both are left in place. If the intent was to *move* it rather than add it, the Summary row is the one to drop.

## ⚠️ Overlaps with #1837

#1837 rewrites this same region of `referencePage/index.jsx` — it changes `SourceList` and replaces `buildUrlFromTemplate` with a `getSingleReferenceUrl` shim. Whichever of the two merges second will hit a conflict here. The conflict is confined to this one JSX block and this PR does not touch `SourceList` itself, so it should resolve cleanly either way.

## Test plan

- [x] `/reference/AGRKB:101000000133151` (single MOD ID) — AGRKB ID renders directly under `MGI:1336455`, no console errors
- [x] `/reference/AGRKB:101000000902868` (multiple MOD IDs) — AGRKB ID stays visible with the MOD list collapsed
- [x] Prettier clean; ESLint unchanged from the `stage` baseline for this file (3 pre-existing errors, none new)

The second commit is unrelated housekeeping: adding `.playwright-mcp/` to `.gitignore` so browser-automation artifacts stop showing up as untracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KANBAN-1151]: https://agr-jira.atlassian.net/browse/KANBAN-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ