### PR TITLE
feat(diseasePortal): add five new disease portal pages (KANBAN-1471)

### DIFF
--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -61,12 +61,10 @@ const PaperEntry = ({ reference }) => {
   );
 };
 
-// The endpoint matches the disease name as free text against title + abstract,
-// requiring all tokens. A trailing "disease" token therefore excludes on-topic
-// papers that don't repeat the word (e.g. "Alzheimer's disease" misses papers
-// titled "...Implications for Alzheimer") and lets the common word "disease"
-// pull in tangential papers. Drop a trailing "disease" word so the query anchors
-// on the distinctive part of the name. See RECENT_PAPERS_API.md.
+// The endpoint matches the disease name loosely against title + abstract and
+// fills every corpus slot even with no real match, so a common trailing token
+// like "disease" injects tangential papers rather than narrowing. Drop it so the
+// query anchors on the distinctive part of the name. See RECENT_PAPERS_API.md.
 const normalizeDiseaseQuery = (name) => {
   if (!name) {
     return name;

--- a/src/containers/diseasePortal/PapersSection.jsx
+++ b/src/containers/diseasePortal/PapersSection.jsx
@@ -75,8 +75,9 @@ const normalizeDiseaseQuery = (name) => {
   return trimmed || name;
 };
 
-const PapersSection = ({ diseaseName }) => {
-  const query = normalizeDiseaseQuery(diseaseName);
+const PapersSection = ({ diseaseName, queryOverride }) => {
+  // An override is a curated query string, so it bypasses normalization.
+  const query = queryOverride || normalizeDiseaseQuery(diseaseName);
   const url = query
     ? `/api/reference/latest-literature-by-disease-per-mod?disease=${encodeURIComponent(query)}&latest=1`
     : null;

--- a/src/containers/diseasePortal/RECENT_PAPERS_API.md
+++ b/src/containers/diseasePortal/RECENT_PAPERS_API.md
@@ -201,9 +201,9 @@ rows, so expect some drift when spot-checking.
 
 ### Query normalization: strip a trailing "disease" token
 
-A trailing `disease` word both **excludes** on-topic papers that don't repeat the
-word and lets the common word `disease` pull in **tangential** papers. So
-`PapersSection` strips a trailing `disease` token before querying
+Under the loose matching above, a trailing `disease` word is a common token that
+pulls **tangential** papers into slots that would otherwise hold an on-topic one.
+So `PapersSection` strips a trailing `disease` token before querying
 (`/\s+disease$/i`):
 
 | `doTerm.name`         | Query sent                                                 |

--- a/src/containers/diseasePortal/RECENT_PAPERS_API.md
+++ b/src/containers/diseasePortal/RECENT_PAPERS_API.md
@@ -63,6 +63,45 @@ and additionally dedupes repeated curies (the backend can return one paper in
 two corpus slots). The clean long-term fix is backend-side (exclude `AGR` from
 the per-corpus grouping, or expose which slot each paper filled).
 
+### Backend follow-ups (needs discussion — do NOT implement UI-side)
+
+Two known problems with per-corpus selection. Both belong in the API, because
+selection is where the ranking already happens; the UI can only compensate for
+it. Recorded Aug 11 2026, pending discussion.
+
+**1. Exclude the `AGR` corpus from per-corpus grouping** (or expose which slot
+each paper filled). This is the duplicate-row problem above; it would retire the
+~18-line redundancy filter in `PapersSection.jsx`.
+
+**2. Filter out reviews — ideally a param** (`excludeTypes=Review` /
+`includeReviews=false`) rather than hardcoded, so the behavior stays visible to
+callers. Curator request, Aug 11 2026: papers with a PubMed publication type of
+`Review` are frequently the newest hit for a corpus while being only marginally
+on-topic, since a review can name-drop a disease once in a list of conditions.
+
+Measured on the autism portal (`disease=autism&latest=1`): 2 of 8 rows are
+reviews — MGI (`P-Rex Rac-GEFs`, autism appears once, in "linked to fibrotic
+diseases, asthma, and autism spectrum disorders") and SGD (`A comprehensive
+review on DDX3X liquid phase condensation…`). The next non-review MGI paper is
+`AGRKB:101000001305569`, "Cortical development dynamics across autism spectrum
+disorder mouse models" (_Nature_, 2026-08-01) — squarely on topic, and only one
+month older, so almost no freshness is lost.
+
+`pubmed_types` is already in the response (e.g.
+`['Journal Article', 'Review']`), so this is _technically_ doable in the UI —
+but it shouldn't be, for three reasons:
+
+- With `latest=1` the backend sends only the newest paper per corpus, so
+  filtering **removes** the row rather than replacing it: the mouse and yeast
+  rows would simply disappear. A UI fix therefore has to over-fetch
+  (`latest=5`+) and re-run the per-corpus pick, duplicating backend logic and
+  inflating the payload ~5×.
+- Even then it silently drops a species whenever every fetched paper for a
+  corpus happens to be a review.
+- Match on the exact string `Review`. `pubmed_types` also carries values like
+  `Research Support, Non-U.S. Gov't` alongside `Journal Article`; a substring
+  match would additionally catch things like `Scientific Integrity Review`.
+
 ## Response
 
 Standard `JsonResultResponse` envelope:
@@ -111,29 +150,61 @@ The component reads exactly what it renders:
   the **authoritative** species source (set by the curator pipeline), replacing
   the old fragile cross-reference-prefix guessing. Fixed map:
 
-  | Corpus | Species (drives `<SpeciesIcon>`)                             |
-  | ------ | ------------------------------------------------------------ |
-  | MGI    | `Mus musculus`                                               |
-  | RGD    | `Homo sapiens` _(rat corpus is shown as Human, per curator)_ |
-  | XB     | `Xenopus tropicalis`                                         |
-  | ZFIN   | `Danio rerio`                                                |
-  | FB     | `Drosophila melanogaster`                                    |
-  | WB     | `Caenorhabditis elegans`                                     |
-  | SGD    | `Saccharomyces cerevisiae`                                   |
+  | Corpus | Species (drives `<SpeciesIcon>`)                                   |
+  | ------ | ------------------------------------------------------------------ |
+  | MGI    | `Mus musculus`                                                     |
+  | RGD    | `Rattus norvegicus` _(per curator, June 2026; was `Homo sapiens`)_ |
+  | XB     | `Xenopus tropicalis`                                               |
+  | ZFIN   | `Danio rerio`                                                      |
+  | FB     | `Drosophila melanogaster`                                          |
+  | WB     | `Caenorhabditis elegans`                                           |
+  | SGD    | `Saccharomyces cerevisiae`                                         |
 
   `AGR` (Alliance central corpus) has no species of its own and is ignored; if a
   paper maps to no MOD species, the icon falls back to `Homo sapiens`.
+
+  The icon reflects **corpus membership, not the paper's study species** — RGD
+  curates human disease literature alongside rat, so an RGD row is occasionally a
+  human clinical-genetics paper wearing a rat icon (measured Aug 11 2026 across
+  all portals: 2 of 8 — ciliopathy, a RAB34 compound-heterozygous variant paper,
+  and long QT, a KCNH2 patient frameshift paper; the other 6 are rat studies). No
+  fixed per-corpus icon avoids this, and it is the same class of problem as the
+  review filter above: the honest fix is a per-paper species signal from the API
+  rather than a per-corpus guess. `Rattus norvegicus` is the better default at
+  6/8, which is why the curator switched to it in June 2026.
 
 The disease name is sourced from the page's existing `/api/disease/{doid}` query
 (`doTerm.name`), so no new lookup table is needed. The root portal (DOID:4) never
 renders this section (it only appears on detail routes).
 
+### Matching behavior (corrected Aug 11 2026)
+
+An earlier version of this document stated that the endpoint requires **all**
+tokens of the query to match. **That is wrong.** Measured behavior:
+
+- Matching is **loose**, and the backend **fills every corpus slot even when
+  nothing genuinely matches**. So extra tokens actively inject junk rather than
+  narrowing: `autism spectrum disorder` returned a "broad-**spectrum**
+  antibacterial" paper for WB and a Xenopus "pigmentary **disorders**" paper.
+- **Quoting forces a phrase match**, and it works: `"long QT syndrome"` returns
+  KCNH2 arrhythmia, KV7.1/KCNE1 and CALM1/2 papers, where the unquoted name
+  returns kidney-aging and yeast-plasmid papers.
+- But quoting only helps when the phrase is reasonably common in the MOD
+  corpora. For autism it changed nothing, while cutting the query to the single
+  distinctive token `autism` went from 6 mostly-noise rows to 8 on-topic ones.
+
+Hence the two knobs: the trailing-"disease" strip below, and the per-portal
+`papersQuery` override in `portalData.js` (quote the phrase, or cut to the
+distinctive token — whichever the corpora reward). Note the endpoint is not
+fully deterministic: two identical requests minutes apart returned different XB
+rows, so expect some drift when spot-checking.
+
 ### Query normalization: strip a trailing "disease" token
 
-Because the endpoint requires **all** tokens of the query to match, a trailing
-`disease` word both **excludes** on-topic papers that don't repeat the word and
-lets the common word `disease` pull in **tangential** papers. So `PapersSection`
-strips a trailing `disease` token before querying (`/\s+disease$/i`):
+A trailing `disease` word both **excludes** on-topic papers that don't repeat the
+word and lets the common word `disease` pull in **tangential** papers. So
+`PapersSection` strips a trailing `disease` token before querying
+(`/\s+disease$/i`):
 
 | `doTerm.name`         | Query sent                                                 |
 | --------------------- | ---------------------------------------------------------- |

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -86,7 +86,7 @@ const DiseasePortalPage = () => {
             <SummarySection disease={diseaseApiData} />
           </Subsection>
           <Subsection title={RECENT_PAPERS}>
-            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} />
+            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
           </Subsection>
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -77,6 +77,25 @@ export const data = {
       { title: 'World Health Organization (WHO) - Diabetes', url: 'https://www.who.int/health-topics/diabetes' },
     ],
   },
+  ciliopathy: {
+    doid: 'DOID:0060340',
+    pageName: 'Ciliopathy',
+    group: 'Genetic disease',
+    listLabel: 'ciliopathy',
+    resources: [
+      { title: 'Ciliopathy Alliance', url: 'https://ciliopathyalliance.org/' },
+      {
+        title: 'NCI/NEI ciliopathy gene-therapy research news (NIH intramural)',
+        url: 'https://www.nih.gov/news-events/news-releases/nih-researchers-develop-gene-therapy-rare-ciliopathy',
+      },
+      { title: 'PCD Research', url: 'https://pcdresearch.org/' },
+      {
+        title: 'Rare Diseases Clinical Research Network (RDCRN) - NIH/NCATS',
+        url: 'https://www.rarediseasesnetwork.org/',
+      },
+      { title: 'TheRaCil (Therapies for Renal Ciliopathies)', url: 'https://theracil.eu/' },
+    ],
+  },
   'long-qt-syndrome': {
     doid: 'DOID:2843',
     pageName: 'Long QT Syndrome',

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -12,7 +12,8 @@ import { DISEASE_ROOT_CURIE } from '../ontologyBrowser/ontologies.js';
 //              Not taken from the API: /api/disease/DOID:4 is named "disease",
 //              and the title has to render before that query resolves.
 //   group      parent-disease heading this portal appears under in the index.
-//              Omit on the root entry.
+//              Uses the DO slim term behind the gene-page disease ribbon, so
+//              headings match the buckets curators see there. Omit on the root.
 //   listLabel  optional. Label in the index, when it differs from pageName.
 //   resources  optional. Community Resources links.
 //   papersQuery optional. Overrides the Recent Papers query for portals whose
@@ -64,7 +65,7 @@ export const data = {
   'autism-spectrum-disorder': {
     doid: 'DOID:0060041',
     pageName: 'Autism Spectrum Disorder',
-    group: 'Developmental disorder of mental health',
+    group: 'Disease of mental health',
     listLabel: 'autism spectrum disorder',
     resources: [
       { title: 'Autism BrainNet', url: 'https://autismbrainnet.org/' },
@@ -106,7 +107,7 @@ export const data = {
   ciliopathy: {
     doid: 'DOID:0060340',
     pageName: 'Ciliopathy',
-    group: 'Genetic disease',
+    group: 'Monogenic disease',
     listLabel: 'ciliopathy',
     resources: [
       { title: 'Ciliopathy Alliance', url: 'https://ciliopathyalliance.org/' },
@@ -125,7 +126,7 @@ export const data = {
   'long-qt-syndrome': {
     doid: 'DOID:2843',
     pageName: 'Long QT Syndrome',
-    group: 'Heart disease',
+    group: 'Cardiovascular system disease',
     listLabel: 'long QT syndrome',
     papersQuery: '"long QT syndrome"',
     resources: [
@@ -140,7 +141,7 @@ export const data = {
   'alzheimers-disease': {
     doid: 'DOID:10652',
     pageName: "Alzheimer's Disease",
-    group: 'Nervous system disease',
+    group: 'Central nervous system disease',
     listLabel: "Alzheimer's disease",
     resources: [
       {
@@ -162,7 +163,7 @@ export const data = {
   epilepsy: {
     doid: 'DOID:1826',
     pageName: 'Epilepsy',
-    group: 'Nervous system disease',
+    group: 'Central nervous system disease',
     listLabel: 'epilepsy',
     resources: [
       { title: 'American Epilepsy Society', url: 'https://aesnet.org' },
@@ -180,7 +181,7 @@ export const data = {
   'parkinsons-disease': {
     doid: 'DOID:14330',
     pageName: "Parkinson's Disease",
-    group: 'Nervous system disease',
+    group: 'Central nervous system disease',
     listLabel: "Parkinson's disease",
     resources: [
       {

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -35,6 +35,26 @@ export const data = {
       { title: 'Portal Kids First DRC', url: 'https://portal.kidsfirstdrc.org/login?redirect_path=/data-exploration' },
     ],
   },
+  'colorectal-cancer': {
+    doid: 'DOID:9256',
+    pageName: 'Colorectal Cancer',
+    group: 'Cancer',
+    listLabel: 'colorectal cancer',
+    resources: [
+      { title: 'Colon Cancer Family Registry (CCFR)', url: 'https://coloncfr.org/' },
+      { title: 'Colorectal Cancer Alliance', url: 'https://colorectalcancer.org' },
+      {
+        title: 'Fight Colorectal Cancer - Research',
+        url: 'https://fightcolorectalcancer.org/our-programs/research-innovation/',
+      },
+      {
+        title: 'GECCO (Genetics and Epidemiology of Colorectal Cancer Consortium)',
+        url: 'https://research.fredhutch.org/peters/en/genetics-and-epidemiology-of-colorectal-cancer-consortium.html',
+      },
+      { title: 'NCI Advances in Colorectal Cancer Research', url: 'https://www.cancer.gov/types/colorectal/research' },
+      { title: 'NCI Genomic Data Commons (GDC)', url: 'https://gdc.cancer.gov/' },
+    ],
+  },
   'autism-spectrum-disorder': {
     doid: 'DOID:0060041',
     pageName: 'Autism Spectrum Disorder',

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -77,6 +77,20 @@ export const data = {
       { title: 'World Health Organization (WHO) - Diabetes', url: 'https://www.who.int/health-topics/diabetes' },
     ],
   },
+  'long-qt-syndrome': {
+    doid: 'DOID:2843',
+    pageName: 'Long QT Syndrome',
+    group: 'Heart disease',
+    listLabel: 'long QT syndrome',
+    resources: [
+      { title: 'Hearts in Rhythm Organization (HiRO)', url: 'https://heartsinrhythm.ca/' },
+      {
+        title: 'International LQTS Registry (University of Rochester)',
+        url: 'https://www.urmc.rochester.edu/clinical-cardiovascular-research/lqts-registry',
+      },
+      { title: 'SADS Foundation (Sudden Arrhythmia Death Syndromes)', url: 'https://sads.org/' },
+    ],
+  },
   'alzheimers-disease': {
     doid: 'DOID:10652',
     pageName: "Alzheimer's Disease",

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -64,7 +64,7 @@ export const data = {
   'alzheimers-disease': {
     doid: 'DOID:10652',
     pageName: "Alzheimer's Disease",
-    group: 'Neurodegenerative disease',
+    group: 'Nervous system disease',
     listLabel: "Alzheimer's disease",
     resources: [
       {
@@ -86,7 +86,7 @@ export const data = {
   'parkinsons-disease': {
     doid: 'DOID:14330',
     pageName: "Parkinson's Disease",
-    group: 'Neurodegenerative disease',
+    group: 'Nervous system disease',
     listLabel: "Parkinson's disease",
     resources: [
       {

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -35,6 +35,22 @@ export const data = {
       { title: 'Portal Kids First DRC', url: 'https://portal.kidsfirstdrc.org/login?redirect_path=/data-exploration' },
     ],
   },
+  'autism-spectrum-disorder': {
+    doid: 'DOID:0060041',
+    pageName: 'Autism Spectrum Disorder',
+    group: 'Developmental disorder of mental health',
+    listLabel: 'autism spectrum disorder',
+    resources: [
+      { title: 'Autism BrainNet', url: 'https://autismbrainnet.org/' },
+      {
+        title: 'NIH Autism Data Science Initiative (ADSI)',
+        url: 'https://dpcpsi.nih.gov/autism-data-science-initiative/funded-research',
+      },
+      { title: 'NIMH Data Archive', url: 'https://nda.nih.gov/' },
+      { title: 'SFARI Gene', url: 'https://gene.sfari.org/' },
+      { title: 'SPARK (Simons Foundation Powering Autism Research)', url: 'https://sparkforautism.org/' },
+    ],
+  },
   'diabetes-mellitus': {
     doid: 'DOID:9351',
     pageName: 'Diabetes Mellitus',

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -17,11 +17,13 @@ import { DISEASE_ROOT_CURIE } from '../ontologyBrowser/ontologies.js';
 //   listLabel  optional. Label in the index, when it differs from pageName.
 //   resources  optional. Community Resources links.
 //   papersQuery optional. Overrides the Recent Papers query for portals whose
-//              name matches badly as free text. The endpoint requires every
-//              token in title/abstract, so a name built from common words
-//              ("long QT syndrome") pulls in unrelated papers; quoting the
-//              phrase anchors it. Used verbatim, skipping the normalization
-//              applied to a disease name. See RECENT_PAPERS_API.md.
+//              name matches badly as free text. The endpoint matches loosely and
+//              fills every MOD slot even with no real match, so a name built from
+//              common words pulls in unrelated papers: quote it to force a phrase
+//              match ("long QT syndrome"), or cut it to the distinctive token
+//              when that phrase is itself rare in the MOD corpora (autism). Used
+//              verbatim, skipping the normalization applied to a disease name.
+//              See RECENT_PAPERS_API.md.
 export const data = {
   human: {
     doid: DISEASE_ROOT_CURIE,
@@ -67,6 +69,7 @@ export const data = {
     pageName: 'Autism Spectrum Disorder',
     group: 'Disease of mental health',
     listLabel: 'autism spectrum disorder',
+    papersQuery: 'autism',
     resources: [
       { title: 'Autism BrainNet', url: 'https://autismbrainnet.org/' },
       {

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -99,6 +99,24 @@ export const data = {
       { title: 'OMIM', url: 'https://omim.org/entry/104300' },
     ],
   },
+  epilepsy: {
+    doid: 'DOID:1826',
+    pageName: 'Epilepsy',
+    group: 'Nervous system disease',
+    listLabel: 'epilepsy',
+    resources: [
+      { title: 'American Epilepsy Society', url: 'https://aesnet.org' },
+      {
+        title: 'CURE Epilepsy - Epilepsy Genetics Initiative (EGI)',
+        url: 'https://www.cureepilepsy.org/our-research/epilepsy-genetics-initiative/',
+      },
+      { title: 'Epi25 Collaborative', url: 'https://epi-25.org/' },
+      {
+        title: 'NINDS Focus on Epilepsy Research',
+        url: 'https://www.ninds.nih.gov/current-research/focus-disorders/focus-epilepsy-research',
+      },
+    ],
+  },
   'parkinsons-disease': {
     doid: 'DOID:14330',
     pageName: "Parkinson's Disease",

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -15,6 +15,12 @@ import { DISEASE_ROOT_CURIE } from '../ontologyBrowser/ontologies.js';
 //              Omit on the root entry.
 //   listLabel  optional. Label in the index, when it differs from pageName.
 //   resources  optional. Community Resources links.
+//   papersQuery optional. Overrides the Recent Papers query for portals whose
+//              name matches badly as free text. The endpoint requires every
+//              token in title/abstract, so a name built from common words
+//              ("long QT syndrome") pulls in unrelated papers; quoting the
+//              phrase anchors it. Used verbatim, skipping the normalization
+//              applied to a disease name. See RECENT_PAPERS_API.md.
 export const data = {
   human: {
     doid: DISEASE_ROOT_CURIE,
@@ -121,6 +127,7 @@ export const data = {
     pageName: 'Long QT Syndrome',
     group: 'Heart disease',
     listLabel: 'long QT syndrome',
+    papersQuery: '"long QT syndrome"',
     resources: [
       { title: 'Hearts in Rhythm Organization (HiRO)', url: 'https://heartsinrhythm.ca/' },
       {


### PR DESCRIPTION
Adds five new Disease Portal pages and fixes what the new pages exposed in the shared Recent Papers query. Jira: [KANBAN-1471](https://agr-jira.atlassian.net/browse/KANBAN-1471)

## New portals

| Portal | DOID | Index heading | Resources |
| --- | --- | --- | --- |
| Colorectal Cancer | DOID:9256 | Cancer | 6 |
| Autism Spectrum Disorder | DOID:0060041 | Disease of mental health | 5 |
| Ciliopathy | DOID:0060340 | Monogenic disease | 5 |
| Long QT Syndrome | DOID:2843 | Cardiovascular system disease | 3 |
| Epilepsy | DOID:1826 | Central nervous system disease | 4 |

Each is a data-only entry in `portalData.js` — no new components. Every page gets the standard portal sections (Summary, Recent Papers, Community Resources, Genes, Alleles, Models, Ontology View) from the existing container.

## Index headings now come from the DO slim

Per curator request, headings match the buckets curators already see in the gene-page disease ribbon (the `Term` entries of `/api/gene/*/disease-ribbon-summary`) rather than parent terms picked per portal:

- Alzheimer's, Parkinson's, epilepsy → **Central nervous system disease** (was *Neurodegenerative disease*, which cannot hold epilepsy)
- autism spectrum disorder → **Disease of mental health**
- long QT syndrome → **Cardiovascular system disease**
- ciliopathy → **Monogenic disease**
- colorectal cancer, diabetes mellitus → unchanged, already slim terms

Three portals fall in two slim buckets each; the curator picked cardiovascular over thoracic (long QT), monogenic over syndrome (ciliopathy), and cancer over gastrointestinal (colorectal).

## Recent Papers: per-portal query override

`/api/reference/latest-literature-by-disease-per-mod` matches the disease name loosely and fills every MOD slot even when nothing genuinely matches, so a name built from common words pulls in unrelated papers. New optional `papersQuery` on a portal entry is used verbatim in place of the normalized disease name. Two portals set it; the rest are unchanged.

- **Long QT Syndrome** — `"long QT syndrome"` (quoted). Unquoted returned 1 relevant paper in 8: *long* matched "Long Noncoding" and "long-term", *syndrome* matched any other syndrome. Quoting the phrase brings it to 5 in 8.
- **Autism Spectrum Disorder** — `autism`. Ranjana flagged this page as off-target; all three tokens matched on one common word each (a broad-*spectrum* antibacterial paper for WB, a Xenopus pigmentary-*disorders* paper for XB). `autism` alone returns 8 distinct on-topic rows including autism-specific papers for WB (WAC), FB (DNMT3L), ZFIN (CMIP) and SGD (DDX3X). Quoting the full phrase does not help here — the phrase is rare in the MOD corpora, the opposite of long QT.

## Docs

`RECENT_PAPERS_API.md` corrected against the live stage endpoint, measured today:

- The doc claimed the endpoint requires all query tokens to match. It does not — matching is loose, every corpus slot is filled regardless, and responses are not deterministic between identical calls. The trailing-"disease" strip is still right; its stated reason was not.
- RGD's species row said *Homo sapiens*; the code has used *Rattus norvegicus* since June 2026. Added the caveat: the icon reflects corpus membership, not the paper's study species, so an RGD row is sometimes a human clinical-genetics paper (2 of 8 portals measured).
- Recorded the two known per-corpus selection problems as **backend** follow-ups with evidence and an explicit do-not-fix-in-UI note: dropping AGR from the grouping, and filtering out reviews (curator request — a UI filter would delete rows rather than replace them, since `latest=1` returns only the newest paper per corpus).

## Testing

Reviewed on the Amplify preview by Ranjana: https://feature-kanban-1471-five-new-portal-pages.d1mrdtdifcvuyq.amplifyapp.com/

Verified per portal: page renders, DOID resolves, index heading and link label correct, Community Resources links resolve, Recent Papers rows on-topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KANBAN-1471]: https://agr-jira.atlassian.net/browse/KANBAN-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ