### PR TITLE
feat(diseasePortal): full name first, acronym in parentheses for resources (KANBAN-1489)

### DIFF
--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -40,7 +40,7 @@ export const data = {
       },
       { title: 'Matchmaker Exchange', url: 'https://www.matchmakerexchange.org/' },
       { title: 'ModelMatcher', url: 'https://www.modelmatcher.net/' },
-      { title: 'Online Mendelian Inheritance of Man (OMIM)', url: 'https://www.omim.org/' },
+      { title: 'Online Mendelian Inheritance in Man (OMIM)', url: 'https://www.omim.org/' },
       { title: 'Portal Kids First DRC', url: 'https://portal.kidsfirstdrc.org/login?redirect_path=/data-exploration' },
     ],
   },
@@ -57,7 +57,7 @@ export const data = {
         url: 'https://fightcolorectalcancer.org/our-programs/research-innovation/',
       },
       {
-        title: 'GECCO (Genetics and Epidemiology of Colorectal Cancer Consortium)',
+        title: 'The Genetics and Epidemiology of Colorectal Cancer Consortium (GECCO)',
         url: 'https://research.fredhutch.org/peters/en/genetics-and-epidemiology-of-colorectal-cancer-consortium.html',
       },
       { title: 'NCI Advances in Colorectal Cancer Research', url: 'https://www.cancer.gov/types/colorectal/research' },
@@ -77,8 +77,8 @@ export const data = {
         url: 'https://dpcpsi.nih.gov/autism-data-science-initiative/funded-research',
       },
       { title: 'NIMH Data Archive', url: 'https://nda.nih.gov/' },
-      { title: 'SFARI Gene', url: 'https://gene.sfari.org/' },
-      { title: 'SPARK (Simons Foundation Powering Autism Research)', url: 'https://sparkforautism.org/' },
+      { title: 'Simons Foundation Autism Research Initiative Gene (SFARI Gene)', url: 'https://gene.sfari.org/' },
+      { title: 'Simons Foundation Powering Autism Research (SPARK)', url: 'https://sparkforautism.org/' },
     ],
   },
   'diabetes-mellitus': {
@@ -118,12 +118,12 @@ export const data = {
         title: 'NCI/NEI ciliopathy gene-therapy research news (NIH intramural)',
         url: 'https://www.nih.gov/news-events/news-releases/nih-researchers-develop-gene-therapy-rare-ciliopathy',
       },
-      { title: 'PCD Research', url: 'https://pcdresearch.org/' },
+      { title: 'Primary Ciliary Dyskinesia Research (PCD Research)', url: 'https://pcdresearch.org/' },
       {
         title: 'Rare Diseases Clinical Research Network (RDCRN) - NIH/NCATS',
         url: 'https://www.rarediseasesnetwork.org/',
       },
-      { title: 'TheRaCil (Therapies for Renal Ciliopathies)', url: 'https://theracil.eu/' },
+      { title: 'Therapies for Renal Ciliopathies (TheRaCil)', url: 'https://theracil.eu/' },
     ],
   },
   'long-qt-syndrome': {
@@ -133,12 +133,12 @@ export const data = {
     listLabel: 'long QT syndrome',
     papersQuery: '"long QT syndrome"',
     resources: [
+      { title: 'The Foundation for Inherited Arrhythmias (FIA)', url: 'https://www.fiacardiac.org/' },
       { title: 'Hearts in Rhythm Organization (HiRO)', url: 'https://heartsinrhythm.ca/' },
       {
         title: 'International LQTS Registry (University of Rochester)',
         url: 'https://www.urmc.rochester.edu/clinical-cardiovascular-research/lqts-registry',
       },
-      { title: 'SADS Foundation (Sudden Arrhythmia Death Syndromes)', url: 'https://sads.org/' },
     ],
   },
   'alzheimers-disease': {
@@ -159,8 +159,11 @@ export const data = {
       },
       { title: "Alzheimer's Foundation of America", url: 'https://alzfdn.org/' },
       { title: 'National Institute on Aging', url: 'https://www.nia.nih.gov/' },
-      { title: 'NIAGADS', url: 'https://www.niagads.org/' },
-      { title: 'OMIM', url: 'https://omim.org/entry/104300' },
+      {
+        title: "National Institute on Aging Genetics of Alzheimer's Disease Data Storage Site (NIAGADS)",
+        url: 'https://www.niagads.org/',
+      },
+      { title: 'Online Mendelian Inheritance in Man (OMIM)', url: 'https://omim.org/entry/104300' },
     ],
   },
   epilepsy: {


### PR DESCRIPTION
Applies **full name first, acronym in parentheses** to the Community Resources titles. Jira: [KANBAN-1489](https://agr-jira.atlassian.net/browse/KANBAN-1489). Base is the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) integration branch, not `stage` — folded into the release 9.1.0 portal edits so it reaches the same curator preview.

## Changed (7 titles + 1 URL)

| Portal | Now |
| --- | --- |
| Colorectal Cancer | The Genetics and Epidemiology of Colorectal Cancer Consortium (GECCO) |
| Autism | Simons Foundation Powering Autism Research (SPARK) |
| Autism | Simons Foundation Autism Research Initiative Gene (SFARI Gene) |
| Ciliopathy | Therapies for Renal Ciliopathies (TheRaCil) |
| Ciliopathy | Primary Ciliary Dyskinesia Research (PCD Research) |
| Alzheimer's | National Institute on Aging Genetics of Alzheimer's Disease Data Storage Site (NIAGADS) |
| Alzheimer's | Online Mendelian Inheritance in Man (OMIM) |
| Long QT | **The Foundation for Inherited Arrhythmias (FIA)**, URL → `https://www.fiacardiac.org/` |

The FIA change is a factual rename rather than formatting; `sads.org` already redirects to that URL, confirmed in the KANBAN-1490 link audit. Also corrected "Inheritance **of** Man" → "**in** Man" on the Human Disease portal so both OMIM entries carry the official name.

## Deliberately not changed — both raised with Ranjana

* **Parkinson's** "Parkinson's Precision Medicine Initiative". She asked for the same treatment here, but the site at ppmi-info.org is the *Parkinson's Progression Markers Initiative (PPMI)* — a different name, not an expansion, so it needs her decision rather than a guess.
* **Agency-prefix titles** — `NCI Advances in Colorectal Cancer Research`, `NCI Genomic Data Commons (GDC)`, `NIMH Data Archive`, `NINDS Focus on Epilepsy Research`, `NIH Autism Data Science Initiative (ADSI)`. The rule as stated is general, but every entry she named is one where the acronym *is* the resource's name; in these the acronym is an institutional prefix qualifying a resource name, and expanding it makes long titles longer and harder to scan. Flagged as a follow-up question.

`SFARI Gene` and `PCD Research` were not named by her; they match the same acronym-as-name pattern and came out of the 51-title audit, so they are included. All expansions are proposed wording and worth her confirming at UAT.

## Ordering

`ResourcesSection` renders declaration order — the lists are hand-alphabetized, so renames can break placement. The FIA entry moves to the top of the long QT list; leading articles are ignored for placement, which also keeps the GECCO entry where it already sat. Verified all six affected portals render alphabetically after the change. Prettier and ESLint clean.


[KANBAN-1489]: https://agr-jira.atlassian.net/browse/KANBAN-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ