### PR TITLE
feat(diseasePortal): sort the index group headings alphabetically (KANBAN-1488)

### DIFF
--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -227,8 +227,8 @@ export const findPortalForDisease = (curie, parentClosureIDs) => {
   return ancestor ? { slug: ancestor[0], pageName: ancestor[1].pageName } : null;
 };
 
-// Portals for the index, grouped by parent disease. Group order and the order
-// within each group both follow `data`.
+// Portals for the index, grouped by parent disease. Group headings are sorted
+// alphabetically; the order within each group follows `data`.
 export const portalsByGroup = () => {
   const groups = [];
   Object.entries(data).forEach(([slug, portal]) => {
@@ -243,5 +243,8 @@ export const portalsByGroup = () => {
     }
     group.portals.push({ slug, label: portal.listLabel || portal.pageName });
   });
-  return groups;
+  // Headings are sorted here rather than by reordering `data` (KANBAN-1488), so
+  // adding a portal cannot silently misplace one. `groups` is built fresh above,
+  // so sorting it in place does not touch the exported `data`.
+  return groups.sort((a, b) => a.name.localeCompare(b.name));
 };


### PR DESCRIPTION
Sorts the disease category headings alphabetically on the portal index. Jira: [KANBAN-1488](https://agr-jira.atlassian.net/browse/KANBAN-1488). Base is the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) integration branch, not `stage` — folded into the release 9.1.0 portal edits so it reaches the same curator preview.

Sorted in `portalsByGroup()` rather than by reordering `data`, so adding a portal can't silently misplace a heading again. `groups` is built fresh inside the function, so sorting in place doesn't touch the exported `data` — worth stating given KANBAN-1325.

Verified on the index: headings now render Cancer, Cardiovascular system disease, Central nervous system disease, Disease of mental health, Disease of metabolism, Monogenic disease — matching the table in the ticket. Portals stay under the right headings, and order within each group still follows `data` (already alphabetical); making that self-maintaining too wasn't part of the request. Prettier and ESLint clean.


[KANBAN-1488]: https://agr-jira.atlassian.net/browse/KANBAN-1488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ