### PR TITLE
feat(diseasePortal): hide the Recent Literature section for 9.1.0 (KANBAN-1473)

### DIFF
--- a/src/containers/diseasePortal/RECENT_PAPERS_API.md
+++ b/src/containers/diseasePortal/RECENT_PAPERS_API.md
@@ -1,6 +1,9 @@
 # Disease Portal — Recent Papers API
 
-Status: **implemented** (endpoint live on stage; UI wired in `PapersSection.jsx`)
+Status: **hidden in the UI for release 9.1.0** (KANBAN-1473). The endpoint is live
+on stage and the UI is still wired in `PapersSection.jsx`, but the section is not
+rendered — the group decided the list must be built from DO-annotated papers
+instead of free-text matches, which is API work not yet done. Details below.
 Branch: `feature/DPrecentpapersAPI`
 Consumer: `src/containers/diseasePortal/PapersSection.jsx`
 
@@ -21,7 +24,26 @@ disease.
 > `RECENT_PAPERS_BACKEND_SCOPE.md` (the ABC-proxy build plan) is obsolete and has
 > been removed.
 
-> **Why free-text matching, not DOID (intentional — do not "fix" back to DOID):**
+> **SUPERSEDED Aug 20 2026 — the group decided the opposite. Read this before
+> touching the query.** The consensus is that the papers listed must be ones
+> **annotated with DO terms for the page's disease**, not free-text matches. That
+> reverses the reasoning kept below, and it is a large change rather than a tweak:
+> free-text search of title + abstract is replaced by a query over curated
+> disease annotations, so it is API work, not a UI query change. See KANBAN-1473.
+>
+> Consequences the group accepted in making that call: the list becomes precise
+> but no longer surfaces papers ahead of curation, so it will be older on average
+> and thinner for diseases with a curation backlog — the exact trade-off the
+> original design refused. Expect it to look much more like the old hand-curated
+> `publications` arrays than the current list does. A rename to "Recent Annotated
+> Papers" was discussed alongside it, which is the honest label for this content.
+>
+> **For 9.1.0 the section is hidden entirely** rather than shipped with free-text
+> results (KANBAN-1473); see `SHOW_RECENT_LITERATURE` in
+> `src/containers/diseasePortal/index.jsx`.
+
+> **Original rationale, kept for the reasoning it captures — no longer the
+> direction (was: "do not fix back to DOID"):**
 > The whole purpose of this section is to surface the _most recent_ literature.
 > DOID-to-paper association is **curated**, which takes time — and the lag
 > differs per MOD corpus. Matching on DOID would therefore systematically miss

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -22,8 +22,20 @@ const COMMUNITY_RESOURCES = 'Community Resources';
 const RECENT_LITERATURE = 'Recent Literature';
 const MEMBERS = 'Members';
 
+// Hidden for release 9.1.0 (KANBAN-1473). The list is free-text matched against
+// title and abstract, and the group decided it must instead be papers annotated
+// with DO terms for the page's disease — API work that is not done, so the
+// section ships hidden rather than misleading. Flip to true once that lands; see
+// RECENT_PAPERS_API.md for the agreed target behavior.
+const SHOW_RECENT_LITERATURE = false;
+
 // Every entry is an in-page anchor, so this no longer varies per disease.
-const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: COMMUNITY_RESOURCES }, { name: RECENT_LITERATURE }];
+const SECTIONS = [
+  { name: SUMMARY },
+  { name: ONTOLOGY },
+  { name: COMMUNITY_RESOURCES },
+  ...(SHOW_RECENT_LITERATURE ? [{ name: RECENT_LITERATURE }] : []),
+];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -98,9 +110,11 @@ const DiseasePortalPage = () => {
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />
           </Subsection>
-          <Subsection title={RECENT_LITERATURE}>
-            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
-          </Subsection>
+          {SHOW_RECENT_LITERATURE && (
+            <Subsection title={RECENT_LITERATURE}>
+              <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
+            </Subsection>
+          )}
           <div className={style.membersFooter}>
             <Subsection hideTitle title={MEMBERS}>
               <MembersSection />


### PR DESCRIPTION
Hides the Recent Literature section on disease portal pages for release 9.1.0. Jira: [KANBAN-1473](https://agr-jira.atlassian.net/browse/KANBAN-1473). Base is the [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493) integration branch, not `stage`.

The hide-or-fix question resolved to **hide**: the current list is free-text matched against title and abstract, which returns unrelated papers for diseases whose names are common words (measured: long QT syndrome 1/8 on topic). The group decided the section must instead list papers **annotated with DO terms for the page's disease** — API work that is not done, so shipping the section as-is would mislead.

Behind `SHOW_RECENT_LITERATURE` rather than deleted, so the section, its side-nav entry, and the query all return with one word. Verified: "Recent Literature" appears nowhere on the page, the nav entry is gone, and `latest-literature-by-disease-per-mod` is not called at all while hidden.

`RECENT_PAPERS_API.md` records the agreed target behavior, and marks the old **"Why free-text matching, not DOID — do not 'fix' back to DOID"** block as superseded. That block argued the opposite case, so left alone it would read as a standing instruction to resist the new direction. Its reasoning is kept rather than deleted, because the trade-off it describes — freshness ahead of curation, at the cost of precision — is exactly what the group knowingly gave up, and the next person should see that it was weighed rather than overlooked.

Side effect worth noting: this makes #1868 (KANBAN-1494, move to the bottom and rename to Recent Literature) invisible for 9.1.0. The code stays in place and takes effect when the section returns, so nothing needs reverting.

Prettier and ESLint clean.


[KANBAN-1473]: https://agr-jira.atlassian.net/browse/KANBAN-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ