### PR TITLE
fix(interactions): render every reference in the Reference ID column (KANBAN-1486)

### DIFF
--- a/src/components/interaction/GeneGeneticInteractionDetailTable.jsx
+++ b/src/components/interaction/GeneGeneticInteractionDetailTable.jsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, GeneCellCuration, ReferenceList, SpeciesCell } from '../dataTable';
+import { DataTable, GeneCellCuration, ReferenceList, ReferencesCellCuration, SpeciesCell } from '../dataTable';
 import { getIdentifier } from '../dataTable/utils.jsx';
-import { buildUrlFromTemplate } from '../../lib/utils.js';
 import SpeciesName from '../SpeciesName.jsx';
 import ExternalLink from '../ExternalLink.jsx';
 import DataSourceLinkCuration from '../dataSourceLinkCuration.jsx';
+import evidenceReferenceIds from './evidenceReferenceIds.js';
 import MITerm from './MITerm.jsx';
 import useDataTableQuery from '../../hooks/useDataTableQuery';
 import AlleleCellCuration from '../dataTable/AlleleCellCuration.jsx';
@@ -200,17 +200,7 @@ const GeneGeneticInteractionDetailTable = ({ focusGeneId, focusGeneDisplayName }
         headerStyle: {
           width: '150px',
         },
-        // eslint-disable-next-line react/prop-types
-        formatter: (reference) => {
-          if (!reference || !reference.length) return null;
-          const refId = reference[0].referenceID;
-          const xref = reference[0].crossReferences?.find((x) => x.referencedCurie === refId);
-          return (
-            <ExternalLink href={xref ? buildUrlFromTemplate(xref) : null} key={refId} title={refId}>
-              {refId}
-            </ExternalLink>
-          );
-        },
+        formatter: (evidence) => <ReferencesCellCuration pubmedPublications={evidenceReferenceIds(evidence)} />,
         filterable: true,
         filterName: 'reference',
       },

--- a/src/components/interaction/evidenceReferenceIds.js
+++ b/src/components/interaction/evidenceReferenceIds.js
@@ -1,0 +1,17 @@
+// The interactions endpoints carry their publications in `evidence[]`, where each entry's
+// `referenceID` (a PMID or MOD reference) is also one of its own `crossReferences`. Pull those
+// cross references out so the whole array can go through ReferencesCellCuration, which is what
+// the other tables use for their Reference ID column.
+export default function evidenceReferenceIds(evidence) {
+  if (!evidence || !evidence.length) return [];
+
+  return evidence
+    .map((entry) => {
+      const referencedCurie = entry?.referenceID;
+      if (!referencedCurie) return null;
+      const crossReference = entry.crossReferences?.find((xref) => xref.referencedCurie === referencedCurie);
+      // without a matching cross reference there is no url template, so render the id unlinked
+      return crossReference || { referencedCurie };
+    })
+    .filter(Boolean);
+}

--- a/src/components/interaction/evidenceReferenceIds.test.jsx
+++ b/src/components/interaction/evidenceReferenceIds.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import evidenceReferenceIds from './evidenceReferenceIds.js';
+import ReferencesCellCuration from '../dataTable/referencesCellCuration.jsx';
+
+const pubmedPage = {
+  name: 'reference',
+  urlTemplate: 'https://pubmed.ncbi.nlm.nih.gov/[%s]',
+};
+
+const makeEvidence = (referenceID, resourceDescriptorPage = pubmedPage) => ({
+  type: 'Reference',
+  curie: `AGRKB:${referenceID}`,
+  referenceID,
+  shortCitation: `${referenceID} citation`,
+  crossReferences: [
+    { referencedCurie: `DOI:10.1000/${referenceID}`, displayName: 'a doi', resourceDescriptorPage: pubmedPage },
+    { referencedCurie: referenceID, displayName: referenceID, resourceDescriptorPage },
+  ],
+});
+
+// the Reference ID cell renders whatever the helper returns, the same way the other tables do
+const renderCell = (evidence) => render(<ReferencesCellCuration pubmedPublications={evidenceReferenceIds(evidence)} />);
+
+describe('evidenceReferenceIds', () => {
+  it('keeps every evidence entry, not just the first', () => {
+    const ids = evidenceReferenceIds([makeEvidence('PMID:1'), makeEvidence('PMID:2'), makeEvidence('PMID:3')]);
+
+    expect(ids.map((xref) => xref.referencedCurie)).toEqual(['PMID:1', 'PMID:2', 'PMID:3']);
+  });
+
+  it('picks the cross reference matching referenceID, ignoring the others', () => {
+    const [xref] = evidenceReferenceIds([makeEvidence('PMID:1')]);
+
+    expect(xref.referencedCurie).toBe('PMID:1');
+    expect(xref.resourceDescriptorPage).toBe(pubmedPage);
+  });
+
+  it('falls back to an unlinkable cross reference when none matches referenceID', () => {
+    const evidence = makeEvidence('PMID:1');
+    evidence.crossReferences = [{ referencedCurie: 'DOI:10.1000/other', resourceDescriptorPage: pubmedPage }];
+
+    expect(evidenceReferenceIds([evidence])).toEqual([{ referencedCurie: 'PMID:1' }]);
+  });
+
+  it('drops evidence entries with no referenceID and tolerates empty input', () => {
+    expect(evidenceReferenceIds([{ curie: 'AGRKB:1' }])).toEqual([]);
+    expect(evidenceReferenceIds([])).toEqual([]);
+    expect(evidenceReferenceIds(undefined)).toEqual([]);
+  });
+});
+
+describe('the Reference ID cell', () => {
+  it('links every reference of a multi-evidence interaction', () => {
+    renderCell([makeEvidence('PMID:1'), makeEvidence('PMID:2')]);
+
+    expect(screen.getByTitle('PMID:1')).toHaveAttribute('href', 'https://pubmed.ncbi.nlm.nih.gov/1');
+    expect(screen.getByTitle('PMID:2')).toHaveAttribute('href', 'https://pubmed.ncbi.nlm.nih.gov/2');
+  });
+
+  it('collapses past two references behind a Show All toggle', () => {
+    renderCell([makeEvidence('PMID:1'), makeEvidence('PMID:2'), makeEvidence('PMID:3')]);
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: /Show All 3/ })).toBeInTheDocument();
+  });
+
+  it('renders a single-evidence interaction as one link, unchanged', () => {
+    renderCell([makeEvidence('PMID:1')]);
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders an id with no url as plain text', () => {
+    renderCell([makeEvidence('FB:FBrf0068180', null)]);
+
+    expect(screen.getByTitle('FB:FBrf0068180')).not.toHaveAttribute('href');
+  });
+
+  it('renders nothing when there is no evidence', () => {
+    const { container } = renderCell([]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/interaction/genePhysicalInteractionDetailTable.jsx
+++ b/src/components/interaction/genePhysicalInteractionDetailTable.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, GeneCellCuration, ReferenceList, SpeciesCell } from '../dataTable';
+import { DataTable, GeneCellCuration, ReferenceList, ReferencesCellCuration, SpeciesCell } from '../dataTable';
 import SpeciesName from '../SpeciesName.jsx';
 import { getIdentifier } from '../dataTable/utils.jsx';
-import { buildUrlFromTemplate } from '../../lib/utils.js';
-import ExternalLink from '../ExternalLink.jsx';
 import DataSourceLinkCuration from '../dataSourceLinkCuration.jsx';
+import evidenceReferenceIds from './evidenceReferenceIds.js';
 import MITerm from './MITerm.jsx';
 import MITermURL from './MITermURL.jsx';
 import style from './genePhysicalInteractionDetailTable.module.scss';
@@ -126,17 +125,7 @@ const GenePhysicalInteractionDetailTable = ({ focusGeneDisplayName, focusGeneId 
     {
       dataField: 'geneMolecularInteraction.evidence',
       text: 'Reference ID',
-      // eslint-disable-next-line react/prop-types
-      formatter: (reference) => {
-        if (!reference || !reference.length) return null;
-        const refId = reference[0].referenceID;
-        const xref = reference[0].crossReferences?.find((x) => x.referencedCurie === refId);
-        return (
-          <ExternalLink href={xref ? buildUrlFromTemplate(xref) : null} key={refId} title={refId}>
-            {refId}
-          </ExternalLink>
-        );
-      },
+      formatter: (evidence) => <ReferencesCellCuration pubmedPublications={evidenceReferenceIds(evidence)} />,
       headerStyle: { width: '10em' },
       headerClasses: style.columnHeaderGroup3,
       classes: style.columnGroup3,


### PR DESCRIPTION
Routes both gene-page interactions tables' **Reference ID** column through `ReferencesCellCuration`, so an interaction supported by several publications shows all of them. Jira: [KANBAN-1486](https://agr-jira.atlassian.net/browse/KANBAN-1486)

## Summary

Both tables built that cell by hand from `evidence[0]` and discarded the rest of the array. The other seven tables with a Reference ID column (phenotypes, expression, disease annotations, DiseaseToGene / DiseaseToAllele / DiseaseToModel, AlleleToDisease) all render it with `ReferencesCellCuration`, which de-duplicates and wraps the list in a `CollapsibleList` ("Show All N", first two shown). Interactions was the only holdout, and the only one with a bespoke formatter.

A small helper, `evidenceReferenceIds`, adapts the shape: the interactions endpoints carry publications in `evidence[]` as `referenceID` plus a nested `crossReferences` list, whereas the other tables receive a ready-made array of cross references. It pulls out the cross reference whose `referencedCurie` matches `referenceID` — the same one the old code linked — and falls back to `{ referencedCurie }` when none matches, which renders the id unlinked exactly as before.

Removing the hand-rolled formatters also removes their stale `// eslint-disable-next-line react/prop-types` directives, so `src/components/interaction/` now lints clean (those were the 2 pre-existing errors noted in #1862).

## No visible change on today's data

The ticket asked for a targeted query before sizing this. I sampled **3,174 evidence entries** across 8 genes (human TP53, WB `daf-2`, fly `w`, mouse, yeast, zebrafish, rat) on both endpoints on stage: **every interaction row carries exactly one evidence entry**, so nothing on a page looks different today. This is alignment and future-proofing — worth knowing if you'd rather it wait.

## Verification

- New unit tests (9) cover the multi-evidence case that no live row provides: all references rendered and linked, `Show All 3` past two, single-evidence unchanged, unlinked fallback, and empty input.
- Browser check on `/gene/FB:FBgn0003996` against the stage API: both tables' Reference ID cells render the same single link as before, PMID hrefs intact (`PMID:26527002`, `PMID:21912621`, …), and the Reference column is untouched.
- `tsc --noEmit` clean; Jest 45 suites / 204 tests pass; Prettier clean; ESLint clean on the changed directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KANBAN-1486]: https://agr-jira.atlassian.net/browse/KANBAN-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ