### PR TITLE
docs(ontologyBrowser): correct the nodeHref comment, now that no caller passes it

### DIFF
--- a/src/containers/ontologyBrowser/OntologyTree.jsx
+++ b/src/containers/ontologyBrowser/OntologyTree.jsx
@@ -70,9 +70,14 @@ const OntologyTree = ({
   // loses it a moment later when the batched fetch reports zero children.
   const hasChildren = childTerms.length > 0 || (data?.doTerm?.descendantCount || 0) > 0;
   const isFocused = focusedCurie === curie;
-  // Embedded viewers (the disease portal) link every label out to the full
-  // browser, since they have no detail panel of their own. The standalone
-  // omits nodeHref and keeps rendering a plain span that selects in place.
+  // nodeHref is an opt-in seam: supply it and the term label renders as a link
+  // out to the full browser instead of a plain span that selects in place. No
+  // caller passes it today — the standalone drives its own detail panel, and the
+  // disease-portal embed dropped it in KANBAN-1497, so its rows are plain text
+  // with a single "Browse ontology for ..." link on the section heading. Kept
+  // rather than deleted because that call has already reversed twice: KANBAN-1470
+  // restored these links, KANBAN-1497 removed them again.
+  // Keyboard selection of a row is a separate gap, tracked in KANBAN-1500.
   const nodeUrl = nodeHref ? nodeHref(curie) : null;
 
   const toggle = (e) => {


### PR DESCRIPTION
Comment-only fix in a shared component, from the bot review on #1880. Targets `stage` directly — `OntologyTree.jsx` was not among that PR's files, so there is no overlap.

The comment said embedded viewers link every label out and "the standalone omits `nodeHref`". After [KANBAN-1497](https://agr-jira.atlassian.net/browse/KANBAN-1497) the disease-portal embed omits it too, so **no caller passes it at all** — the comment described behavior that had just been removed, in the one component shared by both consumers. Left alone it reads as an invitation to restore the links, which is exactly the trap the epic fixed in `RECENT_PAPERS_API.md`.

Now documents the prop as an opt-in seam, and why it is kept rather than deleted: the decision has already reversed twice — KANBAN-1470 restored these links, KANBAN-1497 removed them again — so the seam is worth keeping for the same reason the pill and literature hides sit behind switches. Also points at [KANBAN-1500](https://agr-jira.atlassian.net/browse/KANBAN-1500) for keyboard selection, since the label link used to be the row's only focusable element.

No behavior change. Prettier and ESLint clean.


[KANBAN-1497]: https://agr-jira.atlassian.net/browse/KANBAN-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KANBAN-1500]: https://agr-jira.atlassian.net/browse/KANBAN-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ