### PR TITLE
SCRUM-6498 Fix scoring details pop-up on "debug" public site search

### DIFF
--- a/src/containers/search/explainNode.jsx
+++ b/src/containers/search/explainNode.jsx
@@ -14,11 +14,13 @@ const ExplainNode = ({ explanation }) => {
         <strong>{explanation.value}</strong>: {explanation.match || ''}
         {explanation.description}
       </li>
-      <li>
-        {explanation.details.map((detail, i) => (
-          <ExplainNode explanation={detail} key={i} />
-        ))}
-      </li>
+      {explanation.details && (
+        <li>
+          {explanation.details.map((detail, i) => (
+            <ExplainNode explanation={detail} key={i} />
+          ))}
+        </li>
+      )}
     </ul>
   );
 };


### PR DESCRIPTION
Jira: https://agr-jira.atlassian.net/browse/SCRUM-6498

## Cause

Searching the public site with a query that starts with `debug` puts the API into debug mode, which adds `score` and `explanation` to every hit. `explanation` is the raw Lucene explain tree — every node is `{match, value, description, details[]}`, but `details` is **absent** on leaf nodes rather than an empty array (a leaf is literally `{"match": true, "value": 11.0, "description": "boost"}`).

`ExplainNode` mapped `explanation.details` unconditionally, so the recursion threw at the first leaf:

```
explainNode.jsx:18 Uncaught TypeError: Cannot read properties of undefined (reading 'map')
    at ExplainNode (explainNode.jsx:18:30)
```

Because that throw happens during render with nothing catching it, the whole page went blank instead of just the panel failing.

## Fix

Guard the recursive `<li>` on the presence of `details`. Guarding the entire list item, rather than defaulting to `(explanation.details || [])`, avoids emitting an empty `<li>` — and a stray bullet — for every leaf; the tree for a single hit is 239 nodes, most of them leaves.

No other component needed changing: `ResultExplanation` already toggles the panel in place (`resultExplanation.jsx:43`) so it renders in-line as the ticket requires, and `resultsList.jsx:107` already gates on `d.explanation`. The payload itself was never the problem — `explanation` and `score` arrive intact through the dev proxy.

## Verification

Rendered against a real debug hit captured from the running API (`q=debugRPB7`), not a hand-built fixture:

- **Before the fix** (stashed to confirm): rendering the real tree reproduces the exact reported error, `TypeError: Cannot read properties of undefined (reading 'map')`.
- **After**: all 239 nodes render across 8 levels of depth, leaf content included, and clicking the button takes the panel from 0 rendered nodes to 239 in-line inside the result.
- eslint clean on the changed file, prettier clean, `jest src/containers/search src/tests` 7/7 pass.