### PR TITLE
feat(diseasePortal): Disease Portal page edits for release 9.1.0 (KANBAN-1493)

### DIFF
--- a/src/components/subsection.jsx
+++ b/src/components/subsection.jsx
@@ -10,7 +10,17 @@ import NoData from './noData.jsx';
 import ErrorBoundary from './errorBoundary.jsx';
 import HelpPopup from './helpPopup.jsx';
 
-const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isMeta, level, title }) => {
+const Subsection = ({
+  children,
+  hardcoded,
+  hasData,
+  help,
+  hideTitle = false,
+  isMeta,
+  level,
+  title,
+  titleAdornment,
+}) => {
   const id = title && makeId(title);
   const Target = () => <a className={style.target} id={id} />;
   const helpPopup = help && (
@@ -18,6 +28,7 @@ const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isM
       <HelpPopup id={`help-${title}`}>{help}</HelpPopup>
     </span>
   );
+  const adornment = titleAdornment && <span className="small ml-3">{titleAdornment}</span>;
 
   let renderTitle;
   const titleContent = (
@@ -25,6 +36,7 @@ const Subsection = ({ children, hardcoded, hasData, help, hideTitle = false, isM
       {isMeta && <target />}
       {title}
       {helpPopup}
+      {adornment}
     </>
   );
   switch (level) {
@@ -57,6 +69,7 @@ Subsection.propTypes = {
   isMeta: PropTypes.bool,
   level: PropTypes.number,
   title: PropTypes.string,
+  titleAdornment: PropTypes.node,
 };
 
 Subsection.defaultProps = {

--- a/src/containers/diseasePage/basicDiseaseInfo.jsx
+++ b/src/containers/diseasePage/basicDiseaseInfo.jsx
@@ -13,6 +13,7 @@ import { CollapsibleList } from '../../components/collapsibleList';
 import { smartAlphaSort } from '../../lib/utils';
 import SynonymList from '../../components/synonymList.jsx';
 import { formatLink } from './utils';
+import { findPortalForDisease } from '../diseasePortal/portalData.js';
 
 const TermList = ({ terms }) =>
   terms && (
@@ -89,6 +90,27 @@ const transformSynonyms = (synonyms) => {
   return synonyms.map((item) => item.name);
 };
 
+// Omitted entirely when neither the term nor any ancestor has a portal, rather
+// than falling back to the portal index (KANBAN-1498).
+const PortalRow = ({ disease }) => {
+  const portal = findPortalForDisease(disease.doTerm?.curie, disease.parentClosureIDs);
+  if (!portal) {
+    return null;
+  }
+  return (
+    <>
+      <AttributeLabel>Disease Portal</AttributeLabel>
+      <AttributeValue>
+        <Link to={`/disease-portal/${portal.slug}`}>{portal.pageName} Portal</Link>
+      </AttributeValue>
+    </>
+  );
+};
+
+PortalRow.propTypes = {
+  disease: PropTypes.object,
+};
+
 const BasicDiseaseInfo = ({ disease }) => (
   <AttributeList>
     <AttributeLabel>Definition</AttributeLabel>
@@ -122,6 +144,8 @@ const BasicDiseaseInfo = ({ disease }) => (
     <AttributeValue>
       <SourceList sources={disease.sourceReferenceLinkUrls} />
     </AttributeValue>
+
+    <PortalRow disease={disease} />
   </AttributeList>
 );
 

--- a/src/containers/diseasePortal/DiseasePortalSection.jsx
+++ b/src/containers/diseasePortal/DiseasePortalSection.jsx
@@ -4,18 +4,31 @@ import EntityButton from './EntityButton.jsx';
 import { useEntityButtonCounts } from './useEntityButtonCounts.js';
 import { isRootPortal } from './portalData.js';
 
+// Hidden on every portal page pending a decision on what the count should mean
+// per portal (KANBAN-1492). Flip to true to restore the Alliance-wide pill.
+const SHOW_DISEASE_COUNT = false;
+
 const DiseasePortalSection = ({ disease }) => {
   const url = `/api/disease/${disease.doid}/`;
-  const diseaseCount = useEntityButtonCounts('/api/disease/annotated-count');
+  const isRoot = isRootPortal(disease);
+  const diseaseCount = useEntityButtonCounts(SHOW_DISEASE_COUNT ? '/api/disease/annotated-count' : null);
   const geneCount = useEntityButtonCounts(url + 'genes_counts');
   const modelCount = useEntityButtonCounts(url + 'models_counts');
   const alleleCount = useEntityButtonCounts(url + 'alleles_counts');
 
-  const isRoot = isRootPortal(disease);
   const pageTitle = isRoot
     ? 'Disease Portals'
     : // <a href={`/disease/${disease.doid}`}>{`${disease.pageName} Portal`}</a>
       `${disease.pageName} Portal`;
+  const diseasesEntityButton = SHOW_DISEASE_COUNT ? (
+    <EntityButton id="entity-diseases" to="/search?q=&category=disease_search_result" tooltip="View all diseases">
+      <div>{diseaseCount ? diseaseCount.toLocaleString() : ''}</div>
+      Diseases
+    </EntityButton>
+  ) : (
+    ''
+  );
+  // Whole-Alliance figure, shown on the root portal only.
   const speciesEntityButton = isRoot ? (
     <EntityButton id="entity-species" to="/about-us" tooltip="View all associated species">
       9<br />
@@ -42,10 +55,7 @@ const DiseasePortalSection = ({ disease }) => {
           <li><Link to='/help#how'>More...</Link></li>
         </ul> */}
         <div className="d-flex justify-content-around flex-wrap">
-          <EntityButton id="entity-diseases" to="/search?q=&category=disease_search_result" tooltip="View all diseases">
-            <div>{diseaseCount ? diseaseCount.toLocaleString() : ''}</div>
-            Diseases
-          </EntityButton>
+          {diseasesEntityButton}
           <EntityButton
             id="entity-models"
             to={`/disease/${disease.doid}#associated-models`}

--- a/src/containers/diseasePortal/EntityButton.jsx
+++ b/src/containers/diseasePortal/EntityButton.jsx
@@ -7,7 +7,8 @@ import style from './style.module.scss';
 const EntityButton = ({ children, id, to, tooltip }) => {
   return (
     <b>
-      <Link className={style.entityButton} id={id} to={to}>
+      {/* New tab so the portal page stays put behind the pill (KANBAN-1499). */}
+      <Link className={style.entityButton} id={id} to={to} target="_blank" rel="noopener">
         {children}
         {tooltip && (
           <UncontrolledTooltip placement="bottom" target={id}>

--- a/src/containers/diseasePortal/OntologyContextSection.jsx
+++ b/src/containers/diseasePortal/OntologyContextSection.jsx
@@ -10,12 +10,12 @@ import { TermsProvider } from '../ontologyBrowser/useDiseaseTerms.jsx';
 import style from './style.module.scss';
 
 // Embedded, scoped ontology view for a disease portal page (KANBAN-1391).
-// Two interaction modes by control:
-//  - Term labels — both the ancestor context and every row in the tree — link
-//    OUT to the full-page ontology browser. The embed has no detail panel, so
-//    selecting a term in place would be a dead end.
-//  - The chevron stays in-page: expand/collapse drill-down is local, no route
-//    change.
+// Everything in the tree stays in-page (KANBAN-1497): clicking a term row only
+// highlights it, the chevron expands and collapses, and the route out to the
+// full browser is the single "Browse Ontology for ..." link on the section
+// heading. The G/A/M count badges still link to their disease pages.
+// Omitting nodeHref is what keeps term labels plain spans; the standalone
+// browser omits it too, so this stays embed-local.
 const OntologyContextSection = ({ curie, name }) => {
   // Immediate parents come from the single-term doc (same shape the standalone
   // TermDetailPanel uses). The DO is a DAG, so there can be more than one.
@@ -72,7 +72,6 @@ const OntologyContextSection = ({ curie, name }) => {
             focusedCurie={selectedCurie}
             onSelect={setSelectedCurie}
             scrollOnFocus={false}
-            nodeHref={(c) => `/ontology/disease/${c}`}
           />
         </div>
       </TermsProvider>

--- a/src/containers/diseasePortal/RECENT_PAPERS_API.md
+++ b/src/containers/diseasePortal/RECENT_PAPERS_API.md
@@ -1,6 +1,9 @@
 # Disease Portal — Recent Papers API
 
-Status: **implemented** (endpoint live on stage; UI wired in `PapersSection.jsx`)
+Status: **hidden in the UI for release 9.1.0** (KANBAN-1473). The endpoint is live
+on stage and the UI is still wired in `PapersSection.jsx`, but the section is not
+rendered — the group decided the list must be built from DO-annotated papers
+instead of free-text matches, which is API work not yet done. Details below.
 Branch: `feature/DPrecentpapersAPI`
 Consumer: `src/containers/diseasePortal/PapersSection.jsx`
 
@@ -21,7 +24,26 @@ disease.
 > `RECENT_PAPERS_BACKEND_SCOPE.md` (the ABC-proxy build plan) is obsolete and has
 > been removed.
 
-> **Why free-text matching, not DOID (intentional — do not "fix" back to DOID):**
+> **SUPERSEDED Aug 20 2026 — the group decided the opposite. Read this before
+> touching the query.** The consensus is that the papers listed must be ones
+> **annotated with DO terms for the page's disease**, not free-text matches. That
+> reverses the reasoning kept below, and it is a large change rather than a tweak:
+> free-text search of title + abstract is replaced by a query over curated
+> disease annotations, so it is API work, not a UI query change. See KANBAN-1473.
+>
+> Consequences the group accepted in making that call: the list becomes precise
+> but no longer surfaces papers ahead of curation, so it will be older on average
+> and thinner for diseases with a curation backlog — the exact trade-off the
+> original design refused. Expect it to look much more like the old hand-curated
+> `publications` arrays than the current list does. A rename to "Recent Annotated
+> Papers" was discussed alongside it, which is the honest label for this content.
+>
+> **For 9.1.0 the section is hidden entirely** rather than shipped with free-text
+> results (KANBAN-1473); see `SHOW_RECENT_LITERATURE` in
+> `src/containers/diseasePortal/index.jsx`.
+
+> **Original rationale, kept for the reasoning it captures — no longer the
+> direction (was: "do not fix back to DOID"):**
 > The whole purpose of this section is to surface the _most recent_ literature.
 > DOID-to-paper association is **curated**, which takes time — and the lag
 > differs per MOD corpus. Matching on DOID would therefore systematically miss

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -82,8 +82,8 @@ const DiseasePortalPage = () => {
             title={ONTOLOGY}
             titleAdornment={
               // The section's only route out to the full browser, replacing the removed nav item.
-              <Link to={`/ontology/disease/${diseaseData.doid}`}>
-                Browse Ontology for {diseaseApiData?.doTerm?.name || portalTitle}
+              <Link className={style.ontologyBrowseLink} to={`/ontology/disease/${diseaseData.doid}`}>
+                Browse ontology for {diseaseApiData?.doTerm?.name || portalTitle}
               </Link>
             }
           >

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -91,7 +91,15 @@ const DiseasePortalPage = () => {
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />
           </Subsection>
-          <Subsection title={ONTOLOGY}>
+          <Subsection
+            title={ONTOLOGY}
+            titleAdornment={
+              // The section's only route out to the full browser, replacing the removed nav item.
+              <Link to={`/ontology/disease/${diseaseData.doid}`}>
+                Browse Ontology for {diseaseApiData?.doTerm?.name || portalTitle}
+              </Link>
+            }
+          >
             {/* key on doid forces a remount per disease: the reused fiber (see above)
                 would otherwise leave the embedded tree's scoped state stale. */}
             <OntologyContextSection

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -19,11 +19,11 @@ import style from './style.module.scss';
 const SUMMARY = 'Summary';
 const ONTOLOGY = 'Ontology View';
 const COMMUNITY_RESOURCES = 'Community Resources';
-const RECENT_PAPERS = 'Recent Alliance Papers';
+const RECENT_LITERATURE = 'Recent Literature';
 const MEMBERS = 'Members';
 
 // Every entry is an in-page anchor, so this no longer varies per disease.
-const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
+const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: COMMUNITY_RESOURCES }, { name: RECENT_LITERATURE }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -95,11 +95,11 @@ const DiseasePortalPage = () => {
               name={diseaseApiData?.doTerm?.name || portalTitle}
             />
           </Subsection>
-          <Subsection title={RECENT_PAPERS}>
-            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
-          </Subsection>
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />
+          </Subsection>
+          <Subsection title={RECENT_LITERATURE}>
+            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
           </Subsection>
           <div className={style.membersFooter}>
             <Subsection hideTitle title={MEMBERS}>

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -23,7 +23,7 @@ const RECENT_PAPERS = 'Recent Alliance Papers';
 const MEMBERS = 'Members';
 
 // Every entry is an in-page anchor, so this no longer varies per disease.
-const SECTIONS = [{ name: SUMMARY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }, { name: ONTOLOGY }];
+const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -78,12 +78,6 @@ const DiseasePortalPage = () => {
           <Subsection title={SUMMARY}>
             <SummarySection disease={diseaseApiData} />
           </Subsection>
-          <Subsection title={RECENT_PAPERS}>
-            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
-          </Subsection>
-          <Subsection title={COMMUNITY_RESOURCES}>
-            <ResourcesSection disease={diseaseData} />
-          </Subsection>
           <Subsection
             title={ONTOLOGY}
             titleAdornment={
@@ -100,6 +94,12 @@ const DiseasePortalPage = () => {
               curie={diseaseData.doid}
               name={diseaseApiData?.doTerm?.name || portalTitle}
             />
+          </Subsection>
+          <Subsection title={RECENT_PAPERS}>
+            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
+          </Subsection>
+          <Subsection title={COMMUNITY_RESOURCES}>
+            <ResourcesSection disease={diseaseData} />
           </Subsection>
           <div className={style.membersFooter}>
             <Subsection hideTitle title={MEMBERS}>

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -22,8 +22,20 @@ const COMMUNITY_RESOURCES = 'Community Resources';
 const RECENT_LITERATURE = 'Recent Literature';
 const MEMBERS = 'Members';
 
+// Hidden for release 9.1.0 (KANBAN-1473). The list is free-text matched against
+// title and abstract, and the group decided it must instead be papers annotated
+// with DO terms for the page's disease — API work that is not done, so the
+// section ships hidden rather than misleading. Flip to true once that lands; see
+// RECENT_PAPERS_API.md for the agreed target behavior.
+const SHOW_RECENT_LITERATURE = false;
+
 // Every entry is an in-page anchor, so this no longer varies per disease.
-const SECTIONS = [{ name: SUMMARY }, { name: ONTOLOGY }, { name: COMMUNITY_RESOURCES }, { name: RECENT_LITERATURE }];
+const SECTIONS = [
+  { name: SUMMARY },
+  { name: ONTOLOGY },
+  { name: COMMUNITY_RESOURCES },
+  ...(SHOW_RECENT_LITERATURE ? [{ name: RECENT_LITERATURE }] : []),
+];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -98,9 +110,11 @@ const DiseasePortalPage = () => {
           <Subsection title={COMMUNITY_RESOURCES}>
             <ResourcesSection disease={diseaseData} />
           </Subsection>
-          <Subsection title={RECENT_LITERATURE}>
-            <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
-          </Subsection>
+          {SHOW_RECENT_LITERATURE && (
+            <Subsection title={RECENT_LITERATURE}>
+              <PapersSection diseaseName={diseaseApiData?.doTerm?.name} queryOverride={diseaseData.papersQuery} />
+            </Subsection>
+          )}
           <div className={style.membersFooter}>
             <Subsection hideTitle title={MEMBERS}>
               <MembersSection />

--- a/src/containers/diseasePortal/index.jsx
+++ b/src/containers/diseasePortal/index.jsx
@@ -18,19 +18,12 @@ import style from './style.module.scss';
 
 const SUMMARY = 'Summary';
 const ONTOLOGY = 'Ontology View';
-const BROWSE_ONTOLOGY = 'Browse Ontology';
 const COMMUNITY_RESOURCES = 'Community Resources';
 const RECENT_PAPERS = 'Recent Alliance Papers';
 const MEMBERS = 'Members';
 
-// Browse Ontology is an outbound link rather than an anchor, so sections depend on the doid.
-const makeSections = (doid) => [
-  { name: SUMMARY },
-  { name: RECENT_PAPERS },
-  { name: COMMUNITY_RESOURCES },
-  { name: ONTOLOGY },
-  { name: BROWSE_ONTOLOGY, to: `/ontology/disease/${doid}` },
-];
+// Every entry is an in-page anchor, so this no longer varies per disease.
+const SECTIONS = [{ name: SUMMARY }, { name: RECENT_PAPERS }, { name: COMMUNITY_RESOURCES }, { name: ONTOLOGY }];
 
 const DiseasePortalPage = () => {
   const { name: dname } = useParams();
@@ -76,7 +69,7 @@ const DiseasePortalPage = () => {
       <HeadMetaTags title={`${portalTitle} Portal`} />
       <DiseasePortalSection disease={diseaseData} />
       <DataPage>
-        <PageNav sections={makeSections(diseaseData.doid)}>
+        <PageNav sections={SECTIONS}>
           <PageNavEntity entityName={portalTitle}>
             <Link to={`/disease/${diseaseData.doid}`}>{diseaseData.doid}</Link>
           </PageNavEntity>

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -204,6 +204,29 @@ export const data = {
 // The root portal (the index page); every other entry is a disease portal.
 export const isRootPortal = (portal) => portal?.doid === DISEASE_ROOT_CURIE;
 
+// The portal a disease page should link to (KANBAN-1498): the portal on the term
+// itself, otherwise the portal whose term is one of its ancestors. Costs nothing
+// beyond a set intersection — `parentClosureIDs` is the full DAG closure and is
+// already on the payload the disease page fetches, so no extra request and no
+// walking of parent links. Note the closure is why /{id}/ancestors is not used:
+// that returns a single path, which misses portals on other branches.
+// The root portal is excluded deliberately: DOID:4 is in every closure, so
+// including it would give every disease in the DO a link to the portal index.
+export const findPortalForDisease = (curie, parentClosureIDs) => {
+  const portals = Object.entries(data).filter(([, portal]) => !isRootPortal(portal));
+
+  const own = portals.find(([, portal]) => portal.doid === curie);
+  if (own) {
+    return { slug: own[0], pageName: own[1].pageName };
+  }
+
+  const closure = new Set(parentClosureIDs || []);
+  // No portal term is a descendant of another (verified against the DO), so a
+  // second match would mean separate DAG branches; `data` order breaks the tie.
+  const ancestor = portals.find(([, portal]) => closure.has(portal.doid));
+  return ancestor ? { slug: ancestor[0], pageName: ancestor[1].pageName } : null;
+};
+
 // Portals for the index, grouped by parent disease. Group order and the order
 // within each group both follow `data`.
 export const portalsByGroup = () => {

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -40,7 +40,7 @@ export const data = {
       },
       { title: 'Matchmaker Exchange', url: 'https://www.matchmakerexchange.org/' },
       { title: 'ModelMatcher', url: 'https://www.modelmatcher.net/' },
-      { title: 'Online Mendelian Inheritance of Man (OMIM)', url: 'https://www.omim.org/' },
+      { title: 'Online Mendelian Inheritance in Man (OMIM)', url: 'https://www.omim.org/' },
       { title: 'Portal Kids First DRC', url: 'https://portal.kidsfirstdrc.org/login?redirect_path=/data-exploration' },
     ],
   },
@@ -57,7 +57,7 @@ export const data = {
         url: 'https://fightcolorectalcancer.org/our-programs/research-innovation/',
       },
       {
-        title: 'GECCO (Genetics and Epidemiology of Colorectal Cancer Consortium)',
+        title: 'The Genetics and Epidemiology of Colorectal Cancer Consortium (GECCO)',
         url: 'https://research.fredhutch.org/peters/en/genetics-and-epidemiology-of-colorectal-cancer-consortium.html',
       },
       { title: 'NCI Advances in Colorectal Cancer Research', url: 'https://www.cancer.gov/types/colorectal/research' },
@@ -77,8 +77,8 @@ export const data = {
         url: 'https://dpcpsi.nih.gov/autism-data-science-initiative/funded-research',
       },
       { title: 'NIMH Data Archive', url: 'https://nda.nih.gov/' },
-      { title: 'SFARI Gene', url: 'https://gene.sfari.org/' },
-      { title: 'SPARK (Simons Foundation Powering Autism Research)', url: 'https://sparkforautism.org/' },
+      { title: 'Simons Foundation Autism Research Initiative Gene (SFARI Gene)', url: 'https://gene.sfari.org/' },
+      { title: 'Simons Foundation Powering Autism Research (SPARK)', url: 'https://sparkforautism.org/' },
     ],
   },
   'diabetes-mellitus': {
@@ -118,12 +118,12 @@ export const data = {
         title: 'NCI/NEI ciliopathy gene-therapy research news (NIH intramural)',
         url: 'https://www.nih.gov/news-events/news-releases/nih-researchers-develop-gene-therapy-rare-ciliopathy',
       },
-      { title: 'PCD Research', url: 'https://pcdresearch.org/' },
+      { title: 'Primary Ciliary Dyskinesia Research (PCD Research)', url: 'https://pcdresearch.org/' },
       {
         title: 'Rare Diseases Clinical Research Network (RDCRN) - NIH/NCATS',
         url: 'https://www.rarediseasesnetwork.org/',
       },
-      { title: 'TheRaCil (Therapies for Renal Ciliopathies)', url: 'https://theracil.eu/' },
+      { title: 'Therapies for Renal Ciliopathies (TheRaCil)', url: 'https://theracil.eu/' },
     ],
   },
   'long-qt-syndrome': {
@@ -133,12 +133,12 @@ export const data = {
     listLabel: 'long QT syndrome',
     papersQuery: '"long QT syndrome"',
     resources: [
+      { title: 'The Foundation for Inherited Arrhythmias (FIA)', url: 'https://www.fiacardiac.org/' },
       { title: 'Hearts in Rhythm Organization (HiRO)', url: 'https://heartsinrhythm.ca/' },
       {
         title: 'International LQTS Registry (University of Rochester)',
         url: 'https://www.urmc.rochester.edu/clinical-cardiovascular-research/lqts-registry',
       },
-      { title: 'SADS Foundation (Sudden Arrhythmia Death Syndromes)', url: 'https://sads.org/' },
     ],
   },
   'alzheimers-disease': {
@@ -159,8 +159,11 @@ export const data = {
       },
       { title: "Alzheimer's Foundation of America", url: 'https://alzfdn.org/' },
       { title: 'National Institute on Aging', url: 'https://www.nia.nih.gov/' },
-      { title: 'NIAGADS', url: 'https://www.niagads.org/' },
-      { title: 'OMIM', url: 'https://omim.org/entry/104300' },
+      {
+        title: "National Institute on Aging Genetics of Alzheimer's Disease Data Storage Site (NIAGADS)",
+        url: 'https://www.niagads.org/',
+      },
+      { title: 'Online Mendelian Inheritance in Man (OMIM)', url: 'https://omim.org/entry/104300' },
     ],
   },
   epilepsy: {

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -227,8 +227,8 @@ export const findPortalForDisease = (curie, parentClosureIDs) => {
   return ancestor ? { slug: ancestor[0], pageName: ancestor[1].pageName } : null;
 };
 
-// Portals for the index, grouped by parent disease. Group order and the order
-// within each group both follow `data`.
+// Portals for the index, grouped by parent disease. Group headings are sorted
+// alphabetically; the order within each group follows `data`.
 export const portalsByGroup = () => {
   const groups = [];
   Object.entries(data).forEach(([slug, portal]) => {
@@ -243,5 +243,8 @@ export const portalsByGroup = () => {
     }
     group.portals.push({ slug, label: portal.listLabel || portal.pageName });
   });
-  return groups;
+  // Headings are sorted here rather than by reordering `data` (KANBAN-1488), so
+  // adding a portal cannot silently misplace one. `groups` is built fresh above,
+  // so sorting it in place does not touch the exported `data`.
+  return groups.sort((a, b) => a.name.localeCompare(b.name));
 };

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -15,7 +15,21 @@ import { DISEASE_ROOT_CURIE } from '../ontologyBrowser/ontologies.js';
 //              Uses the DO slim term behind the gene-page disease ribbon, so
 //              headings match the buckets curators see there. Omit on the root.
 //   listLabel  optional. Label in the index, when it differs from pageName.
-//   resources  optional. Community Resources links.
+//   resources  optional. Community Resources links. Keep each list alphabetical
+//              by title, ignoring a leading "The" — the convention is enforced by
+//              hand only: ResourcesSection renders the array in declaration order
+//              with no sort, so a new or renamed entry sits wherever it is typed
+//              and nothing flags a list that has drifted. This bit us in
+//              KANBAN-1489, where renaming "SADS Foundation ..." to "The
+//              Foundation for Inherited Arrhythmias (FIA)" left it last in a list
+//              it now sorts first in.
+//              Possible improvement: sort by title in ResourcesSection at render
+//              time, stripping a leading article for comparison, the way
+//              portalsByGroup() now sorts the index headings (KANBAN-1488). That
+//              would make placement here irrelevant. Not done for 9.1.0 because
+//              the lists are curator-vetted and were already in the right order —
+//              worth doing the next time this file's resources are touched in
+//              bulk.
 //   papersQuery optional. Overrides the Recent Papers query for portals whose
 //              name matches badly as free text. The endpoint matches loosely and
 //              fills every MOD slot even with no real match, so a name built from

--- a/src/containers/diseasePortal/style.module.scss
+++ b/src/containers/diseasePortal/style.module.scss
@@ -186,3 +186,12 @@ $max-width: 800px;
     border-bottom: 0;
   }
 }
+
+// Secondary action on the Ontology View heading (KANBAN-1497). Sizes are
+// absolute on purpose: Bootstrap's .small is relative, so inside an h3 it still
+// rendered at heading scale and read as a second title. 0.85rem and weight 400
+// match the section's other meta text (.ontologyLegend, .ontologyParentsLabel).
+.ontologyBrowseLink {
+  font-size: 0.85rem;
+  font-weight: 400;
+}


### PR DESCRIPTION
All Disease Portal changes for release **9.1.0**, requested at the Aug 19 D&P meeting and tracked under [KANBAN-1493](https://agr-jira.atlassian.net/browse/KANBAN-1493). Nine tickets, twelve commits, nine files.

**Curator-approved.** Ranjana reviewed the whole set together on the shared Amplify preview (`feature-kanban-1493-dp-9-1-0`) on Aug 20 2026 and approved all changes, including the Recent Literature hide. She has no GitHub account, so this is the record of that sign-off.

## What's in it

| Ticket | Change |
| --- | --- |
| [1492](https://agr-jira.atlassian.net/browse/KANBAN-1492) | Diseases headline pill hidden on all portal pages |
| [1495](https://agr-jira.atlassian.net/browse/KANBAN-1495) | Ontology View moved directly below Summary |
| [1494](https://agr-jira.atlassian.net/browse/KANBAN-1494) | Recent Papers moved to the bottom, renamed Recent Literature |
| [1496](https://agr-jira.atlassian.net/browse/KANBAN-1496) | Browse Ontology removed from the portal side nav |
| [1497](https://agr-jira.atlassian.net/browse/KANBAN-1497) | "Browse ontology for &lt;disease&gt;" link on the Ontology View heading; tree term labels unlinked; link toned down after preview feedback |
| [1498](https://agr-jira.atlassian.net/browse/KANBAN-1498) | Disease Portal link at the bottom of the Summary on disease pages |
| [1499](https://agr-jira.atlassian.net/browse/KANBAN-1499) | Portal headline number links open in a new tab |
| [1488](https://agr-jira.atlassian.net/browse/KANBAN-1488) | Index category headings sorted alphabetically |
| [1489](https://agr-jira.atlassian.net/browse/KANBAN-1489) | Community Resources: full name first, acronym in parentheses; SADS Foundation → The Foundation for Inherited Arrhythmias (FIA), URL included |
| [1473](https://agr-jira.atlassian.net/browse/KANBAN-1473) | Recent Literature section hidden for this release |

Net effect on a portal page: **Summary → Ontology View → Community Resources**, no Diseases pill, no Browse Ontology nav item, counts opening in new tabs.

## Things worth knowing before merging

**Two changes deliberately reverse shipped work**, both confirmed with the curators first, so they are intended rather than regressions: 1496 undoes [KANBAN-1464](https://agr-jira.atlassian.net/browse/KANBAN-1464) (Release), and 1497's unlinking undoes [KANBAN-1470](https://agr-jira.atlassian.net/browse/KANBAN-1470) (Ready for UAT).

**Nothing is deleted where a decision may reverse.** Both hides sit behind a module constant — `SHOW_DISEASE_COUNT` and `SHOW_RECENT_LITERATURE` — so each returns with a one-word change once its blocking question is settled. Neither fetches its endpoint while hidden.

**1473 carries a design reversal.** The group decided the literature list must eventually be built from papers **annotated with DO terms** for the page's disease, not free-text matches. `RECENT_PAPERS_API.md` records that and marks the previous "do not fix back to DOID" rationale as superseded — it argued the opposite case and would otherwise read as a standing instruction against the agreed direction.

**1498 needs no extra API call.** Portal matching intersects `parentClosureIDs`, already on the disease page's payload, against the eight portal DOIDs. `/{id}/ancestors` is deliberately unused: it returns a single path and so misses portals on other DAG branches.

**1497 is embed-local.** Unlinking is just dropping `nodeHref`; `OntologyTree` treats it as optional and the standalone `/ontology` browser already omits it, so shared-component behavior is untouched.

**One shared component changed:** `Subsection` gains an optional `titleAdornment` slot, mirroring its existing `help` prop. `undefined` for every other caller.

## Verification

Each ticket was verified in a browser against the dev server as it landed, and the combined result re-checked after every merge into the integration branch — section order and headings, side-nav contents, the three 1498 cases (own portal / ancestor match / no portal → no row), new-tab behavior by actual click, and resource titles and ordering across the six affected portals. Ranjana then reviewed the assembled result on the preview.

`stage` was merged into the integration branch when it moved, so this is 0 behind and the diff is exactly these changes.

## Known, not blocking

* Two pre-existing ESLint errors in files touched here — unused `Component` import in `basicDiseaseInfo.jsx`, `jsx-a11y` disable comments for undefined rules in `subsection.jsx`. Both fail identically on `stage` today; left alone rather than widening these tickets.
* Open curator questions recorded on 1489 (the Parkinson's PPMI name; whether agency-prefix titles like `NIMH Data Archive` should be expanded) and 1488 (whether portals within a heading should be sorted too). None affect what ships here.
* Resource lists stay hand-alphabetized; `portalData.js` now documents that, and the render-time sort that would make it self-maintaining.


[KANBAN-1493]: https://agr-jira.atlassian.net/browse/KANBAN-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1464]: https://agr-jira.atlassian.net/browse/KANBAN-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ