### PR TITLE
feat(diseasePortal): add "Browse Ontology" link to the side nav (KANBAN-1464)

### DIFF
--- a/src/components/dataPage/pageNav.jsx
+++ b/src/components/dataPage/pageNav.jsx
@@ -24,6 +24,7 @@ const PageNav = ({ children, sections }) => {
           </button>
         </div>
         <Collapse isOpen={isOpen} navbar>
+          {/* Scrollspy maps items to children by index, so `to` entries (filtered out here) must stay last. */}
           <Scrollspy
             className={`list-group list-group-flush ${style.scrollSpy}`}
             componentTag="div"

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -18,11 +18,19 @@ import style from './style.module.scss';
 
 const SUMMARY = 'Summary';
 const ONTOLOGY = 'Ontology View';
+const BROWSE_ONTOLOGY = 'Browse Ontology';
 const COMMUNITY_RESOURCES = 'Community Resources';
 const RECENT_PAPERS = 'Recent Alliance Papers';
 const MEMBERS = 'Members';
 
-const SECTIONS = [{ name: SUMMARY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }, { name: ONTOLOGY }];
+// Browse Ontology is an outbound link rather than an anchor, so sections depend on the doid.
+const makeSections = (doid) => [
+  { name: SUMMARY },
+  { name: RECENT_PAPERS },
+  { name: COMMUNITY_RESOURCES },
+  { name: ONTOLOGY },
+  { name: BROWSE_ONTOLOGY, to: `/ontology/disease/${doid}` },
+];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -67,7 +75,7 @@ const DiseasePortalPage = () => {
       <HeadMetaTags title={`${diseaseData.pageName} Portal`} />
       <DiseasePortalSection disease={diseaseData} />
       <DataPage>
-        <PageNav sections={SECTIONS}>
+        <PageNav sections={makeSections(diseaseData.doid)}>
           <PageNavEntity entityName={portalTitle}>
             <Link to={`/disease/${diseaseData.doid}`}>{diseaseData.doid}</Link>
           </PageNavEntity>


### PR DESCRIPTION
## KANBAN-1464

Adds a **Browse Ontology** entry to the disease portal side navigation. It links to the standalone Disease Ontology browser focused on the portal's term (`/ontology/disease/<doid>`), complementing the existing **Ontology View** within-page anchor link, which is unchanged.

https://agr-jira.atlassian.net/browse/KANBAN-1464

### Implementation

`PageNav` already supported outbound nav entries — a section with a `to` prop renders a `<Link>` instead of a `HashLink`, and such entries are excluded from Scrollspy's `items` so they never pick up spurious `active` highlighting. **No component changes were needed.** `diseasePage` already uses this same pattern for its own `BROWSE_ONTOLOGY` entry, so this follows established precedent.

The only structural change: `SECTIONS` becomes `makeSections(doid)`, since the link target is per-disease and can't be a module-level constant.

The second commit adds a comment to `pageNav.jsx` documenting a non-obvious invariant: `Scrollspy` receives only the anchor sections as `items` but renders every section as a child, and maps items to children **by index**. Outbound entries must therefore stay last, or the active class lands on the wrong nav item. Both callers comply today; the comment guards against a future mid-list insertion.

### Testing

Verified in the browser: the link renders as a peer of "Ontology View", navigates to the ontology browser rather than scrolling in place, and never receives active highlighting while scrolling the portal page.

### Known issues (pre-existing, not from this PR)

- **KANBAN-1466** — side nav scroll highlighting stops working once entity data loads, on every data page. Caused by `Subsection` remounting its anchor element on each render, which detaches the nodes `react-scrollspy` caches. Confirmed on gene pages, so it is unrelated to this change; filed separately since the fix touches a shared component. Reviewers clicking through this feature will see it.
- **KANBAN-1395** — the ontology browser fails to focus multi-parent (DAG) terms. The link built here is correct; the focus logic in the standalone browser is what falls short for those terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
