### PR TITLE
fix(sitemap): add the application routes and derive portal URLs from portalData (KANBAN-1472)

### DIFF
--- a/bin/build_sitemap.js
+++ b/bin/build_sitemap.js
@@ -1,5 +1,6 @@
 import { simpleSitemapAndIndex } from 'sitemap';
 import { data as portalData, isRootPortal } from '../src/containers/diseasePortal/portalData.js';
+import { NAV_MENU } from '../src/constants.js';
 
 // derived from portalData so a new portal is indexed without anyone remembering this file
 const diseasePortalUrls = Object.entries(portalData)
@@ -10,6 +11,14 @@ const diseasePortalUrls = Object.entries(portalData)
     priority: 0.7,
     lastmodrealtime: true,
   }));
+
+// likewise from the nav, so a new MOD landing page is indexed with no second edit
+const memberUrls = (NAV_MENU.find((section) => section.label === 'Members')?.sub ?? []).map(({ route }) => ({
+  url: route,
+  changefreq: 'monthly',
+  priority: 0.7,
+  lastmodrealtime: true,
+}));
 
 simpleSitemapAndIndex({
   hostname: 'https://www.alliancegenome.org',
@@ -40,5 +49,6 @@ simpleSitemapAndIndex({
     { url: '/downloads', changefreq: 'monthly', priority: 0.7, lastmodrealtime: true },
     { url: '/news', changefreq: 'weekly', priority: 0.7, lastmodrealtime: true },
     { url: '/blastservice', changefreq: 'monthly', priority: 0.7, lastmodrealtime: true },
+    ...memberUrls,
   ],
 });

--- a/bin/build_sitemap.js
+++ b/bin/build_sitemap.js
@@ -1,5 +1,15 @@
 import { simpleSitemapAndIndex } from 'sitemap';
-import fs from 'fs';
+import { data as portalData, isRootPortal } from '../src/containers/diseasePortal/portalData.js';
+
+// derived from portalData so a new portal is indexed without anyone remembering this file
+const diseasePortalUrls = Object.entries(portalData)
+  .filter(([, portal]) => !isRootPortal(portal))
+  .map(([slug]) => ({
+    url: `/disease-portal/${slug}`,
+    changefreq: 'monthly',
+    priority: 0.7,
+    lastmodrealtime: true,
+  }));
 
 simpleSitemapAndIndex({
   hostname: 'https://www.alliancegenome.org',
@@ -23,5 +33,12 @@ simpleSitemapAndIndex({
     { url: '/textpresso', changefreq: 'monthly', priority: 0.7, lastmodrealtime: true },
     { url: '/event-calendar', changefreq: 'monthly', priority: 0.7, lastmodrealtime: true },
     { url: '/blast', changefreq: 'monthly', priority: 0.7, lastmodrealtime: true },
+    // app routes; /search is left out on purpose, and /ontology redirects so its target is listed
+    { url: '/disease-portal', changefreq: 'monthly', priority: 0.8, lastmodrealtime: true },
+    ...diseasePortalUrls,
+    { url: '/ontology/disease', changefreq: 'monthly', priority: 0.7, lastmodrealtime: true },
+    { url: '/downloads', changefreq: 'monthly', priority: 0.7, lastmodrealtime: true },
+    { url: '/news', changefreq: 'weekly', priority: 0.7, lastmodrealtime: true },
+    { url: '/blastservice', changefreq: 'monthly', priority: 0.7, lastmodrealtime: true },
   ],
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,6 @@
+// Imported by bin/build_sitemap.js under plain node, so keep this file free of JSX, TypeScript
+// and import.meta — prebuild runs before vite build, so a parse error here fails the whole
+// deploy. RECAPTCHA_SITE_KEY lives in contactPage for exactly that reason.
 export const CONTACT_API_URL = 'https://1ythblxki4.execute-api.us-east-1.amazonaws.com/prod/contact';
 export const HELP_EMAIL = 'help@alliancegenome.org';
 export const SEARCH_API_ERROR_MESSAGE = `There was a problem connecting to the server. Please refresh the page. If you continue to see this message, please contact ${HELP_EMAIL}`;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,5 @@
 export const CONTACT_API_URL = 'https://1ythblxki4.execute-api.us-east-1.amazonaws.com/prod/contact';
 export const HELP_EMAIL = 'help@alliancegenome.org';
-export const RECAPTCHA_SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
 export const SEARCH_API_ERROR_MESSAGE = `There was a problem connecting to the server. Please refresh the page. If you continue to see this message, please contact ${HELP_EMAIL}`;
 export const LARGE_COL_CLASS = 'col-md-8 col-12';
 export const SMALL_COL_CLASS = 'col-md-4 col-12';

--- a/src/containers/contactPage/index.jsx
+++ b/src/containers/contactPage/index.jsx
@@ -1,10 +1,13 @@
 import React, { useCallback, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { GoogleReCaptchaProvider, useGoogleReCaptcha } from 'react-google-recaptcha-v3';
-import { HELP_EMAIL, RECAPTCHA_SITE_KEY } from '../../constants';
+import { HELP_EMAIL } from '../../constants';
 import HeadMetaTags from '../../components/headMetaTags.jsx';
 import style from '../wordpress/style.module.scss';
 import { sendContactEmail } from '../../lib/sendContactEmail';
+
+// lives here, not in constants.js, so that module stays importable outside Vite (bin/build_sitemap.js)
+const RECAPTCHA_SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
 
 const ContactForm = () => {
   const [searchParams] = useSearchParams();

--- a/src/containers/diseasePortal/portalData.js
+++ b/src/containers/diseasePortal/portalData.js
@@ -1,3 +1,6 @@
+// Imported by bin/build_sitemap.js under plain node, so keep this file (and anything it imports)
+// free of JSX, TypeScript and import.meta — prebuild runs before vite build, so a parse error
+// here fails the whole deploy, not just sitemap generation.
 import { DISEASE_ROOT_CURIE } from '../ontologyBrowser/ontologies.js';
 
 // One entry per disease portal, keyed by the URL slug (/disease-portal/{slug}).


### PR DESCRIPTION
Fixes [KANBAN-1472](https://agr-jira.atlassian.net/browse/KANBAN-1472).

`bin/build_sitemap.js` was a hand-maintained list of 17 URLs, every one a WordPress content page. No application route had ever been added, so four shipped features were invisible to search engines — including the eight curator-authored disease portal pages, whose entire purpose is to be found.

**17 → 30 URLs.** Diffed the generator output against `stage`; 13 added, none removed:

```
/disease-portal                            /downloads
/disease-portal/alzheimers-disease         /news
/disease-portal/autism-spectrum-disorder   /ontology/disease
/disease-portal/ciliopathy                 /blastservice
/disease-portal/colorectal-cancer
/disease-portal/diabetes-mellitus
/disease-portal/epilepsy
/disease-portal/long-qt-syndrome
/disease-portal/parkinsons-disease
```

### Portal URLs are derived, not listed

They come from `portalData` via `Object.entries(...).filter(([, p]) => !isRootPortal(p))`, so the next portal is indexed the moment it is added. Hardcoding is precisely how the existing eight drifted out of the sitemap. `isRootPortal` drops the root entry, which is the `/disease-portal` index page itself and contributes no slug.

### Judgement calls

- **`/search` stays out** — search result pages are not worth indexing.
- **`/ontology` is a client-side `<Navigate replace to="/ontology/disease">`** (`routes.jsx:55`), so the target is listed rather than the redirect.
- Also drops the unused `fs` import, which ESLint was flagging on this file.

### Verified

- `npm run sitemap` runs clean; output is well-formed per `xmllint`. The import chain `build_sitemap.js → portalData.js → ontologies.js` is plain JS with no further imports, so it is safe under plain `node`.
- All four new non-portal routes render: `/ontology/disease` ("Ontology Browser"), `/blastservice` ("BLAST Service"), `/news` ("News and Events"), `/downloads` ("Downloads").
- ESLint and Prettier clean; full suite green at 49 suites / 227 tests.

### Two things found while in here, both worth knowing and neither changed

1. **The serving chain is fine.** `public/sitemap.xml` is a tracked, hand-written index pointing at `/sitemap-index.xml` and `/api/sitemap.xml`; the first two generated files are gitignored and built at `prebuild`. So these URLs do reach the served sitemap, despite `sitemap.xml` itself carrying a Nov 2025 timestamp.
2. **Entity pages are already covered, by the API.** `/api/sitemap.xml` is a 343-entry sitemap index — 245 allele, 97 gene, 1 disease. That answers the ticket's open question about whether genes/diseases/alleles belong here: they don't, they are already indexed server-side. It also scopes KANBAN-1480 usefully — reference and variant sitemaps are absent from that API index, so that work belongs in agr_java_software, not here.



---

## Second commit: member landing pages (30 → 38)

Adds the 8 MOD landing pages, derived from `NAV_MENU` rather than a second hardcoded list. This settles the `/members/:id` question that [KANBAN-1480](https://agr-jira.atlassian.net/browse/KANBAN-1480) AC 3 left to "here or in KANBAN-1472" — it needs no API work, unlike the reference and variant sitemaps that ticket also covers.

```
/members/flybase   /members/sgd        /members/zfin
/members/mgd       /members/wormbase   /members/goc
/members/rgd       /members/xenbase
```

### This required moving RECAPTCHA_SITE_KEY

`constants.js` could not be imported from a plain `node` script at all. Line 3 evaluated `import.meta.env.VITE_RECAPTCHA_SITE_KEY` at module scope, and outside Vite `import.meta.env` is `undefined`, so the import threw:

```
TypeError: Cannot read properties of undefined (reading 'VITE_RECAPTCHA_SITE_KEY')
    at src/constants.js:3:51
```

`RECAPTCHA_SITE_KEY` moves to `contactPage/index.jsx`, its only consumer, leaving `constants.js` as pure data any generator can import. The alternative — hardcoding eight URLs — would have contradicted the whole point of this PR.

**The expression itself is unchanged, only relocated**, so Vite's define-substitution behaves exactly as before. Verified rather than assumed: a full production build with `VITE_RECAPTCHA_SITE_KEY=test-key-sentinel-12345` puts that sentinel in the bundle **once**, with **no** unsubstituted `VITE_RECAPTCHA_SITE_KEY` remaining. `npm run build` succeeds end to end, prebuild generators included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KANBAN-1472]: https://agr-jira.atlassian.net/browse/KANBAN-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KANBAN-1480]: https://agr-jira.atlassian.net/browse/KANBAN-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ