### PR TITLE
feat(diseasePortal): move Ontology View directly below Summary (KANBAN-1495)

### DIFF
--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -23,7 +23,7 @@ const RECENT_PAPERS = 'Recent Alliance Papers';
 const MEMBERS = 'Members';
 
 // Every entry is an in-page anchor, so this no longer varies per disease.
-const SECTIONS = [{ name: SUMMARY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }, { name: ONTOLOGY }];
+const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -78,12 +78,6 @@ const DiseasePortalPage = () => {
           <Subsection title={SUMMARY}>
             <SummarySection disease={diseaseApiData} />
           </Subsection>
-          <Subsection title={RECENT_PAPERS}>
-            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
-          </Subsection>
-          <Subsection title={COMMUNITY_RESOURCES}>
-            <ResourcesSection disease={diseaseData} />
-          </Subsection>
           <Subsection
             title={ONTOLOGY}
             titleAdornment={
@@ -100,6 +94,12 @@ const DiseasePortalPage = () => {
               curie={diseaseData.doid}
               name={diseaseApiData?.doTerm?.name || portalTitle}
             />
+          </Subsection>
+          <Subsection title={RECENT_PAPERS}>
+            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
+          </Subsection>
+          <Subsection title={COMMUNITY_RESOURCES}>
+            <ResourcesSection disease={diseaseData} />
           </Subsection>
           <div className={style.membersFooter}>
             <Subsection hideTitle title={MEMBERS}>


### PR DESCRIPTION
Moves the **Ontology View** section directly below Summary on disease portal pages. Jira: [KANBAN-1495](https://agr-jira.atlassian.net/browse/KANBAN-1495)

**Base branch is `feature/KANBAN-1493-dp-9-1-0`, not `stage`** — the integration branch for the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) release 9.1.0 portal edits.

## Summary

Requested at the Aug 19 D&P meeting. Section order is declared in two places in `src/containers/diseasePortal/index.jsx` — the `SECTIONS` list that drives the side nav, and the `Subsection` order inside `PageData` — so both were reordered together to keep the nav and the page in step.

Order is now Summary, Ontology View, Recent Alliance Papers, Community Resources. KANBAN-1494 then moves Recent Papers to the bottom and renames it, giving the final Summary, Ontology View, Community Resources, Recent Literature.

## Verification

Colorectal cancer and epilepsy portals, dev server: page headings render in the order Summary, Ontology View, Recent Alliance Papers, Community Resources. The embedded tree still loads, expands, and keeps its heading link after the move. Prettier and ESLint clean.


[KANBAN-1495]: https://agr-jira.atlassian.net/browse/KANBAN-1495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ