### PR TITLE
feat(referencePage): flag retracted references with a banner (KANBAN-1227)

### DIFF
--- a/src/containers/referencePage/index.jsx
+++ b/src/containers/referencePage/index.jsx
@@ -174,6 +174,12 @@ const ReferencePage = () => {
 
       <PageData>
         <PageCategoryLabel category="reference" />
+        {/* set to one of the retraction types, and absent otherwise */}
+        {ref.retraction_status && (
+          <div className={`alert alert-danger ${styles.retractionBanner}`} role="alert">
+            This reference has been retracted. Some or all of the associated data have been removed.
+          </div>
+        )}
         <PageHeader>
           <ApplySpeciesNameFormat text={ref.title} />
         </PageHeader>

--- a/src/containers/referencePage/style.module.scss
+++ b/src/containers/referencePage/style.module.scss
@@ -7,6 +7,11 @@
   margin-right: 0.5rem;
 }
 
+.retractionBanner {
+  font-size: 1.2rem;
+  text-align: center;
+}
+
 div.speciesSprites span {
   margin-bottom: -20px;
 }


### PR DESCRIPTION
Closes KANBAN-1227.

Shows a banner above the reference title when a reference has been retracted, with the wording from the ticket's acceptance criteria:

> This reference has been retracted. Some or all of the associated data have been removed.

## How it decides

The flag is already in the `/api/reference/{id}` payload as `literatureSummary.retraction_status`, so no new request is needed.

```jsx
{ref.retraction_status && ( ... )}
```

Per curator guidance on the ticket, the banner shows whenever that field is populated rather than matching a specific curie. There are three retraction types — `ATP:0000346` (retracted, from PubMed) plus the curated children `ATP:0000347` (partially retracted) and `ATP:0000348` (fully retracted) — so matching one curie would miss two of them, and any type added later should surface as well. The API omits the field entirely on references that are not retracted.

## Verified

| AGRKB ID | `retraction_status` | expected | result |
| --- | --- | --- | --- |
| AGRKB:101000001209757 | `ATP:0000346` retracted | banner | pass |
| AGRKB:101000000391588 | `ATP:0000347` partially retracted | banner | pass |
| AGRKB:101000001192616 | `ATP:0000348` fully retracted | banner | pass |
| AGRKB:101000001209750 | field absent | no banner | pass |
| AGRKB:101000001209751 | field absent | no banner | pass |
| AGRKB:101000001172700 | field absent | no banner | pass |

Checked in the running dev server against the stage API. The banner renders with `role="alert"`, and the reference title remains the page's only `level=1` heading — a heading tag was deliberately avoided so the notice does not enter the document outline above the title.

## Notes for review

- Styling follows the existing house pattern of Bootstrap alert classes on a plain `div` (`errorBoundary.jsx:29`, `notFound.jsx:8`) rather than introducing reactstrap's `<Alert>`, which is not used anywhere in `src/`.
- The nine ESLint findings in `referencePage/index.jsx` are pre-existing (leftovers from the hidden Reference tables) and untouched; the count is identical before and after this change.
- **Open question, not blocking:** the three retraction types carry different messages in the ABC. This PR shows the single AC message for all three, which reads a little loosely for `partially retracted`. `retraction_status_name` is already in the payload, so per-type wording would be a small follow-up if curators want it.
- Three of the five IDs originally supplied on the ticket (`AGRKB:101000001203590`, `AGRKB:101000000994936`, `AGRKB:101000001172808`) return `No literature summary found` from `/api/reference/{id}` on stage, test, and prod alike, so those pages render Not Found and are out of scope here. Notably `…1203590` is one of the ABC examples on the ticket, so it appears to exist in ABC without being in the AGR reference index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
