### PR TITLE
SCRUM-6462 Pin JBrowse 2 maximum features fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "d3-selection": "^3.0.0",
         "events": "^3.3.0",
         "generic-sequence-panel": "^2.0.0",
-        "genomefeatures": "github:alliance-genome/genomefeatures#9f86e78e22aab78d33e2d56413d126127f00cad1",
+        "genomefeatures": "github:alliance-genome/genomefeatures#b4ea048a1fa9023b1ccb89f4dd372071bb6547b4",
         "html-react-parser": "^5.2.17",
         "immutable": "^5.1.5",
         "js-yaml": "^4.1.1",
@@ -8887,8 +8887,8 @@
     },
     "node_modules/genomefeatures": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#9f86e78e22aab78d33e2d56413d126127f00cad1",
-      "integrity": "sha512-Pd8RpDF6T+NCqFl4lsqzP2fDcwWYjK0PasOs3ctE+uR6BhcvgpyIyP6lgVCFJS/ag/B1WRSRy+iaftt/bVzfSA==",
+      "resolved": "git+ssh://git@github.com/alliance-genome/genomefeatures.git#b4ea048a1fa9023b1ccb89f4dd372071bb6547b4",
+      "integrity": "sha512-ZTuMh1iPqKFatEtAHHy5ZcZHsOHEltnPxUKTpqTuhfrF6rfMRR3Z1Hro5gQoeH/hw1jH9FQYGSCd82gRQsCdww==",
       "license": "MIT",
       "dependencies": {
         "@gmod/gff": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "d3-selection": "^3.0.0",
     "events": "^3.3.0",
     "generic-sequence-panel": "^2.0.0",
-    "genomefeatures": "github:alliance-genome/genomefeatures#9f86e78e22aab78d33e2d56413d126127f00cad1",
+    "genomefeatures": "github:alliance-genome/genomefeatures#b4ea048a1fa9023b1ccb89f4dd372071bb6547b4",
     "html-react-parser": "^5.2.17",
     "immutable": "^5.1.5",
     "js-yaml": "^4.1.1",


### PR DESCRIPTION
## Summary
- pin genomefeatures commit `b4ea048a1fa9023b1ccb89f4dd372071bb6547b4`
- maximum-features links now open the current JBrowse 2 assembly and tracks

## Validation
- `npm ci`
- `npm test -- --runInBand src/containers/genePage/tests/genomefeatures-import.test.js` (7 passed)
- upstream genomefeatures implementation independently reviewed by GPT-5.6-sol xhigh with max-review-skill and accepted with no material defects

Upstream: https://github.com/alliance-genome/genomefeatures/pull/9