### PR TITLE
fix(diseasePortal): hide the Diseases pill on all portal pages (KANBAN-1492)

### DIFF
--- a/src/containers/diseasePortal/DiseasePortalSection.jsx
+++ b/src/containers/diseasePortal/DiseasePortalSection.jsx
@@ -4,18 +4,31 @@ import EntityButton from './EntityButton.jsx';
 import { useEntityButtonCounts } from './useEntityButtonCounts.js';
 import { isRootPortal } from './portalData.js';
 
+// Hidden on every portal page pending a decision on what the count should mean
+// per portal (KANBAN-1492). Flip to true to restore the Alliance-wide pill.
+const SHOW_DISEASE_COUNT = false;
+
 const DiseasePortalSection = ({ disease }) => {
   const url = `/api/disease/${disease.doid}/`;
-  const diseaseCount = useEntityButtonCounts('/api/disease/annotated-count');
+  const isRoot = isRootPortal(disease);
+  const diseaseCount = useEntityButtonCounts(SHOW_DISEASE_COUNT ? '/api/disease/annotated-count' : null);
   const geneCount = useEntityButtonCounts(url + 'genes_counts');
   const modelCount = useEntityButtonCounts(url + 'models_counts');
   const alleleCount = useEntityButtonCounts(url + 'alleles_counts');
 
-  const isRoot = isRootPortal(disease);
   const pageTitle = isRoot
     ? 'Disease Portals'
     : // <a href={`/disease/${disease.doid}`}>{`${disease.pageName} Portal`}</a>
       `${disease.pageName} Portal`;
+  const diseasesEntityButton = SHOW_DISEASE_COUNT ? (
+    <EntityButton id="entity-diseases" to="/search?q=&category=disease_search_result" tooltip="View all diseases">
+      <div>{diseaseCount ? diseaseCount.toLocaleString() : ''}</div>
+      Diseases
+    </EntityButton>
+  ) : (
+    ''
+  );
+  // Whole-Alliance figure, shown on the root portal only.
   const speciesEntityButton = isRoot ? (
     <EntityButton id="entity-species" to="/about-us" tooltip="View all associated species">
       9<br />
@@ -42,10 +55,7 @@ const DiseasePortalSection = ({ disease }) => {
           <li><Link to='/help#how'>More...</Link></li>
         </ul> */}
         <div className="d-flex justify-content-around flex-wrap">
-          <EntityButton id="entity-diseases" to="/search?q=&category=disease_search_result" tooltip="View all diseases">
-            <div>{diseaseCount ? diseaseCount.toLocaleString() : ''}</div>
-            Diseases
-          </EntityButton>
+          {diseasesEntityButton}
           <EntityButton
             id="entity-models"
             to={`/disease/${disease.doid}#associated-models`}


### PR DESCRIPTION
Hides the Diseases headline number on every Disease Portal page. Jira: [KANBAN-1492](https://agr-jira.atlassian.net/browse/KANBAN-1492)

**Base branch is `feature/KANBAN-1493-dp-9-1-0`, not `stage`** — the integration branch for the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) release 9.1.0 portal edits, so all eight tickets share one Amplify preview for curator review. That branch opens a single PR to `stage` once the epic is signed off.

## Summary

The pill shows `/api/disease/annotated-count`, an Alliance-wide figure, but was added to the shared `DiseasePortalSection` without the `isRoot` guard the Species pill has (KANBAN-1095, #1855). So every per-disease portal displayed the global 7,024 beside its own scoped Models/Genes/Alleles counts. The tooltip ("View all diseases") and the link (`/search?...category=disease_search_result`) are global too, so the whole pill was out of place there, not just the number.

Per the Aug 19 D&P meeting it is hidden everywhere for now, root page included, pending a decision on what the count should mean per portal.

## Scope / implementation

- `SHOW_DISEASE_COUNT = false` at module scope rather than deleting the markup, so restoring the pill is a one-word change once the intended behavior is settled.
- Passing a `null` url also skips the request while hidden (`useEntityButtonCounts` is `enabled: !!url`).
- Not an API bug: `annotated-count` is correct and intentionally unscoped. The eventual per-portal number (focus disease plus its child terms) would need a scoped endpoint that does not exist — `/api/disease/{doid}/annotated-count` 404s, and a DO ID passed as a query param is silently ignored.

## Verification

Rendered against the dev server:

| Page | Pills |
| --- | --- |
| `/disease-portal` | 26,391 Models · 67,398 Genes · 11,422 Alleles · 9 Species |
| `/disease-portal/colorectal-cancer` | 86 Models · 4,167 Genes · 34 Alleles |
| `/disease-portal/epilepsy` | 558 Models · 5,390 Genes · 296 Alleles |

Remaining counts match `/api/disease/counts` for both DOIDs, and the three pills still space evenly. Prettier and ESLint clean.


[KANBAN-1492]: https://agr-jira.atlassian.net/browse/KANBAN-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ