### PR TITLE
SCRUM-6462 Pin environment-aware JBrowse links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "d3-selection": "^3.0.0",
         "events": "^3.3.0",
         "generic-sequence-panel": "^2.0.0",
-        "genomefeatures": "github:alliance-genome/genomefeatures#e33e9e24644b897781fd85469b8c7380eca9a439",
+        "genomefeatures": "github:alliance-genome/genomefeatures#9f86e78e22aab78d33e2d56413d126127f00cad1",
         "html-react-parser": "^5.2.17",
         "immutable": "^5.1.5",
         "js-yaml": "^4.1.1",
@@ -8887,8 +8887,8 @@
     },
     "node_modules/genomefeatures": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#e33e9e24644b897781fd85469b8c7380eca9a439",
-      "integrity": "sha512-U0m7VYifh0/TvjnneXQCJx3W7Xqm7OKuNluN06RayN+CwZYY3CljBziidiIpvcSUc5TqdgwUg52lzK0irvKdkA==",
+      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#9f86e78e22aab78d33e2d56413d126127f00cad1",
+      "integrity": "sha512-Pd8RpDF6T+NCqFl4lsqzP2fDcwWYjK0PasOs3ctE+uR6BhcvgpyIyP6lgVCFJS/ag/B1WRSRy+iaftt/bVzfSA==",
       "license": "MIT",
       "dependencies": {
         "@gmod/gff": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "d3-selection": "^3.0.0",
     "events": "^3.3.0",
     "generic-sequence-panel": "^2.0.0",
-    "genomefeatures": "github:alliance-genome/genomefeatures#e33e9e24644b897781fd85469b8c7380eca9a439",
+    "genomefeatures": "github:alliance-genome/genomefeatures#9f86e78e22aab78d33e2d56413d126127f00cad1",
     "html-react-parser": "^5.2.17",
     "immutable": "^5.1.5",
     "js-yaml": "^4.1.1",


### PR DESCRIPTION
## Summary
- update the genomefeatures pin to the environment-relative JBrowse fix
- regenerate the resolved commit and integrity only

## Verification
- `npm ci`
- focused genomefeatures import suite — 7 passed
- independent GPT-5.6-sol xhigh max review — Accept

AI-assisted change by OpenAI Codex.