### PR TITLE
KANBAN-1153 reference page: move Alliance Publication Type under Publication Source

### DIFF
--- a/src/containers/referencePage/ReferenceSummary.jsx
+++ b/src/containers/referencePage/ReferenceSummary.jsx
@@ -116,6 +116,8 @@ const ReferenceSummary = ({ ref }) => {
           {copied ? 'copied to clipboard!' : 'copy citation'}
         </button>
       </AttributeValue>
+      <AttributeLabel>Alliance Publication Type</AttributeLabel>
+      <AttributeValue>{ref.category ? ref.category.replace(/_/g, ' ') : <NoData>Not Available</NoData>}</AttributeValue>
       <AttributeLabel>Cross References</AttributeLabel>
       <AttributeValue placeholder="None">
         <ExternalCrossReferences xrefs={ref.extXrefs} />
@@ -124,8 +126,6 @@ const ReferenceSummary = ({ ref }) => {
       <AttributeValue placeholder="None">
         <MODidentifiers xrefs={ref.modXrefs} />
       </AttributeValue>
-      <AttributeLabel>Alliance Publication Type</AttributeLabel>
-      <AttributeValue>{ref.category ? ref.category.replace(/_/g, ' ') : <NoData>Not Available</NoData>}</AttributeValue>
       <AttributeLabel>AGRKB ID</AttributeLabel>
       <AttributeValue>{ref.curie}</AttributeValue>
     </AttributeList>

--- a/src/containers/referencePage/ReferenceSummary.jsx
+++ b/src/containers/referencePage/ReferenceSummary.jsx
@@ -1,18 +1,12 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { AttributeLabel, AttributeList, AttributeValue } from '../../components/attribute';
-import { Link } from 'react-router-dom';
-import DataSourceLink from '../../components/dataSourceLink.jsx';
-import { ReferencesCellCuration, SourceCell } from '../../components/dataTable';
-import CrossReferenceList from '../../components/crossReferenceList.jsx';
 import CommaSeparatedList from '../../components/commaSeparatedList.jsx';
 import ExternalLink from '../../components/ExternalLink.jsx';
 import NoData from '../../components/noData.jsx';
 import { buildUrlFromTemplate } from '../../lib/utils.js';
-import ApplySpeciesNameFormat from './SpeciesFinderFormatter.jsx';
 import styles from './style.module.scss';
 
-const modMap = { FB: 'flybase', MGI: 'mgd', RGI: 'rgd', SGD: 'sgd', WB: 'wormbase', Xenbase: 'xenbase', ZFIN: 'zfin' };
 const CommaSeparatedSourceList = ({ sources }) => {
   if (!sources) return null;
   return (
@@ -46,9 +40,7 @@ const PubSourceLink = ({ ref }) => {
   const pubIss = ref.issue_name ? `(${ref.issue_name})` : '';
   const pubRng = ref.page_range || '';
   // extract DOI cross-reference (already enriched with resourceDescriptorPage in index.jsx)
-  const doiXref = [...(ref.extXrefs || []), ...(ref.modXrefs || [])].find(
-    (xr) => xr.curie && xr.curie.match(/^doi\:/i)
-  );
+  const doiXref = [...(ref.extXrefs || []), ...(ref.modXrefs || [])].find((xr) => xr.curie && xr.curie.match(/^doi:/i));
   // build link text string, omitting empty segments so missing fields don't render as "undefined"
   const volIssRng = `${pubVol} ${pubIss}:${pubRng}`.replace(/^\s*:\s*$/, '').trim();
   const pubsrc = [publisher, dateString].filter(Boolean).join('. ') + (volIssRng ? `; ${volIssRng}` : '');


### PR DESCRIPTION
## KANBAN-1153

On the Reference Page, move **Alliance Publication Type** up so it follows **Publication Source** in the Summary attribute list. It then sits with the publication information, and the three identifier fields end up contiguous as a set.

The list in the page body, under the article title, now reads:

| # | Field |
|---|-------|
| 1 | Author(s) |
| 2 | Publication Source |
| 3 | Alliance Publication Type &nbsp;&nbsp;&larr; moved up from position 5 |
| 4 | Cross References |
| 5 | MOD Identifier |
| 6 | AGRKB ID |

### Commits

**1. The reorder** — a pure move of two `AttributeLabel`/`AttributeValue` pairs in `ReferenceSummary.jsx`. The added and removed lines are byte-identical, so no rendered value changes.

**2. ESLint cleanup** — the file carried 8 pre-existing ESLint errors, all local to it. Cleared as part of this ticket:

- Seven unused declarations left over from earlier iterations — the `Link`, `DataSourceLink`, `ReferencesCellCuration`, `SourceCell`, `CrossReferenceList`, and `ApplySpeciesNameFormat` imports, plus the `modMap` constant. Each was referenced only at its own declaration. `SpeciesFinderFormatter.jsx` is still imported by `index.jsx`, so no component is orphaned.
- One unnecessary escape in the DOI matcher: `/^doi\:/i` becomes `/^doi:/i`. A colon is not a regex metacharacter, so the match is unchanged. Prettier reflowed the shortened line onto one.

`eslint` now reports no problems for this file.

### Testing

- Verified rendering on `localhost:3000`
- `tsc --noEmit` clean
- Prettier clean
- 43/43 test suites, 192/192 tests pass

### Notes for reviewers

Independent of PR #1842 (KANBAN-1151) despite both being Reference Page work — that one touches only `referencePage/index.jsx` (the PageNav sidebar), while this touches only `ReferenceSummary.jsx` (the page body). The `AGRKB ID` row in the body list is pre-existing on `stage`, not from #1842. No conflict, no merge ordering required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
