### PR TITLE
SCRUM-6460 Fix allele viewer table filtering

### DIFF
--- a/src/hooks/tests/useAlleleSelection.test.js
+++ b/src/hooks/tests/useAlleleSelection.test.js
@@ -1,4 +1,5 @@
-import { getSelectedAlleleCategory } from '../useAlleleSelection';
+import { buildSelectedAlleleRow, getSelectedAlleleCategory, getSelectedVariantList } from '../useAlleleSelection';
+import { getIdentifier } from '../../components/dataTable/utils';
 
 describe('getSelectedAlleleCategory', () => {
   test('derives one-variant category from the fetched variant list', () => {
@@ -15,5 +16,40 @@ describe('getSelectedAlleleCategory', () => {
 
   test('falls back to the individual allele response without variants', () => {
     expect(getSelectedAlleleCategory({ alterationType: 'allele' })).toBe('allele');
+  });
+});
+
+describe('buildSelectedAlleleRow', () => {
+  test('preserves the nested allele shape used to match viewer selections to table rows', () => {
+    const response = {
+      category: 'allele_summary',
+      allele: {
+        primaryExternalId: 'MGI:2667355',
+        alleleSymbol: { displayText: 'Ahr<sup>b-2</sup>' },
+      },
+      alterationType: 'allele',
+      hasPhenotype: true,
+      hasDisease: false,
+      variantList: [{}],
+    };
+
+    const row = buildSelectedAlleleRow(response);
+
+    expect(getIdentifier(row.allele)).toBe('MGI:2667355');
+    expect(row.alterationType).toBe('allele with one variant');
+    expect(row.hasPhenotype).toBe(true);
+    expect(row.hasDisease).toBe(false);
+    expect(row.variantList).toBe(response.variantList);
+  });
+});
+
+describe('getSelectedVariantList', () => {
+  test('extracts variants from allele variant summary rows', () => {
+    const variants = [{ curatedVariantGenomicLocations: [{ hgvs: 'NC_000078.7:g.35550690A>G' }] }];
+    const response = {
+      results: [{ category: 'variant_summary', variantList: variants }],
+    };
+
+    expect(getSelectedVariantList(response)).toEqual(variants);
   });
 });

--- a/src/hooks/useAlleleSelection.js
+++ b/src/hooks/useAlleleSelection.js
@@ -14,6 +14,19 @@ export function getSelectedAlleleCategory(response) {
   return response.alterationType || response.category || 'allele';
 }
 
+export function buildSelectedAlleleRow(response) {
+  if (!response?.allele) return null;
+
+  return {
+    ...response,
+    alterationType: getSelectedAlleleCategory(response),
+  };
+}
+
+export function getSelectedVariantList(response) {
+  return response?.results?.flatMap((row) => row.variantList || []) || [];
+}
+
 export default function useAlleleSelection(tableProps) {
   const [alleleIdsSelected, setAlleleIdsSelected] = useState([]);
   const [selectionOverride, setSelectionOverride] = useState({
@@ -71,7 +84,7 @@ export default function useAlleleSelection(tableProps) {
             if (alleleData && variantsData) {
               return {
                 ...alleleData,
-                variantList: variantsData.results || [],
+                variantList: getSelectedVariantList(variantsData),
               };
             }
             return alleleData;
@@ -85,46 +98,17 @@ export default function useAlleleSelection(tableProps) {
             return;
           }
 
-          // Extract the nested allele object from the API response
-          // API returns: { category: "allele_summary", allele: {...}, alterationType: "...", variants: [...] }
-          // We need to map the individual allele API response to match the gene alleles list format
-          const validAlleles = alleles
-            .filter((a) => a !== null && a.allele)
-            .map((response) => {
-              const allele = response.allele;
-              return {
-                ...allele,
-                id: allele.primaryExternalId, // Map primaryExternalId to id
-                symbol: allele.alleleSymbol?.displayText || allele.alleleSymbol?.formatText,
-                synonyms: allele.alleleSynonyms?.map((s) => s.displayText || s.formatText) || [],
-                category: getSelectedAlleleCategory(response),
-                // Map crossReference structure to crossReferenceMap for table compatibility
-                crossReferenceMap: {
-                  primary: {
-                    url:
-                      response.crossReference?.resourceDescriptorPage?.urlTemplate?.replace(
-                        '[%s]',
-                        allele.primaryExternalId?.split(':')[1] || ''
-                      ) ||
-                      allele.dataProviderCrossReference?.resourceDescriptorPage?.urlTemplate?.replace(
-                        '[%s]',
-                        allele.primaryExternalId?.split(':')[1] || ''
-                      ),
-                  },
-                },
-                // Include variants fetched from /api/allele/{id}/variants endpoint
-                variantList: response.variantList || [],
-                diseases: [],
-              };
-            });
+          const validAlleles = alleles.map(buildSelectedAlleleRow).filter(Boolean);
 
           // Deduplicate alleles based on ID to prevent duplicates
           const uniqueAlleles = [];
           const seenIds = new Set();
 
           for (const allele of validAlleles) {
-            if (allele && allele.id && !seenIds.has(allele.id)) {
-              seenIds.add(allele.id);
+            const alleleId = allele.allele.primaryExternalId;
+
+            if (alleleId && !seenIds.has(alleleId)) {
+              seenIds.add(alleleId);
 
               uniqueAlleles.push(allele);
             }

--- a/src/hooks/useAlleleSelection.js
+++ b/src/hooks/useAlleleSelection.js
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import fetchData from '../lib/fetchData';
 import { ALLELE_WITH_MULTIPLE_VARIANTS, ALLELE_WITH_ONE_VARIANT } from '../constants';
+import { getIdentifier } from '../components/dataTable/utils';
 
 /**
  * Custom hook for managing allele selection state and fetching selected allele data
@@ -105,7 +106,7 @@ export default function useAlleleSelection(tableProps) {
           const seenIds = new Set();
 
           for (const allele of validAlleles) {
-            const alleleId = allele.allele.primaryExternalId;
+            const alleleId = getIdentifier(allele.allele);
 
             if (alleleId && !seenIds.has(alleleId)) {
               seenIds.add(alleleId);


### PR DESCRIPTION
## Summary

- preserve the nested allele API response used by the gene table so viewer-selected allele IDs continue to match table row IDs
- unwrap variant objects from the allele variant-summary response so selected rows retain HGVS, variant type, consequence, and JBrowse location data
- add focused regression coverage for both API-to-table shape contracts

## Validation

- `npm test -- --runInBand` (50 suites, 232 tests passed)
- `npm run build`
- targeted ESLint and Prettier checks for both changed files
- Chrome smoke test against stage data for `MGI:105043`: selecting the `Ahrb-2` glyph produced one table row with `NC_000078.7:g.35550690A>G`, `point mutation`, `stop lost`, and a valid JBrowse highlight
- independent GPT-5.6 Sol high review: accepted with no findings after the final browser-tested revision

Jira: https://agr-jira.atlassian.net/browse/SCRUM-6460
