### PR TITLE
fix(diseasePortal): link embedded ontology terms back to the browser (KANBAN-1470)

### DIFF
--- a/src/containers/diseasePortal/OntologyContextSection.jsx
+++ b/src/containers/diseasePortal/OntologyContextSection.jsx
@@ -10,11 +10,12 @@ import { TermsProvider } from '../ontologyBrowser/useDiseaseTerms.jsx';
 import style from './style.module.scss';
 
 // Embedded, scoped ontology view for a disease portal page (KANBAN-1391).
-// Two interaction modes by region:
-//  - Ancestor context (immediate parents) renders as links OUT to the full-page
-//    ontology browser, so the user can jump up the hierarchy.
-//  - The focus term and its descendants stay in-page: the reused OntologyTree
-//    handles expand/collapse drill-down locally, no route change.
+// Two interaction modes by control:
+//  - Term labels — both the ancestor context and every row in the tree — link
+//    OUT to the full-page ontology browser. The embed has no detail panel, so
+//    selecting a term in place would be a dead end.
+//  - The chevron stays in-page: expand/collapse drill-down is local, no route
+//    change.
 const OntologyContextSection = ({ curie, name }) => {
   // Immediate parents come from the single-term doc (same shape the standalone
   // TermDetailPanel uses). The DO is a DAG, so there can be more than one.

--- a/src/containers/ontologyBrowser/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/OntologyTree.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import CountBadge from './CountBadge.jsx';
@@ -17,6 +18,7 @@ const OntologyTree = ({
   onSelect,
   scrollOnFocus = true,
   onFocusMounted,
+  nodeHref,
 }) => {
   const [open, setOpen] = useState(false);
   const rowRef = useRef(null);
@@ -68,6 +70,10 @@ const OntologyTree = ({
   // loses it a moment later when the batched fetch reports zero children.
   const hasChildren = childTerms.length > 0 || (data?.doTerm?.descendantCount || 0) > 0;
   const isFocused = focusedCurie === curie;
+  // Embedded viewers (the disease portal) link every label out to the full
+  // browser, since they have no detail panel of their own. The standalone
+  // omits nodeHref and keeps rendering a plain span that selects in place.
+  const nodeUrl = nodeHref ? nodeHref(curie) : null;
 
   const toggle = (e) => {
     e.stopPropagation();
@@ -94,7 +100,13 @@ const OntologyTree = ({
         ) : (
           <span className={style.toggleSpacer} />
         )}
-        <span>{name}</span>
+        {nodeUrl ? (
+          <Link to={nodeUrl} onClick={(e) => e.stopPropagation()}>
+            {name}
+          </Link>
+        ) : (
+          <span>{name}</span>
+        )}
         <span className={style.curie}>&nbsp;{curie}</span>
         <span className={style.badgeRow}>
           {ANNOTATION_TYPES.map((t) => (
@@ -117,6 +129,7 @@ const OntologyTree = ({
                 onSelect={onSelect}
                 scrollOnFocus={scrollOnFocus}
                 onFocusMounted={onFocusMounted}
+                nodeHref={nodeHref}
               />
             ))}
         </div>
@@ -134,6 +147,7 @@ OntologyTree.propTypes = {
   onSelect: PropTypes.func.isRequired,
   scrollOnFocus: PropTypes.bool,
   onFocusMounted: PropTypes.func,
+  nodeHref: PropTypes.func,
 };
 
 export default OntologyTree;


### PR DESCRIPTION
Restores the outbound link on term labels in the disease portal's "Ontology View" section. [KANBAN-1470](https://agr-jira.atlassian.net/browse/KANBAN-1470)

## What broke

`OntologyContextSection.jsx` has been passing `nodeHref` into `OntologyTree` ever since 513e3fb8 (KANBAN-1322) removed the prop, so the embed has been handing over a prop nothing consumes. Term labels silently stopped linking to the full browser, and because the embed has no detail panel of its own, clicking a term became a highlight with nowhere to go. The only links left were the G/A/M badges, which go to the disease page.

Nothing warned about this: React silently ignores an unrecognized prop, so the embed's behavior degraded quietly.

The removal looks incidental rather than intended — 513e3fb8's message is entirely about scroll anchoring and click-jump behavior and never mentions links; the label rendering was rewritten as part of simplifying the row, and the embed was the only consumer.

## The fix

Re-adds **only** the five `nodeHref` pieces: the `Link` import, the prop in the signature, `nodeUrl`, the label branch, the pass-down to child nodes, and the propType. **This is not a revert of 513e3fb8** — every line of its scroll anchoring and no-jump click handling is left untouched, since those hunks are disjoint from the label rendering.

The prop stays opt-in. The standalone browser doesn't pass it, so it takes the `<span>` branch and its DOM is unchanged.

@jdepons — thanks for the OK on this approach. Flagging explicitly that the scroll work from your commit was left alone, and that the standalone renders no anchors at all (verified below).

## Verification

Local dev server against the stage API.

**Standalone browser unchanged** — `/ontology/disease/DOID:0060639`, 1414 rendered rows:

| Check | Result |
|---|---|
| Anchors pointing at `/ontology/` in tree rows | **0** |
| Focused row's label element | `SPAN` |

So no links appear in the main browser, active or otherwise.

**No re-introduced jumpiness** — measured the tree pane's scroll offset around an in-tree click:

| | Before | After |
|---|---|---|
| Pane `scrollTop` | 27443 | 27443 |
| `window.scrollY` | 138 | 138 |

0px of movement in both, with selection correctly following the click. Deep-link focus still lands centered and in viewport.

**Embed behaves as designed** — `/disease-portal/diabetes-mellitus`:

- All 6 tree rows carry a label link to `/ontology/disease/<curie>`, with their 3 badge links intact.
- The chevron on "neonatal diabetes mellitus" expanded 6 → 9 rows with no route change.
- Clicking the "permanent neonatal diabetes mellitus" label — the ticket's repro — landed on the browser with the term focused, centered, and the correct detail panel.

**Tests:** jest 43 suites / 192 tests passing. Prettier and ESLint clean.

## Also

Updated the stale comment at the top of `OntologyContextSection.jsx`, which still claimed the focus term and its descendants "stay in-page". It now describes the actual split: labels link out, the chevron drills down locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KANBAN-1470]: https://agr-jira.atlassian.net/browse/KANBAN-1470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ