### PR TITLE
fix(crossReferenceList): sort a copy instead of mutating the prop (KANBAN-1325)

### DIFF
--- a/src/components/crossReferenceList.jsx
+++ b/src/components/crossReferenceList.jsx
@@ -22,13 +22,12 @@ const CrossReferenceList = ({ collapsible = true, crossReferences, sort = true }
 
   const size = collapsible ? undefined : crossReferences.length;
 
-  if (sort) {
-    crossReferences.sort(byWithLinkThenName);
-  }
+  // Copy before sorting — sort mutates in place and crossReferences is a prop.
+  const orderedReferences = sort ? [...crossReferences].sort(byWithLinkThenName) : crossReferences;
 
   return (
     <CollapsibleList collapsedSize={size}>
-      {crossReferences.map((ref) => (
+      {orderedReferences.map((ref) => (
         <DataSourceLink key={ref.displayName + ref.name + ref.url} reference={ref} />
       ))}
     </CollapsibleList>

--- a/src/components/crossReferenceList.test.jsx
+++ b/src/components/crossReferenceList.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CrossReferenceList from './crossReferenceList.jsx';
+
+const makeReferences = () => [
+  { name: 'Zebra', url: 'http://example.org/zebra' },
+  { name: 'apple' },
+  { name: 'Mango', url: 'http://example.org/mango' },
+];
+
+const renderedNames = () => screen.getAllByRole('listitem').map((item) => item.textContent);
+
+describe('CrossReferenceList', () => {
+  it('sorts linked references first, then alphabetically case-insensitively', () => {
+    render(<CrossReferenceList collapsible={false} crossReferences={makeReferences()} />);
+
+    expect(renderedNames()).toEqual(['Mango', 'Zebra', 'apple']);
+  });
+
+  it('does not mutate the crossReferences prop', () => {
+    const references = makeReferences();
+    const originalOrder = [...references];
+
+    render(<CrossReferenceList collapsible={false} crossReferences={references} />);
+
+    expect(references).toEqual(originalOrder);
+  });
+
+  it('preserves the given order when sort is disabled', () => {
+    render(<CrossReferenceList collapsible={false} crossReferences={makeReferences()} sort={false} />);
+
+    expect(renderedNames()).toEqual(['Zebra', 'apple', 'Mango']);
+  });
+});


### PR DESCRIPTION
## Summary

`crossReferenceList.jsx` called `crossReferences.sort()` directly on its prop. `Array.prototype.sort` mutates in place, so rendering reordered the caller's array — a React immutability violation. This is the same bug fixed for the curation variant (`CrossReferenceListCuration.jsx`) in 08461f05; this is the pre-existing non-curation copy.

Fix: sort a copy and map over it.

## Scope / impact

No live user-visible impact today, so this is hygiene rather than a user-facing fix:

- The disease page (`basicDiseaseInfo.jsx`, the only live caller) passes a freshly built array from `transformCrossReferenceLinkUrls`, so the mutated array is a throwaway.
- The other caller, `basicGeneInfo.jsx`, passes cached query data — but that file is imported nowhere and is dead code. The live gene-page cross references render through `GeneSummary` -> `CrossReferenceListCuration`, already fixed.

The value is that the next caller to pass cached data doesn't silently corrupt the query cache.

## Tests

New `src/components/crossReferenceList.test.jsx` covers the ordering contract, prop immutability, and the `sort={false}` passthrough. Companion e2e coverage of the disease-page ordering is proposed separately in `agr_release_testing`.

KANBAN-1325
