### PR TITLE
fix(phenotypeTable): drop the /gene/undefined link from Annotation details (KANBAN-1463)

### DIFF
--- a/src/containers/genePage/phenotypeTable.jsx
+++ b/src/containers/genePage/phenotypeTable.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import hash from 'object-hash';
-import { DataTable, ReferencesCellCuration, ReferenceList, GeneCellCuration } from '../../components/dataTable';
+import { DataTable, ReferencesCellCuration, ReferenceList } from '../../components/dataTable';
 import useDataTableQuery from '../../hooks/useDataTableQuery';
-import { getIdentifier } from '../../components/dataTable/utils.jsx';
 import AnnotatedPhenotypePopupCuration from '../../components/dataTable/AnnotatedPhenotypePopupCuration.jsx';
 import { GENE_DETAILS_COLUMNS } from '../../components/dataTable/constants';
 import ProvidersCellCuration from '../../components/dataTable/ProvidersCellCuration.jsx';
@@ -30,20 +29,17 @@ const PhenotypeTable = ({ geneId, entityType, hideSourceColumn = false }) => {
     {
       dataField: 'primaryAnnotations',
       text: 'Annotation details',
-      formatter: (subject, row) => (
-        <>
-          <GeneCellCuration identifier={getIdentifier(subject)} gene={subject} />
-          <small>
-            <AnnotatedPhenotypePopupCuration
-              entities={row.primaryAnnotations}
-              mainRowCurie={getIdentifier(subject)}
-              pubmedPublications={row.pubmedPublications}
-              columnNameSet={GENE_DETAILS_COLUMNS}
-            >
-              View
-            </AnnotatedPhenotypePopupCuration>
-          </small>
-        </>
+      // every row's subject is the page's own gene or allele, so only the popup link belongs here
+      formatter: (_, row) => (
+        <small>
+          <AnnotatedPhenotypePopupCuration
+            entities={row.primaryAnnotations}
+            pubmedPublications={row.pubmedPublications}
+            columnNameSet={GENE_DETAILS_COLUMNS}
+          >
+            View
+          </AnnotatedPhenotypePopupCuration>
+        </small>
       ),
       headerStyle: { width: '90px' },
     },


### PR DESCRIPTION
Fixes [KANBAN-1463](https://agr-jira.atlassian.net/browse/KANBAN-1463).

The "Annotation details" column declares `dataField: 'primaryAnnotations'`, so react-bootstrap-table hands the formatter *that array* as its first argument — despite the parameter being named `subject`. `getIdentifier()` finds no curie on an array and returns `undefined`, so `GeneCellCuration` rendered `<Link to="/gene/undefined">` on every row.

Both the gene page and the allele page are affected; they share `phenotypeTable.jsx`.

### Why nobody noticed

The link is **invisible**. An array has no `geneSymbol`, so it rendered as a zero-width anchor with no text — measured 0px wide on stage. It cannot be clicked with a mouse.

It is, however, `tabIndex: 0` and focusable, with an empty accessible name. So keyboard and screen-reader users meet **10 empty links per page** on TP53, and Enter navigates to a broken gene page. That makes this an accessibility defect rather than the visibly-broken link the ticket originally described.

### The fix

Every row's subject is the page's own gene or allele, so a link there would be self-referential on the gene page and meaningless on the allele page. Removed the `GeneCellCuration` element and kept the View popup.

The `mainRowCurie` prop went with it: it was passed the same `undefined` value, and `AnnotatedPhenotypePopupCuration` accepts it but never reads it — so that half was always inert. The now-unused `GeneCellCuration` and `getIdentifier` imports are dropped.

### Verified

| Page | Before | After |
| --- | --- | --- |
| `/gene/HGNC:11998` (TP53) | 10 links to `/gene/undefined` | 0 undefined links, 0 empty links; cell reads "View" |
| `/allele/RGD:7241046` (Pink1[em1Sage]) | same, 10 rows | 0 undefined links, 0 empty links |

The View popup itself is untouched and still resolves its gene and Orphanet links correctly. Full suite green at 48 suites / 219 tests; ESLint and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KANBAN-1463]: https://agr-jira.atlassian.net/browse/KANBAN-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ