### PR TITLE
fix(dataTable): don't link uncited or non-AGRKB references (KANBAN-1505)

### DIFF
--- a/src/components/dataTable/referenceList.jsx
+++ b/src/components/dataTable/referenceList.jsx
@@ -14,26 +14,31 @@ const ReferenceList = ({ refs, trunc = true, filterTerm }) => {
         .toLowerCase()
     )
     .filter(Boolean);
+  // Orphanet/OMIM evidence carries no citation, so there is nothing to show (KANBAN-1505).
+  const citedRefs = (refs || []).filter((ref) => ref?.shortCitation);
+  if (!citedRefs.length) {
+    return null;
+  }
+
   return (
-    refs && (
-      <CollapsibleList>
-        {refs.map((ref) => {
-          // when a filter is active, de-emphasize references matching none of its terms
-          const citation = (ref.shortCitation || '').toLowerCase();
-          const dim = terms.length > 0 && !terms.some((term) => citation.includes(term));
-          return (
-            <Link
-              to={`/reference/${ref.curie}`}
-              title={ref.shortCitation}
-              className={`${trunc ? style.ellipses : ''}${dim ? ' ' + style.referenceDim : ''}`}
-              key={ref.curie}
-            >
-              {ref.shortCitation}
-            </Link>
-          );
-        })}
-      </CollapsibleList>
-    )
+    <CollapsibleList>
+      {citedRefs.map((ref) => {
+        // when a filter is active, de-emphasize references matching none of its terms
+        const citation = ref.shortCitation.toLowerCase();
+        const dim = terms.length > 0 && !terms.some((term) => citation.includes(term));
+        const className = `${trunc ? style.ellipses : ''}${dim ? ' ' + style.referenceDim : ''}`;
+        // only AGRKB references have an Alliance reference page to link to
+        return ref.curie?.startsWith('AGRKB:') ? (
+          <Link to={`/reference/${ref.curie}`} title={ref.shortCitation} className={className} key={ref.curie}>
+            {ref.shortCitation}
+          </Link>
+        ) : (
+          <span title={ref.shortCitation} className={className} key={ref.curie}>
+            {ref.shortCitation}
+          </span>
+        );
+      })}
+    </CollapsibleList>
   );
 };
 

--- a/src/components/dataTable/referenceList.test.jsx
+++ b/src/components/dataTable/referenceList.test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import ReferenceList from './referenceList.jsx';
+
+const agrkbRef = (n) => ({
+  type: 'Reference',
+  curie: `AGRKB:10100000000000${n}`,
+  shortCitation: `Author ${n} (200${n}) J Test 1(1):1-2`,
+});
+
+// Orphanet evidence as the API returns it: no citation, and a curie with no Alliance page
+const orphaRef = (n) => ({
+  type: 'ExternalDatabaseReference',
+  curie: `ORPHA:${n}`,
+});
+
+const renderList = (refs, props = {}) =>
+  render(
+    <MemoryRouter>
+      <ReferenceList refs={refs} {...props} />
+    </MemoryRouter>
+  );
+
+describe('ReferenceList', () => {
+  it('links a reference that has an AGRKB curie and a citation', () => {
+    renderList([agrkbRef(1)]);
+
+    const link = screen.getByTitle('Author 1 (2001) J Test 1(1):1-2');
+    expect(link).toHaveAttribute('href', '/reference/AGRKB:101000000000001');
+    expect(link).toHaveTextContent('Author 1 (2001) J Test 1(1):1-2');
+  });
+
+  it('renders nothing when every reference is uncited Orphanet evidence', () => {
+    const { container } = renderList([orphaRef(96253), orphaRef(1333)]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('drops uncited references but keeps the cited ones alongside them', () => {
+    renderList([orphaRef(96253), agrkbRef(1), orphaRef(1333)]);
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByTitle('Author 1 (2001) J Test 1(1):1-2')).toBeInTheDocument();
+  });
+
+  it('never emits a link to a reference page for a non-AGRKB curie', () => {
+    renderList([{ type: 'ExternalDatabaseReference', curie: 'OMIM:151623', shortCitation: 'OMIM entry 151623' }]);
+
+    const cell = screen.getByTitle('OMIM entry 151623');
+    expect(cell).toHaveTextContent('OMIM entry 151623');
+    expect(cell).not.toHaveAttribute('href');
+    expect(document.querySelector('a')).toBeNull();
+  });
+
+  it('renders nothing for empty or missing input', () => {
+    expect(renderList([]).container).toBeEmptyDOMElement();
+    expect(renderList(undefined).container).toBeEmptyDOMElement();
+  });
+
+  it('collapses past two cited references behind a Show All toggle', () => {
+    renderList([agrkbRef(1), agrkbRef(2), agrkbRef(3)]);
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: /Show All 3/ })).toBeInTheDocument();
+  });
+
+  it('counts only cited references in the Show All total', () => {
+    renderList([agrkbRef(1), agrkbRef(2), agrkbRef(3), orphaRef(96253), orphaRef(1333)]);
+
+    expect(screen.getByRole('button', { name: /Show All 3/ })).toBeInTheDocument();
+  });
+
+  it('dims references that do not match an active filter term', () => {
+    renderList([agrkbRef(1), agrkbRef(2)], { filterTerm: 'Author 1' });
+
+    expect(screen.getByTitle('Author 1 (2001) J Test 1(1):1-2').className).not.toMatch(/referenceDim/);
+    expect(screen.getByTitle('Author 2 (2002) J Test 1(1):1-2').className).toMatch(/referenceDim/);
+  });
+});


### PR DESCRIPTION
Fixes [KANBAN-1505](https://agr-jira.atlassian.net/browse/KANBAN-1505).

`ReferenceList` backs the "Reference" column in all 8 KANBAN-864 tables. It rendered `{ref.shortCitation}` inside `<Link to={/reference/${ref.curie}}>` with no guard, so annotation evidence that is an `ExternalDatabaseReference` (Orphanet, OMIM) — which has neither a citation nor an Alliance reference page — produced an **empty link to a URL that 400s**.

Most visible on human gene pages. On `/api/gene/HGNC:11998/phenotypes` (TP53), **73 of 81 references** are uncited ORPHA entries; only 8 are real literature. The column read as blank enough to look missing.

### The fix

Ports the two guards `singleReferenceLinkCuration.jsx` already applies (which is why the three annotation popups were never affected):

1. no `shortCitation` → the entry is skipped
2. curie not `AGRKB:` → the citation renders as plain text, not a link

Uncited entries are filtered *before* `CollapsibleList` rather than returning `null` inside the map, so they no longer inflate its "Show All N" count.

**No API or Elasticsearch change is possible here.** For those 73 the evidence genuinely is the Orphanet entry — the annotation's identity is keyed on it (`uniqueId: HGNC:11998|has_phenotype|Abdominal obesity|HP:0012743|ORPHA:96253`) — so there is no Alliance reference to point at.

### Verified

| Page | Before | After |
| --- | --- | --- |
| TP53 (human) Phenotypes | 5/5 sampled rows had an empty `/reference/ORPHA:…` link | 0 empty links; cells cleanly blank, Reference ID still links to orpha.net |
| Trp53 (mouse) Phenotypes | citations linked | unchanged — "Hamard PJ (2013) Genes Dev 27(17):1868-85" → `/reference/AGRKB:101000000264700` |

8 new unit tests covering both guards, the mixed cited/uncited case, the Show All count, and filter dimming. Full suite 49 suites / 227 tests green; ESLint and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KANBAN-1505]: https://agr-jira.atlassian.net/browse/KANBAN-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ