### PR TITLE
feat(diseasePortal): move Recent Papers to the bottom, rename Recent Literature (KANBAN-1494)

### DIFF
--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -19,11 +19,11 @@ import style from './style.module.scss';
 const SUMMARY = 'Summary';
 const ONTOLOGY = 'Ontology View';
 const COMMUNITY_RESOURCES = 'Community Resources';
-const RECENT_PAPERS = 'Recent Alliance Papers';
+const RECENT_LITERATURE = 'Recent Literature';
 const MEMBERS = 'Members';
 
 // Every entry is an in-page anchor, so this no longer varies per disease.
-const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
+const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: COMMUNITY_RESOURCES }, { name: RECENT_LITERATURE }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -95,11 +95,11 @@ const DiseasePortalPage = () => {
               name={diseaseApiData?.doTerm?.name || portalTitle}
             />
           </Subsection>
-          <Subsection title={RECENT_PAPERS}>
-            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
-          </Subsection>
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />
+          </Subsection>
+          <Subsection title={RECENT_LITERATURE}>
+            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
           </Subsection>
           <div className={style.membersFooter}>
             <Subsection hideTitle title={MEMBERS}>


### PR DESCRIPTION
Moves the Recent Papers section to the bottom of disease portal pages and renames it **Recent Literature**. Jira: [KANBAN-1494](https://agr-jira.atlassian.net/browse/KANBAN-1494)

**Base branch is `feature/KANBAN-1493-dp-9-1-0`, not `stage`** — the integration branch for the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) release 9.1.0 portal edits.

## Summary

Requested at the Aug 19 D&P meeting. Moved in both places order is declared (the `SECTIONS` list driving the side nav, and the `Subsection` order in `PageData`), and the label changed in the one constant that feeds the heading and the nav item. Together with #1867 (KANBAN-1495) the final order is **Summary, Ontology View, Community Resources, Recent Literature**.

Scope kept to the title and position: `PapersSection`, the query, and `RECENT_PAPERS_API.md` are untouched, since the underlying request is unchanged. The eventual "Recent Annotated Papers" rename is a content change and stays out of this ticket.

This no longer waits on [KANBAN-1473](https://agr-jira.atlassian.net/browse/KANBAN-1473) (the hide-or-fix decision on search terms), which has been deferred — if that lands on hiding the section, hiding it is a one-line change on top of this.

## Worth knowing

The in-page anchor derives from the label via `makeId(title)`, so it changes from `#recent-alliance-papers` to `#recent-literature`. Nothing in the repo links to the old anchor (grepped), but any external deep link to it would break.

## Verification

Colorectal cancer and epilepsy portals, dev server: sections render as Summary, Ontology View, Community Resources, Recent Literature; the heading and side-nav label both read Recent Literature; the papers themselves still load. Prettier and ESLint clean.


[KANBAN-1494]: https://agr-jira.atlassian.net/browse/KANBAN-1494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1473]: https://agr-jira.atlassian.net/browse/KANBAN-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ