### PR TITLE
feat(interactions): add Alliance Reference column to interactions tables (KANBAN-1485)

### DIFF
--- a/src/components/interaction/GeneGeneticInteractionDetailTable.jsx
+++ b/src/components/interaction/GeneGeneticInteractionDetailTable.jsx
@@ -191,6 +191,8 @@ const GeneGeneticInteractionDetailTable = ({ focusGeneId, focusGeneDisplayName }
           width: '180px',
         },
         formatter: (_, row) => <ReferenceList refs={row.geneGeneticInteraction?.evidence} />,
+        filterable: true,
+        filterName: 'referenceCitation',
       },
       {
         dataField: 'geneGeneticInteraction.evidence',

--- a/src/components/interaction/GeneGeneticInteractionDetailTable.jsx
+++ b/src/components/interaction/GeneGeneticInteractionDetailTable.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, GeneCellCuration, SpeciesCell } from '../dataTable';
+import { DataTable, GeneCellCuration, ReferenceList, SpeciesCell } from '../dataTable';
 import { getIdentifier } from '../dataTable/utils.jsx';
 import { buildUrlFromTemplate } from '../../lib/utils.js';
 import SpeciesName from '../SpeciesName.jsx';
@@ -183,8 +183,18 @@ const GeneGeneticInteractionDetailTable = ({ focusGeneId, focusGeneDisplayName }
         filterName: 'source',
       },
       {
-        dataField: 'geneGeneticInteraction.evidence',
+        // dummy field: the Reference ID column below owns the real evidence dataField
+        dataField: 'referenceCitation',
+        isDummyField: true,
         text: 'Reference',
+        headerStyle: {
+          width: '180px',
+        },
+        formatter: (_, row) => <ReferenceList refs={row.geneGeneticInteraction?.evidence} />,
+      },
+      {
+        dataField: 'geneGeneticInteraction.evidence',
+        text: 'Reference ID',
         headerStyle: {
           width: '150px',
         },

--- a/src/components/interaction/genePhysicalInteractionDetailTable.jsx
+++ b/src/components/interaction/genePhysicalInteractionDetailTable.jsx
@@ -120,6 +120,8 @@ const GenePhysicalInteractionDetailTable = ({ focusGeneDisplayName, focusGeneId 
       headerStyle: { width: '11em' },
       headerClasses: style.columnHeaderGroup3,
       classes: style.columnGroup3,
+      filterable: true,
+      filterName: 'referenceCitation',
     },
     {
       dataField: 'geneMolecularInteraction.evidence',

--- a/src/components/interaction/genePhysicalInteractionDetailTable.jsx
+++ b/src/components/interaction/genePhysicalInteractionDetailTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, GeneCellCuration, SpeciesCell } from '../dataTable';
+import { DataTable, GeneCellCuration, ReferenceList, SpeciesCell } from '../dataTable';
 import SpeciesName from '../SpeciesName.jsx';
 import { getIdentifier } from '../dataTable/utils.jsx';
 import { buildUrlFromTemplate } from '../../lib/utils.js';
@@ -112,8 +112,18 @@ const GenePhysicalInteractionDetailTable = ({ focusGeneDisplayName, focusGeneId 
       filterName: 'source',
     },
     {
-      dataField: 'geneMolecularInteraction.evidence',
+      // dummy field: the Reference ID column below owns the real evidence dataField
+      dataField: 'referenceCitation',
+      isDummyField: true,
       text: 'Reference',
+      formatter: (_, row) => <ReferenceList refs={row.geneMolecularInteraction?.evidence} />,
+      headerStyle: { width: '11em' },
+      headerClasses: style.columnHeaderGroup3,
+      classes: style.columnGroup3,
+    },
+    {
+      dataField: 'geneMolecularInteraction.evidence',
+      text: 'Reference ID',
       // eslint-disable-next-line react/prop-types
       formatter: (reference) => {
         if (!reference || !reference.length) return null;


### PR DESCRIPTION
Adds the Alliance Reference (short citation) column to the two gene-page interactions tables. Jira: [KANBAN-1485](https://agr-jira.atlassian.net/browse/KANBAN-1485)

## Summary

Both tables already had a column headed "Reference", but it rendered `evidence[0].referenceID` as an outbound PubMed link — functionally the "Reference ID" column of the other tables under the wrong label, which is likely why the gap was not obvious. So:

- Renamed the existing column to **Reference ID** (unchanged behavior, still `filterName: 'reference'`).
- Added a **Reference** column before it, rendering `evidence[]` through `ReferenceList` — the same treatment KANBAN-864 gave the Phase 1 tables. Links to `/reference/<curie>`.

No API work needed; the endpoints already return `curie` and `shortCitation` in `evidence[]`.

### Why the new column uses a dummy dataField

`react-bootstrap-table-next` keys header and filter cells by `dataField` (`header.js:84`, `filters.js:47`). Two columns both pointing at `evidence` would collide on that key and could misplace the filter element, which belongs only to Reference ID. The new column is therefore `isDummyField: true` with its own `dataField`, reading evidence off the row. The existing column is left completely untouched so its filter wiring still resolves.

### Citation filter — now enabled

The new column carries a free-text filter (`filter.referenceCitation`), the same
widget the Reference ID column has.

This shipped unfiltered at first, because the server side did not exist yet and these
endpoints ignore unknown filter params *silently* — a filter box that returned the full
result set would have looked functional. That is resolved:
[KANBAN-1487](https://agr-jira.atlassian.net/browse/KANBAN-1487) merged as
[agr_java_software#1662](https://github.com/alliance-genome/agr_java_software/pull/1662)
on Aug 18, and its merge-triggered reindex has landed, so `evidence.shortCitation` is
genuinely indexed on stage. Verified against the stage API before enabling the UI filter:
`filter.referenceCitation=Tanaka` on `w`'s genetic interactions returns 2 of 159, and a
nonsense string returns 0 — i.e. neither silently ignored nor zero-matching.

Note the `test` API deploy predates that merge and still ignores the param, so review the
filter on stage or on the branch preview, not on test.

Matching is case-insensitive substring and multi-token, so `Nat Commun`, `2024`, and
`giot l (2003)` all work.

## Verification

Ran the local UI against the **test** API on `/gene/FB:FBgn0003996` — stage's API was returning 502 on every endpoint when this was opened — both tables:

- Reference renders e.g. `Tanaka T (2024) Nat Commun 15(1):6993` → `/reference/AGRKB:101000001041200`; Reference ID still renders `PMID:39143098`.
- Column order is Reference then Reference ID.
- Applying the Reference ID filter still sends `filter.reference=PMID%3A39143098` and narrows to 2 rows.
- Filter, re-verified on `/gene/HGNC:11998` against the **stage** API after KANBAN-1487 landed: molecular 5,594 → **2** rows on `Desantis A (2015)`, genetic 385 → **105** on `Xie L`, `Clear` restores the full set.
- The two filters are independent — with both applied the request carries `filter.reference=PMID%3A23284306&filter.referenceCitation=Xie%20L`, so the dummy `dataField` avoids the header/filter key collision it was introduced to avoid.
- Console key-warning count is identical to clean `stage` (2, from `Body2`/`Cell2`, pre-existing and from another table) — the dummy field adds none.
- `tsc --noEmit` clean; Jest 44 suites / 195 tests pass; Prettier clean. The 2 ESLint errors in these files are pre-existing on `stage` (an `eslint-disable` for a rule this config does not define).

Rendering more than the first evidence entry in Reference ID is out of scope — [KANBAN-1486](https://agr-jira.atlassian.net/browse/KANBAN-1486). Note the new Reference column already renders the whole array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KANBAN-1485]: https://agr-jira.atlassian.net/browse/KANBAN-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1487]: https://agr-jira.atlassian.net/browse/KANBAN-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ