### PR TITLE
refactor(dataTable): drop the unused mainRowCurie prop from the phenotype popup

### DIFF
--- a/src/components/dataTable/AnnotatedPhenotypePopupCuration.jsx
+++ b/src/components/dataTable/AnnotatedPhenotypePopupCuration.jsx
@@ -66,10 +66,7 @@ function AnnotatedPhenotypePopupCuration({ children, entities, pubmedPublication
             </thead>
             <tbody>
               {sortedEntities.map((entity) => {
-                var expCondition = entity.conditionRelations;
-                if (entity.conditionModifiers != null) {
-                  expCondition = entity.conditionModifiers;
-                }
+                const expCondition = entity.conditionModifiers ?? entity.conditionRelations;
                 return (
                   <tr key={entity.id}>
                     {columnNameSet.has('Name') && <td>{renderLink(entity)}</td>}

--- a/src/components/dataTable/AnnotatedPhenotypePopupCuration.jsx
+++ b/src/components/dataTable/AnnotatedPhenotypePopupCuration.jsx
@@ -29,7 +29,7 @@ function renderLink(entity) {
   }
 }
 
-function AnnotatedPhenotypePopupCuration({ children, entities, mainRowCurie, pubmedPublications, columnNameSet }) {
+function AnnotatedPhenotypePopupCuration({ children, entities, pubmedPublications, columnNameSet }) {
   if (!entities || !entities.length) {
     return null;
   }
@@ -110,7 +110,6 @@ function AnnotatedPhenotypePopupCuration({ children, entities, mainRowCurie, pub
 AnnotatedPhenotypePopupCuration.propTypes = {
   children: PropTypes.node,
   entities: PropTypes.array,
-  mainRowCurie: PropTypes.string,
   pubmedPublications: PropTypes.array,
   columnNameSet: PropTypes.object,
 };


### PR DESCRIPTION
Follow-up to [KANBAN-1463](https://agr-jira.atlassian.net/browse/KANBAN-1463) / #1886, which removed the last caller that passed this prop. No ticket — same shape as `622ed38d` ("correct the nodeHref comment, now that no caller passes it").

`AnnotatedPhenotypePopupCuration` accepted `mainRowCurie` but never read it: the name appeared exactly twice in the file, in the destructured signature and in propTypes.

It's dead structurally, not merely unwired:

- The prop exists only to filter the main row's entity out of an **asserted-gene/allele list** (`AssertedAlleles`: *"the identifier of the main row's allele to exclude from the list"*). This popup renders no such list — it doesn't import `AssertedGenes` or `AssertedAlleles`, and its table is Name / Type / Experimental condition / Reference / Reference ID. The two sibling popups that *do* import them use the prop correctly, and are untouched here.
- The data can't support it either: `assertedGenes` and `assertedAlleles` appear **zero times** across 197 phenotype annotations sampled on a human gene page, a mouse gene page, and an allele page. Mouse rows carry `inferredGene`/`inferredAllele`, but those are singular, not the lists this prop dedupes.
- The popup's own links don't need it — `renderLink` derives each identifier from `entity.phenotypeAnnotationSubject`.

**ESLint was already reporting it.** On `stage` the file has three errors, one of them `'mainRowCurie' is defined but never used`; this removes exactly that one.

Also swept up, second commit: the pre-existing `no-var` at line 69. `expCondition` was assigned once and conditionally overwritten under an `!= null` guard, which `??` matches exactly, so it collapses to a single `const` with no behaviour change.

That takes the file from **three** ESLint errors on `stage` to **one**.

Not touched: the last one, a missing `jsx-a11y/anchor-is-valid` rule definition. That disable comment is not vestigial — line 51 is a real `<a href="#" onClick={preventDefault}>`, exactly what the rule targets. The root cause is that `jsx-a11y` is not configured in this repo at all, so the same dead disable errors in **7** files under `src`. That is a repo-wide lint-config fix, not something to bury in this diff.

Full suite green at 48 suites / 219 tests. No behaviour change: the prop was never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KANBAN-1463]: https://agr-jira.atlassian.net/browse/KANBAN-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ