### PR TITLE
feat(diseasePortal): open the headline number links in a new tab (KANBAN-1499)

### DIFF
--- a/src/containers/diseasePortal/EntityButton.jsx
+++ b/src/containers/diseasePortal/EntityButton.jsx
@@ -7,7 +7,8 @@ import style from './style.module.scss';
 const EntityButton = ({ children, id, to, tooltip }) => {
   return (
     <b>
-      <Link className={style.entityButton} id={id} to={to}>
+      {/* New tab so the portal page stays put behind the pill (KANBAN-1499). */}
+      <Link className={style.entityButton} id={id} to={to} target="_blank" rel="noopener">
         {children}
         {tooltip && (
           <UncontrolledTooltip placement="bottom" target={id}>


### PR DESCRIPTION
Makes the portal headline numbers open in a new tab, so following a count no longer loses the portal page. Jira: [KANBAN-1499](https://agr-jira.atlassian.net/browse/KANBAN-1499). Base is the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) integration branch, not `stage`.

`target`/`rel` go on `EntityButton`: every pill is built there, and `DiseasePortalSection` is its only consumer — `PortalListSection` imports just the counts hook, so the portal index list is unaffected.

`rel="noopener"` rather than `noopener noreferrer` — same-origin links, so the `window.opener` guard is the useful half, while stripping the referrer would lose internal analytics attribution.

Verified by clicking, not just the attribute: Genes opened `/disease/DOID:9256#associated-genes` in a second tab with the portal still loaded behind it. Species pill on the root page covered too. Prettier and ESLint clean.


[KANBAN-1499]: https://agr-jira.atlassian.net/browse/KANBAN-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ