### PR TITLE
feat(diseasePage): link the Summary to the matching Disease Portal (KANBAN-1498)

### DIFF
--- a/src/containers/diseasePage/basicDiseaseInfo.jsx
+++ b/src/containers/diseasePage/basicDiseaseInfo.jsx
@@ -13,6 +13,7 @@ import { CollapsibleList } from '../../components/collapsibleList';
 import { smartAlphaSort } from '../../lib/utils';
 import SynonymList from '../../components/synonymList.jsx';
 import { formatLink } from './utils';
+import { findPortalForDisease } from '../diseasePortal/portalData.js';
 
 const TermList = ({ terms }) =>
   terms && (
@@ -89,6 +90,27 @@ const transformSynonyms = (synonyms) => {
   return synonyms.map((item) => item.name);
 };
 
+// Omitted entirely when neither the term nor any ancestor has a portal, rather
+// than falling back to the portal index (KANBAN-1498).
+const PortalRow = ({ disease }) => {
+  const portal = findPortalForDisease(disease.doTerm?.curie, disease.parentClosureIDs);
+  if (!portal) {
+    return null;
+  }
+  return (
+    <>
+      <AttributeLabel>Disease Portal</AttributeLabel>
+      <AttributeValue>
+        <Link to={`/disease-portal/${portal.slug}`}>{portal.pageName} Portal</Link>
+      </AttributeValue>
+    </>
+  );
+};
+
+PortalRow.propTypes = {
+  disease: PropTypes.object,
+};
+
 const BasicDiseaseInfo = ({ disease }) => (
   <AttributeList>
     <AttributeLabel>Definition</AttributeLabel>
@@ -122,6 +144,8 @@ const BasicDiseaseInfo = ({ disease }) => (
     <AttributeValue>
       <SourceList sources={disease.sourceReferenceLinkUrls} />
     </AttributeValue>
+
+    <PortalRow disease={disease} />
   </AttributeList>
 );
 

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -204,6 +204,29 @@ export const data = {
 // The root portal (the index page); every other entry is a disease portal.
 export const isRootPortal = (portal) => portal?.doid === DISEASE_ROOT_CURIE;
 
+// The portal a disease page should link to (KANBAN-1498): the portal on the term
+// itself, otherwise the portal whose term is one of its ancestors. Costs nothing
+// beyond a set intersection — `parentClosureIDs` is the full DAG closure and is
+// already on the payload the disease page fetches, so no extra request and no
+// walking of parent links. Note the closure is why /{id}/ancestors is not used:
+// that returns a single path, which misses portals on other branches.
+// The root portal is excluded deliberately: DOID:4 is in every closure, so
+// including it would give every disease in the DO a link to the portal index.
+export const findPortalForDisease = (curie, parentClosureIDs) => {
+  const portals = Object.entries(data).filter(([, portal]) => !isRootPortal(portal));
+
+  const own = portals.find(([, portal]) => portal.doid === curie);
+  if (own) {
+    return { slug: own[0], pageName: own[1].pageName };
+  }
+
+  const closure = new Set(parentClosureIDs || []);
+  // No portal term is a descendant of another (verified against the DO), so a
+  // second match would mean separate DAG branches; `data` order breaks the tie.
+  const ancestor = portals.find(([, portal]) => closure.has(portal.doid));
+  return ancestor ? { slug: ancestor[0], pageName: ancestor[1].pageName } : null;
+};
+
 // Portals for the index, grouped by parent disease. Group order and the order
 // within each group both follow `data`.
 export const portalsByGroup = () => {


### PR DESCRIPTION
Adds a **Disease Portal** row at the bottom of the disease page Summary, linking to the portal for the term itself or its nearest portal ancestor. Jira: [KANBAN-1498](https://agr-jira.atlassian.net/browse/KANBAN-1498). Base is the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) integration branch, not `stage`.

**Matching is free.** `parentClosureIDs` is the full DAG closure and already rides along on the payload the disease page fetches, so `findPortalForDisease` is a set intersection against the eight portal DOIDs — no extra request, no walking parent links. `/{id}/ancestors` is deliberately unused: it returns a single path, so it misses portals on other branches (colorectal adenocarcinoma never reaches DOID:9256 that way).

The root portal is excluded from matching — DOID:4 is in every closure, so including it would give every disease in the DO a link to the portal index. Per the D&P consensus the row is omitted entirely when nothing matches, rather than falling back to that index.

## Verification

Dev server, four cases:

| Disease page | Row |
| --- | --- |
| DOID:9256 colorectal cancer (own portal) | Colorectal Cancer Portal |
| DOID:0050861 colorectal adenocarcinoma (match via the other DAG branch) | Colorectal Cancer Portal |
| DOID:0080199 colorectal carcinoma | Colorectal Cancer Portal |
| DOID:2841 asthma (nothing above it) | no row at all |

Row renders last in the Summary: Definition, Synonyms, Cross References, Parent Terms, Child Terms, Sources of Associations, Disease Portal. Prettier clean; ESLint reports one pre-existing error in `basicDiseaseInfo.jsx` (unused `Component` import, identical on the unmodified file) which I left alone.


[KANBAN-1498]: https://agr-jira.atlassian.net/browse/KANBAN-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ