### PR TITLE
feat(diseasePortal): append the PPMI acronym to the Parkinson's resource (KANBAN-1489)

### DIFF
--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -213,7 +213,7 @@ export const data = {
         title: "Parkinson's Disease Clinical Trials",
         url: 'https://clinicaltrials.gov/search?cond=Parkinson%27s%20Disease&viewType=Card',
       },
-      { title: "Parkinson's Precision Medicine Initiative", url: 'https://www.ppmi-info.org/' },
+      { title: "Parkinson's Precision Medicine Initiative (PPMI)", url: 'https://www.ppmi-info.org/' },
     ],
   },
 };


### PR DESCRIPTION
Appends the acronym to the one Community Resources entry left open by [KANBAN-1489](https://agr-jira.atlassian.net/browse/KANBAN-1489): `Parkinson's Precision Medicine Initiative` → `Parkinson's Precision Medicine Initiative (PPMI)`.

I had held this back on the belief that the title named the wrong organisation — PPMI is historically the *Parkinson's Progression Markers Initiative*. Checked the site before editing: ppmi-info.org's own page title is "Parkinson's Precision Medicine Initiative", so the existing name was correct and only the acronym was missing. The organisation rebranded and kept the acronym, which is what caused the doubt.

Alphabetical placement is unchanged — it still sorts after "Parkinson's Disease Clinical Trials". Verified the rendered list on the Parkinson's portal. Prettier and ESLint clean.


[KANBAN-1489]: https://agr-jira.atlassian.net/browse/KANBAN-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ