### PR TITLE
feat(diseasePortal): label the Ontology View heading, unlink tree terms (KANBAN-1497)

### DIFF
--- a/src/components/subsection.jsx
+++ b/src/components/subsection.jsx
@@ -10,7 +10,17 @@ import NoData from './noData.jsx';
 import ErrorBoundary from './errorBoundary.jsx';
 import HelpPopup from './helpPopup.jsx';
 
-const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isMeta, level, title }) => {
+const Subsection = ({
+  children,
+  hardcoded,
+  hasData,
+  help,
+  hideTitle = false,
+  isMeta,
+  level,
+  title,
+  titleAdornment,
+}) => {
   const id = title && makeId(title);
   const Target = () => <a className={style.target} id={id} />;
   const helpPopup = help && (
@@ -18,6 +28,7 @@ const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isM
       <HelpPopup id={`help-${title}`}>{help}</HelpPopup>
     </span>
   );
+  const adornment = titleAdornment && <span className="small ml-3">{titleAdornment}</span>;
 
   let renderTitle;
   const titleContent = (
@@ -25,6 +36,7 @@ const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isM
       {isMeta && <target />}
       {title}
       {helpPopup}
+      {adornment}
     </>
   );
   switch (level) {
@@ -57,6 +69,7 @@ Subsection.propTypes = {
   isMeta: PropTypes.bool,
   level: PropTypes.number,
   title: PropTypes.string,
+  titleAdornment: PropTypes.node,
 };
 
 Subsection.defaultProps = {

--- a/src/containers/diseasePortal/OntologyContextSection.jsx
+++ b/src/containers/diseasePortal/OntologyContextSection.jsx
@@ -10,12 +10,12 @@ import { TermsProvider } from '../ontologyBrowser/useDiseaseTerms.jsx';
 import style from './style.module.scss';
 
 // Embedded, scoped ontology view for a disease portal page (KANBAN-1391).
-// Two interaction modes by control:
-//  - Term labels — both the ancestor context and every row in the tree — link
-//    OUT to the full-page ontology browser. The embed has no detail panel, so
-//    selecting a term in place would be a dead end.
-//  - The chevron stays in-page: expand/collapse drill-down is local, no route
-//    change.
+// Everything in the tree stays in-page (KANBAN-1497): clicking a term row only
+// highlights it, the chevron expands and collapses, and the route out to the
+// full browser is the single "Browse Ontology for ..." link on the section
+// heading. The G/A/M count badges still link to their disease pages.
+// Omitting nodeHref is what keeps term labels plain spans; the standalone
+// browser omits it too, so this stays embed-local.
 const OntologyContextSection = ({ curie, name }) => {
   // Immediate parents come from the single-term doc (same shape the standalone
   // TermDetailPanel uses). The DO is a DAG, so there can be more than one.
@@ -72,7 +72,6 @@ const OntologyContextSection = ({ curie, name }) => {
             focusedCurie={selectedCurie}
             onSelect={setSelectedCurie}
             scrollOnFocus={false}
-            nodeHref={(c) => `/ontology/disease/${c}`}
           />
         </div>
       </TermsProvider>

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -91,7 +91,15 @@ const DiseasePortalPage = () => {
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />
           </Subsection>
-          <Subsection title={ONTOLOGY}>
+          <Subsection
+            title={ONTOLOGY}
+            titleAdornment={
+              // The section's only route out to the full browser, replacing the removed nav item.
+              <Link to={`/ontology/disease/${diseaseData.doid}`}>
+                Browse Ontology for {diseaseApiData?.doTerm?.name || portalTitle}
+              </Link>
+            }
+          >
             {/* key on doid forces a remount per disease: the reused fiber (see above)
                 would otherwise leave the embedded tree's scoped state stale. */}
             <OntologyContextSection


### PR DESCRIPTION
Adds the labeled **Browse Ontology for &lt;disease&gt;** link to the Ontology View heading and unlinks the term rows in the embedded tree. Jira: [KANBAN-1497](https://agr-jira.atlassian.net/browse/KANBAN-1497)

**Base branch is `feature/KANBAN-1493-dp-9-1-0`, not `stage`** — the integration branch for the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) release 9.1.0 portal edits.

## Summary

Requested at the Aug 19 D&P meeting and confirmed with the curators before implementing — the unlinking half reverses [KANBAN-1470](https://agr-jira.atlassian.net/browse/KANBAN-1470), so it is intended, not a regression. Pairs with #1865 (KANBAN-1496), which removes the side-nav item this link replaces; merge this one first so portal pages always have a route to the browser.

**Unlinking is just dropping `nodeHref`.** `OntologyTree` treats the prop as optional and the standalone browser already omits it, so the shared component is not touched and standalone behavior is unchanged — the embed-local constraint the ticket called out. Term labels fall back to plain spans that select in place.

**The heading link uses a new optional `titleAdornment` slot on `Subsection`**, mirroring how the existing `help` prop renders inside the title. Additive and `undefined` for all other callers, so no other page changes.

Per curator decision, the **G/A/M count badges keep their links** to disease pages, and chevron drill-down plus row highlighting are unaffected.

## Verification

Colorectal cancer portal, dev server:

- Heading reads `Ontology View  Browse Ontology for colorectal cancer`, linking to `/ontology/disease/DOID:9256`.
- Exactly 2 links to `/ontology/disease/*` remain: that heading link, and the parent-term context link (`large intestine cancer`).
- Tree term `colorectal carcinoma` renders as a plain `SPAN`, not inside an `<a>`.
- 12 G/A/M badge links to `/disease/*` still present.

Prettier clean. ESLint reports two pre-existing errors in `subsection.jsx` (`jsx-a11y` disable comments for rules the current config does not define) — identical on the unmodified file, so untouched here.

## Open question, not blocking

The **parent-term context link** above the tree is still a link, since the ticket scoped unlinking to "term labels in the embedded tree". If the intent was every disease term in the section, that one is a one-line follow-up.


[KANBAN-1497]: https://agr-jira.atlassian.net/browse/KANBAN-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1470]: https://agr-jira.atlassian.net/browse/KANBAN-1470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ