### PR TITLE
fix(diseasePortal): render a zero count as 0 instead of a blank pill (KANBAN-1504)

### DIFF
--- a/src/containers/diseasePortal/DiseasePortalSection.jsx
+++ b/src/containers/diseasePortal/DiseasePortalSection.jsx
@@ -22,7 +22,7 @@ const DiseasePortalSection = ({ disease }) => {
       `${disease.pageName} Portal`;
   const diseasesEntityButton = SHOW_DISEASE_COUNT ? (
     <EntityButton id="entity-diseases" to="/search?q=&category=disease_search_result" tooltip="View all diseases">
-      <div>{diseaseCount ? diseaseCount.toLocaleString() : ''}</div>
+      <div>{diseaseCount != null && diseaseCount.toLocaleString()}</div>
       Diseases
     </EntityButton>
   ) : (
@@ -62,7 +62,7 @@ const DiseasePortalSection = ({ disease }) => {
             to={`/disease/${disease.doid}#associated-genes`}
             tooltip="View all associated genes"
           >
-            <div>{geneCount ? geneCount.toLocaleString() : ''}</div>
+            <div>{geneCount != null && geneCount.toLocaleString()}</div>
             Genes
           </EntityButton>
           <EntityButton
@@ -70,7 +70,7 @@ const DiseasePortalSection = ({ disease }) => {
             to={`/disease/${disease.doid}#associated-alleles`}
             tooltip="View all associated alleles"
           >
-            <div>{alleleCount ? alleleCount.toLocaleString() : ''}</div>
+            <div>{alleleCount != null && alleleCount.toLocaleString()}</div>
             Alleles
           </EntityButton>
           <EntityButton
@@ -78,7 +78,7 @@ const DiseasePortalSection = ({ disease }) => {
             to={`/disease/${disease.doid}#associated-models`}
             tooltip="View all associated models"
           >
-            <div>{modelCount ? modelCount.toLocaleString() : ''}</div>
+            <div>{modelCount != null && modelCount.toLocaleString()}</div>
             Models
           </EntityButton>
           {/* <EntityButton id="entity-publications" to="">

--- a/src/containers/diseasePortal/DiseasePortalSection.test.jsx
+++ b/src/containers/diseasePortal/DiseasePortalSection.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+import DiseasePortalSection from './DiseasePortalSection.jsx';
+import { useEntityButtonCounts } from './useEntityButtonCounts.js';
+
+jest.mock('./useEntityButtonCounts.js', () => ({ useEntityButtonCounts: jest.fn() }));
+
+// a non-root portal, so the Species pill stays out of the way
+const disease = { doid: 'DOID:2843', pageName: 'Long QT Syndrome' };
+
+const renderSection = () =>
+  render(
+    <MemoryRouter>
+      <DiseasePortalSection disease={disease} />
+    </MemoryRouter>
+  );
+
+const pillText = (id) => document.querySelector(`a#entity-${id}`)?.textContent;
+
+describe('DiseasePortalSection counts', () => {
+  afterEach(() => useEntityButtonCounts.mockReset());
+
+  it('renders a real zero as "0" rather than a blank number', () => {
+    useEntityButtonCounts.mockReturnValue(0);
+    renderSection();
+
+    // the regression: 0 is falsy, so a truthiness guard printed nothing here
+    expect(pillText('genes')).toBe('0Genes');
+    expect(pillText('alleles')).toBe('0Alleles');
+    expect(pillText('models')).toBe('0Models');
+  });
+
+  it('renders no number while the counts are still loading', () => {
+    useEntityButtonCounts.mockReturnValue(undefined);
+    renderSection();
+
+    expect(pillText('genes')).toBe('Genes');
+    expect(pillText('alleles')).toBe('Alleles');
+    expect(pillText('models')).toBe('Models');
+    expect(screen.queryByText('false')).not.toBeInTheDocument();
+  });
+
+  it('still thousands-separates a populated count', () => {
+    useEntityButtonCounts.mockReturnValue(4167);
+    renderSection();
+
+    expect(pillText('genes')).toBe('4,167Genes');
+  });
+});


### PR DESCRIPTION
Fixes [KANBAN-1504](https://agr-jira.atlassian.net/browse/KANBAN-1504), raised by the automated review on #1884 and deliberately left out of that PR.

The headline numbers in `DiseasePortalSection.jsx` guarded on truthiness:

```jsx
<div>{alleleCount ? alleleCount.toLocaleString() : ''}</div>
```

A genuine count of **0** is falsy, so the pill rendered its label with an empty number above it — visually identical to a count that failed to load. A user could not tell "this disease has zero alleles" from "this number is broken". `PortalListSection.jsx` already guarded the same data with `!= null` and would have said "0 alleles", so the two components disagreed.

`useEntityButtonCounts` returns `undefined` while the query is in flight, which `!= null` already covers — so the truthiness check bought nothing and only ever cost the zero case.

### All four pills, including the hidden one

Genes, Alleles and Models, plus the **Diseases** pill that KANBAN-1492 currently hides behind `SHOW_DISEASE_COUNT`. It carried the same guard and would have inherited the bug the day that flag flips back on — fixing three of four and leaving a latent one behind a feature flag is how this sort of thing survives.

### Tests

First tests for this component: zero renders `0`, `undefined` renders nothing (and no stray `false`), and a populated count still thousands-separates.

**Confirmed they actually catch the regression.** Reverted one guard to the old form and re-ran:

```
Expected: "0Genes"
Received: "Genes"
```

That matters here because no portal is anywhere near zero — the floor across all eight is 17 alleles on Long QT — so this path is unreachable from live data and a passing test proves nothing on its own.

Full suite green at 50 suites / 230 tests; ESLint and Prettier clean. No visible change on any current page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KANBAN-1504]: https://agr-jira.atlassian.net/browse/KANBAN-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ