### PR TITLE
feat(diseasePortal): order pills Genes, Alleles, Models and fix the Species tooltip (KANBAN-1503)

### DIFF
--- a/src/containers/diseasePortal/DiseasePortalSection.jsx
+++ b/src/containers/diseasePortal/DiseasePortalSection.jsx
@@ -13,8 +13,8 @@ const DiseasePortalSection = ({ disease }) => {
   const isRoot = isRootPortal(disease);
   const diseaseCount = useEntityButtonCounts(SHOW_DISEASE_COUNT ? '/api/disease/annotated-count' : null);
   const geneCount = useEntityButtonCounts(url + 'genes_counts');
-  const modelCount = useEntityButtonCounts(url + 'models_counts');
   const alleleCount = useEntityButtonCounts(url + 'alleles_counts');
+  const modelCount = useEntityButtonCounts(url + 'models_counts');
 
   const pageTitle = isRoot
     ? 'Disease Portals'
@@ -30,7 +30,7 @@ const DiseasePortalSection = ({ disease }) => {
   );
   // Whole-Alliance figure, shown on the root portal only.
   const speciesEntityButton = isRoot ? (
-    <EntityButton id="entity-species" to="/about-us" tooltip="View all associated species">
+    <EntityButton id="entity-species" to="/about-us" tooltip="About the Alliance">
       9<br />
       Species
     </EntityButton>
@@ -56,14 +56,7 @@ const DiseasePortalSection = ({ disease }) => {
         </ul> */}
         <div className="d-flex justify-content-around flex-wrap">
           {diseasesEntityButton}
-          <EntityButton
-            id="entity-models"
-            to={`/disease/${disease.doid}#associated-models`}
-            tooltip="View all associated models"
-          >
-            <div>{modelCount ? modelCount.toLocaleString() : ''}</div>
-            Models
-          </EntityButton>
+          {/* Gene, Allele, Model order matches the disease pages and the ontology browser (KANBAN-1503). */}
           <EntityButton
             id="entity-genes"
             to={`/disease/${disease.doid}#associated-genes`}
@@ -79,6 +72,14 @@ const DiseasePortalSection = ({ disease }) => {
           >
             <div>{alleleCount ? alleleCount.toLocaleString() : ''}</div>
             Alleles
+          </EntityButton>
+          <EntityButton
+            id="entity-models"
+            to={`/disease/${disease.doid}#associated-models`}
+            tooltip="View all associated models"
+          >
+            <div>{modelCount ? modelCount.toLocaleString() : ''}</div>
+            Models
           </EntityButton>
           {/* <EntityButton id="entity-publications" to="">
             96,000

--- a/src/containers/diseasePortal/PortalListSection.jsx
+++ b/src/containers/diseasePortal/PortalListSection.jsx
@@ -7,17 +7,18 @@ import style from './style.module.scss';
 const PortalListItem = ({ portalKey, label }) => {
   const disease = data[portalKey];
   const url = `/api/disease/${disease.doid}/`;
-  const modelCount = useEntityButtonCounts(url + 'models_counts');
   const geneCount = useEntityButtonCounts(url + 'genes_counts');
   const alleleCount = useEntityButtonCounts(url + 'alleles_counts');
+  const modelCount = useEntityButtonCounts(url + 'models_counts');
 
   return (
     <li>
       <Link to={`/disease-portal/${portalKey}`}>{label}</Link>
+      {/* Gene, Allele, Model order matches the portal page pills (KANBAN-1503). */}
       <span className={style.portalCounts}>
-        {modelCount != null && <span>{modelCount.toLocaleString()} models</span>}
         {geneCount != null && <span>{geneCount.toLocaleString()} genes</span>}
         {alleleCount != null && <span>{alleleCount.toLocaleString()} alleles</span>}
+        {modelCount != null && <span>{modelCount.toLocaleString()} models</span>}
       </span>
     </li>
   );


### PR DESCRIPTION
Curator request from the [KANBAN-1471](https://agr-jira.atlassian.net/browse/KANBAN-1471) thread, tracked as KANBAN-1503 under the Disease Portal 9.1.0 epic.

**Pill order.** Sue Bello: *"On the disease pages and in the browser, we go Gene, Allele, Model. I think it would be helpful to keep this order consistent."* The portal rendered Models, Genes, Alleles in both places she named:

- `DiseasePortalSection.jsx` — the coloured top-section pills
- `PortalListSection.jsx` — the count line beside each portal link on `/disease-portal`

**Species tooltip.** The pill's hover text read "View all associated species" but the link goes to `/about-us`. Sue flagged it as misleading and Ranjana approved the change to "About the Alliance".

The hidden Diseases pill (KANBAN-1492) is unaffected, and Species stays last on the root portal.

### Verified locally

| Page | Result |
| --- | --- |
| `/disease-portal` | Genes, Alleles, Models, Species |
| `/disease-portal/epilepsy` | Genes, Alleles, Models |
| Landing count lines | "4,167 genes / 34 alleles / 86 models" |
| Species tooltip | "About the Alliance", href still `/about-us` |

Hrefs and `target="_blank"` (KANBAN-1499) are unchanged. Jest 48 suites / 219 tests pass; ESLint and Prettier clean.

No test updates needed — the Playwright coverage in agr_release_testing asserts per-link and per-label, not left-to-right order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KANBAN-1471]: https://agr-jira.atlassian.net/browse/KANBAN-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ