### PR TITLE
feat(diseasePortal): remove the Browse Ontology side-nav item (KANBAN-1496)

### DIFF
--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -18,19 +18,12 @@ import style from './style.module.scss';
 
 const SUMMARY = 'Summary';
 const ONTOLOGY = 'Ontology View';
-const BROWSE_ONTOLOGY = 'Browse Ontology';
 const COMMUNITY_RESOURCES = 'Community Resources';
 const RECENT_PAPERS = 'Recent Alliance Papers';
 const MEMBERS = 'Members';
 
-// Browse Ontology is an outbound link rather than an anchor, so sections depend on the doid.
-const makeSections = (doid) => [
-  { name: SUMMARY },
-  { name: RECENT_PAPERS },
-  { name: COMMUNITY_RESOURCES },
-  { name: ONTOLOGY },
-  { name: BROWSE_ONTOLOGY, to: `/ontology/disease/${doid}` },
-];
+// Every entry is an in-page anchor, so this no longer varies per disease.
+const SECTIONS = [{ name: SUMMARY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }, { name: ONTOLOGY }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -76,7 +69,7 @@ const DiseasePortalPage = () => {
       <HeadMetaTags title={`${portalTitle} Portal`} />
       <DiseasePortalSection disease={diseaseData} />
       <DataPage>
-        <PageNav sections={makeSections(diseaseData.doid)}>
+        <PageNav sections={SECTIONS}>
           <PageNavEntity entityName={portalTitle}>
             <Link to={`/disease/${diseaseData.doid}`}>{diseaseData.doid}</Link>
           </PageNavEntity>


### PR DESCRIPTION
Removes the **Browse Ontology** item from the disease portal side navigation. Jira: [KANBAN-1496](https://agr-jira.atlassian.net/browse/KANBAN-1496)

**Base branch is `feature/KANBAN-1493-dp-9-1-0`, not `stage`** — the integration branch for the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) release 9.1.0 portal edits, so all the epic's changes share one curator preview.

## Summary

Requested at the Aug 19 D&P meeting, and confirmed with the curators before implementing — this reverses [KANBAN-1464](https://agr-jira.atlassian.net/browse/KANBAN-1464), which added the item deliberately, so it is an intended removal rather than a regression.

`Browse Ontology` was the only nav entry that was an outbound link (`/ontology/disease/{doid}`) rather than an in-page anchor — the reason `makeSections()` took the `doid` at all, and the reason `PageNav` filters `!s.to` out of its scrollspy list. With the entry gone the list no longer varies per disease, so `makeSections(doid)` collapses to a plain `SECTIONS` constant. `PageNav` only filters and maps over the prop, so sharing one module-level array across renders is safe.

## Sequencing

The replacement route to the ontology browser is the labeled heading link in KANBAN-1497 (`Browse Ontology for <disease>`), which is still in curator verification. Until that lands, portal pages have no link out to the browser — worth holding this merge until 1497 is in, or accepting the gap on the preview in the meantime.

## Verification

Rendered against the dev server on the colorectal-cancer and epilepsy portals:

- Side nav now reads Summary / Recent Alliance Papers / Community Resources / Ontology View.
- The string "Browse Ontology" appears nowhere on either page (0 occurrences).
- Remaining anchors still scroll to their sections; the four section headings are unchanged.

Prettier and ESLint clean.


[KANBAN-1496]: https://agr-jira.atlassian.net/browse/KANBAN-1496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1464]: https://agr-jira.atlassian.net/browse/KANBAN-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ