### PR TITLE
SCRUM-6349 Add literature category to public site search

### DIFF
--- a/src/_theme.module.scss
+++ b/src/_theme.module.scss
@@ -39,6 +39,7 @@ $data-type-go: $tertiary-700;
 $data-type-model: #bcbd22;
 $data-type-allele: #8c564b;
 $data-type-dataset: #f7b6d2;
+$data-type-literature: #ff7f0e;
 /*
 Category colors (from SGD) that aren't used yet
 .reference{background:#ff7f0e}

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ export const ALLELE_CATEGORY = 'allele_search_result';
 export const VARIANT_CATEGORY = 'variant_search_result';
 export const MODEL_CATEGORY = 'model_search_result';
 export const DATASET_CATEGORY = 'htp_dataset_search_result';
+export const LITERATURE_CATEGORY = 'literature_search_result';
 
 /* Wordpress REST API connection setting  */
 export const WORDPRESS_REST_API_BASE = 'https://public-api.wordpress.com/wp/v2/sites/alliancegenome.wordpress.com';
@@ -79,6 +80,11 @@ export const CATEGORIES = [
       'crossReferences',
       'molecularConsequence',
     ],
+  },
+  {
+    name: LITERATURE_CATEGORY,
+    displayName: 'Literature',
+    displayFields: ['shortCitation', 'authors', 'publicationYear', 'abstractText', 'crossReferences'],
   },
 ];
 

--- a/src/containers/search/detailList.jsx
+++ b/src/containers/search/detailList.jsx
@@ -9,6 +9,7 @@ import { CollapsibleList } from '../../components/collapsibleList';
 import SpeciesName from '../../components/SpeciesName.jsx';
 
 const COLLAPSIBLE_FIELDS = ['collapsible_synonyms', 'variants'];
+const COLLAPSIBLE_BOX_FIELDS = ['summary', 'abstractText'];
 
 const JOIN_CHAR = ', ';
 
@@ -39,7 +40,10 @@ const DetailList = ({ data, fields }) => {
       }
     }
 
-    if (field.toLocaleString() === 'summary') {
+    if (COLLAPSIBLE_BOX_FIELDS.includes(field)) {
+      if (!value) {
+        return null;
+      }
       return (
         <div key={`sumField.${field}`}>
           <CollapsibleBox>

--- a/src/containers/search/style.module.scss
+++ b/src/containers/search/style.module.scss
@@ -150,6 +150,9 @@ a > span > .sprite {
   &.variant_search_result::before {
     color: $data-type-allele;
   }
+  &.literature_search_result::before {
+    color: $data-type-literature;
+  }
 }
 
 .resultSpeciesIcon {

--- a/src/lib/searchHelpers.jsx
+++ b/src/lib/searchHelpers.jsx
@@ -10,6 +10,7 @@ import {
   DISEASE_CATEGORY,
   GENE_CATEGORY,
   GO_CATEGORY,
+  LITERATURE_CATEGORY,
   VARIANT_CATEGORY,
 } from '../constants';
 
@@ -138,6 +139,10 @@ export function makeFieldDisplayName(unformattedName, category = '') {
       return 'Variant Type';
     case 'variantName':
       return 'Variant Name';
+    case 'authors':
+      return 'Author';
+    case 'abstractText':
+      return 'Abstract';
     case 'alterationType':
       // Non-breaking space prevents key collision with the 'category' field
       // in flattenWithPrettyFieldNames when both are present in highlights
@@ -212,6 +217,8 @@ export const getURLForEntry = (category, id, alterationType) => {
       return `/allele/${id}`;
     case VARIANT_CATEGORY:
       return `/variant/${id}`;
+    case LITERATURE_CATEGORY:
+      return `/reference/${id}`;
     default:
       return '';
   }

--- a/src/reducers/searchParsers.js
+++ b/src/reducers/searchParsers.js
@@ -7,6 +7,7 @@ import {
   DUPLICATE_HIGHLIGHTED_FIELDS,
   GENE_CATEGORY,
   GO_CATEGORY,
+  LITERATURE_CATEGORY,
   NON_HIGHLIGHTED_FIELDS,
   VARIANT_CATEGORY,
 } from '../constants';
@@ -96,6 +97,8 @@ export function parseResults(results) {
         return parseHomologyGroupResult(d);
       case VARIANT_CATEGORY:
         return parseVariantSearchResult(d);
+      case LITERATURE_CATEGORY:
+        return parseLiteratureResult(d);
       default:
         return parseDefaultResult(d);
     }
@@ -271,6 +274,13 @@ function parseVariantSearchResult(_d) {
     missing: d.missingTerms,
     ...(d.crossReferences != null && { crossReferences: d.crossReferences }),
   };
+}
+
+function parseLiteratureResult(_d) {
+  const d = parseDefaultResult(_d);
+  delete d.highlight[makeFieldDisplayName('name')];
+  delete d.highlight[makeFieldDisplayName('nameKey')];
+  return d;
 }
 
 function parseDefaultResult(_d) {


### PR DESCRIPTION
Jira: https://agr-jira.atlassian.net/browse/SCRUM-6349

Frontend side of the new literature/reference search. Depends on the agr_java_software SCRUM-6394 PR being deployed — without it the API returns no literature-specific fields and no abstract highlight.

## Changes

- **`constants.js`** — `LITERATURE_CATEGORY` plus a `CATEGORIES` entry (`displayName: 'Literature'`, `displayFields: ['shortCitation', 'authors', 'publicationYear', 'abstractText', 'crossReferences']`), appended last so existing category icon order is undisturbed. This one entry drives the header search dropdown, the category facet label, breadcrumbs, and the result-card badge.
- **`searchHelpers.jsx`** — `authors` → "Author" and `abstractText` → "Abstract" labels, and a `LITERATURE_CATEGORY` case in `getURLForEntry` returning `/reference/${id}`. Previously literature titles fell through to `<ExternalLink href={null}>`, i.e. an external-styled link that did nothing.
- **`detailList.jsx`** — `COLLAPSIBLE_BOX_FIELDS = ['summary', 'abstractText']` replaces the hardcoded `=== 'summary'` check, so the abstract renders in the existing `CollapsibleBox` (CSS clamp, never slices the string, so `<em>` markup can't be cut). Added a `!value` guard to that branch, which also stops a dataset with no summary rendering a dangling "Summary:" label.
- **`searchParsers.js`** — new `parseLiteratureResult` in the existing per-category switch, dropping the `name` and `nameKey` highlight entries. `LiteratureConverter` writes the same title into both fields, so a title match rendered the title three times (heading + " Name:" + "Symbol:"). Deleting after `parseDefaultResult` keeps the heading's own highlighting.
- **theme + search SCSS** — category badge colour, reusing the `#ff7f0e` already reserved for `.reference` in the theme's unused-colours block.

The facet sidebar needed no changes: it renders whatever aggregations the API returns and titles them through `makeFieldDisplayName`, so `authors` / `publicationYear` and their filter, exclude and URL-param handling work generically.

## Verification

- Verified by rendering literature hits, not just reading code: abstract renders once and highlighted, no duplicate title line, no "Not Available" rows, title links to `/reference/AGRKB:...`.
- Control check in the same run: a disease hit with identical `name`/`nameKey` highlights keeps today's behaviour, confirming the parser change is literature-only.
- eslint at parity with `stage` (no new problems), prettier clean, `jest src/containers/search src/tests` 7/7.

## Known follow-ups, deliberately not in scope

- Highlight-block labels render with a leading space (" Citation:") because `makeFieldDisplayName` runs twice over already-prettified keys. Pre-existing and generic to every category.
- The reference detail page's `PageCategoryLabel category="reference"` doesn't match the new category name, so its badge is unstyled. Pre-existing.

## Related

- SCRUM-6394 — API side (`agr_java_software`)
- SCRUM-6031 — created the `literature_search_result` document