### PR TITLE
style(diseasePortal): downplay the Browse ontology link on the section heading (KANBAN-1497)

### DIFF
--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -82,8 +82,8 @@ const DiseasePortalPage = () => {
             title={ONTOLOGY}
             titleAdornment={
               // The section's only route out to the full browser, replacing the removed nav item.
-              <Link to={`/ontology/disease/${diseaseData.doid}`}>
-                Browse Ontology for {diseaseApiData?.doTerm?.name || portalTitle}
+              <Link className={style.ontologyBrowseLink} to={`/ontology/disease/${diseaseData.doid}`}>
+                Browse ontology for {diseaseApiData?.doTerm?.name || portalTitle}
               </Link>
             }
           >

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -186,3 +186,12 @@ $max-width: 800px;
     border-bottom: 0;
   }
 }
+
+// Secondary action on the Ontology View heading (KANBAN-1497). Sizes are
+// absolute on purpose: Bootstrap's .small is relative, so inside an h3 it still
+// rendered at heading scale and read as a second title. 0.85rem and weight 400
+// match the section's other meta text (.ontologyLegend, .ontologyParentsLabel).
+.ontologyBrowseLink {
+  font-size: 0.85rem;
+  font-weight: 400;
+}


### PR DESCRIPTION
Downplays the **Browse ontology** link on the Ontology View heading, per Ranjana's feedback on the shared preview that it was too prominent. Jira: [KANBAN-1497](https://agr-jira.atlassian.net/browse/KANBAN-1497). Base is the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) integration branch, not `stage`.

The cause was inheritance, not colour: the link sat inside the `h3` wrapped in Bootstrap's `.small`, which is *relative*, so at heading scale it still rendered ~1.5rem in the heading's bold weight and read as a second title. Fixed with an absolute `0.85rem` and weight 400 in a `style.module.scss` class, matching the section's existing meta text (`.ontologyLegend`, `.ontologyParentsLabel`).

Deliberately still link-blue. With the side-nav item removed in #1865 this is the only route from a portal page to the ontology browser, and muted grey static text is easy to miss entirely. If it is still too loud, the next levers in order are muting to `$gray-700` with link colour on hover, then right-aligning it on the heading row — not further shrinking.

Label switched to sentence case so it reads as a link rather than a heading.

Verified on the colorectal-cancer portal: heading clearly dominates, link still resolves to `/ontology/disease/DOID:9256`. Prettier and ESLint clean.


[KANBAN-1497]: https://agr-jira.atlassian.net/browse/KANBAN-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ