### PR TITLE
fix(layout): size the footer sitemap from content, not a fixed height (KANBAN-518)

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -237,12 +237,12 @@ export const NAV_MENU = [
       },
       {
         label: 'Organization and Governance',
-        shortLabel: 'Organization / Governance',
+        shortLabel: 'Organization',
         route: '/organization-and-governance',
       },
       {
         label: 'Privacy, Warranty, Licensing, and Data Preservation Commitment',
-        shortLabel: 'Licensing, Privacy, etc',
+        shortLabel: 'Licensing, Privacy',
         route: '/privacy-warranty-licensing',
       },
     ],

--- a/src/containers/layout/style.module.scss
+++ b/src/containers/layout/style.module.scss
@@ -84,25 +84,29 @@
     margin-bottom: 1rem;
   }
 
+  // multi-column: column count follows the width, height follows the content
   .siteMapContainer {
-    display: flex;
     flex-grow: 1;
-    flex-direction: column;
-    flex-wrap: wrap;
-    height: 460px;
+    column-width: 7rem;
+    column-gap: 1rem;
+
+    @include media-breakpoint-up(sm) {
+      column-width: 8rem;
+    }
 
     @include media-breakpoint-up(md) {
-      height: 235px;
+      column-width: 9rem;
+      column-gap: 1.5rem;
     }
   }
 
   .siteMapGroup {
     margin-bottom: 0.5rem;
-    width: 50%;
-
-    @include media-breakpoint-up(md) {
-      width: 15%;
-    }
+    // keep a group whole in its column
+    -webkit-column-break-inside: avoid;
+    break-inside: avoid;
+    // an over-long label wraps instead of overhanging the next column
+    white-space: normal;
   }
 
   .siteMapHeader {


### PR DESCRIPTION
**TL;DR** — the footer CSS was brittle with respect to added menu items, this bit when we recently added the Ontology Browser item (the column layout hung off a hand-tuned fixed height); changed to be responsive, so the footer now sizes itself from its content.

---

Fixes [KANBAN-518](https://agr-jira.atlassian.net/browse/KANBAN-518) — the bottom of the footer is cut off, so link text isn't fully visible.

## Cause

`.siteMapContainer` used `flex-direction: column` + `flex-wrap: wrap`, which can only wrap into columns against a **definite height**. That height was therefore hand-tuned every time the nav grew — `180 → 235 → 325 → 360 → 460` across four past commits. Adding the Ontology Browser item made the "Data and Tools" group **259px** tall inside the **235px** cap, so its last link ("Tools") rendered below the footer's background and read as cut off.

## Change

Replace the mechanism with CSS multi-column, so the browser derives the column count from the available width and the height from the content. No pixel value tracks the menu any more.

- `column-width` `7rem` / `8rem` / `9rem` across `xs` / `sm` / `md+`, sized to hold the longest label rather than tuned to a height
- `break-inside: avoid` keeps each menu group whole within its column
- `white-space: normal` makes a future over-long label wrap instead of overhanging the next column

Two footer `shortLabel`s are shortened so every label fits its column without the old (intentional but brittle) column-3 → column-4 overhang:

| label | was | now |
|---|---|---|
| Organization and Governance | Organization / Governance (186px) | **Organization** (99px) |
| Privacy, Warranty, Licensing, … | Licensing, Privacy, etc (152px) | **Licensing, Privacy** (128px) |

**Header labels are unaffected** — `MenuItem.jsx` renders `label`; only `SiteMap.jsx` reads `shortLabel`.

This also removes the horizontal page overflow the footer caused below `md`, where three `width: 50%` columns spanned 150% of their container — 118px of sideways scroll at 375px, 219px at 576px. That sideways scroll was also what made the footer's blue background appear clipped when scrolled right (backgrounds paint only to the element box, which is viewport-width).

## Verification

Measured in-browser against the stage API, 320–1920px:

| viewport | columns | footer height | vertical clip | footer h-overflow |
|---|---|---|---|---|
| 320 | 2 | 678px | 0 | 0 |
| 375 | 2 | 635px | 0 | 0 |
| 480 | 3 | 546px | 0 | 0 |
| 576 | 3 | 525px | 0 | 0 |
| 767 | 3 | 525px | 0 | 0 |
| 768 | 4 | 387px | 0 | 0 |
| 992 | 4 | 321px | 0 | 0 |
| 1440 / 1920 | 5 | 291px | 0 | 0 |

No label wraps at 375px or at 480px+; at 320px four long labels take two lines, which is the intended graceful degradation.

Regression test for the root cause: injecting two hypothetical extra nav items grows the footer 291 → 335px with **zero** clipping, where the old layout would have clipped them.

## Scope

Confined to the footer. `.siteMapContainer` / `.siteMapGroup` are nested inside `.footer {}` in the SCSS, are referenced only by `SiteMap.jsx`, and `SiteMap` is imported only by `Footer.jsx`. A computed-style sweep of the rendered page confirms exactly one element in the document has a column property applied, inside `<footer>`.

## Not in scope

Below ~440px the page still scrolls horizontally, from a separate source: the header top-bar row has a ~439px minimum content width (13rem logo + version text + hamburger). Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KANBAN-518]: https://agr-jira.atlassian.net/browse/KANBAN-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ