### PR TITLE
fix(ontologyBrowser): restore natural sort for numbered sibling terms (KANBAN-1483)

### DIFF
--- a/src/containers/ontologyBrowser/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/OntologyTree.jsx
@@ -117,7 +117,8 @@ const OntologyTree = ({
       {open && childTerms.length > 0 && (
         <div className={style.children}>
           {[...childTerms]
-            .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+            // numeric: true so "ataxia 2" sorts before "ataxia 10"
+            .sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { numeric: true }))
             .map((c) => (
               <OntologyTree
                 key={c.curie}


### PR DESCRIPTION
## Summary

Restores natural sort for numbered sibling terms in the ontology tree. `{ numeric: true }` was added to the `localeCompare` in 8709427a (Jun 25) and dropped when 513e3fb8 (Jul 28, "reliable deep-link scroll, no-jump tree clicks") rewrote the surrounding block — a silent revert, not a deliberate change.

Before: `1, 10, 11, 12, 13, 14, 15, 17, 18, 2, 20 ...`
After: `1, 2, 4, 5, 6, 7, 8, 10, 11, 12 ... 44, 45, 46`

`OntologyTree.jsx` is shared, so this covers both the standalone browser and the disease-portal Ontology View embed.

## Verification

Ran the local UI against the stage API and expanded DOID:1441 (autosomal dominant cerebellar ataxia, 33 numbered children), before and after the change. Non-numbered siblings stay alphabetical.

Found while writing the first Playwright coverage for the DO browser (agr_release_testing#26). That PR deliberately omits a sibling-ordering assertion rather than lock in the regressed order; once this ships, a natural-sort assertion is worth adding there.

KANBAN-1483
