### PR TITLE
SCRUM-6349 Fix category badge colors for literature, variant and model

### DIFF
--- a/src/_theme.module.scss
+++ b/src/_theme.module.scss
@@ -39,14 +39,13 @@ $data-type-go: $tertiary-700;
 $data-type-model: #bcbd22;
 $data-type-allele: #8c564b;
 $data-type-dataset: #f7b6d2;
-$data-type-literature: #ff7f0e;
+$data-type-variant: #17becf;
+$data-type-literature: #2ca02c;
 /*
 Category colors (from SGD) that aren't used yet
 .reference{background:#ff7f0e}
-.biological_process{background:#2ca02c}
 .molecular_function{background:#8c564b}
 .phenotype{background:#e377c2}
-.resource{background:#17becf}
 .contig{background:#7f7f7f}
 .download{background:#d62728}
 .colleague{background:#ffbb78}

--- a/src/containers/search/style.module.scss
+++ b/src/containers/search/style.module.scss
@@ -138,7 +138,7 @@ a > span > .sprite {
   &.disease_search_result::before {
     color: $data-type-disease;
   }
-  &.model::before {
+  &.model_search_result::before {
     color: $data-type-model;
   }
   &.allele_search_result::before {
@@ -148,7 +148,7 @@ a > span > .sprite {
     color: $data-type-dataset;
   }
   &.variant_search_result::before {
-    color: $data-type-allele;
+    color: $data-type-variant;
   }
   &.literature_search_result::before {
     color: $data-type-literature;


### PR DESCRIPTION
Jira: https://agr-jira.atlassian.net/browse/SCRUM-6349

Follow-up to the literature search work on the same ticket. The literature badge colour introduced there was too close to disease, and reviewing the palette turned up two adjacent bugs in the same block.

## Changes

| Category | Before | After |
|---|---|---|
| literature | `#ff7f0e` orange | `#2ca02c` green |
| variant | `$data-type-allele` — identical to allele | `$data-type-variant: #17becf` teal |
| model | `&.model::before` — a class no category uses, so it never applied | `&.model_search_result::before` |

### Why green for literature

`#ff7f0e` came from the SGD palette, where it's the *reference* colour, but it lands at hue 28 — **2 degrees** from the disease accent `#d95f02` at hue 26, and 18 from the allele/variant brown at hue 10. Three of seven badge colours were inside an 18-degree wedge of orange-brown, and at ⬢ glyph size literature and disease were indistinguishable. Measured perceptual distance (ΔE76) between them was **14.4**.

Green is the one hue family absent from the set: 60 degrees from its nearest neighbour either way, ΔE **45.8** from the model olive that now actually renders, and lightness 40 keeps it legible on white.

### Why teal for variant

Allele and variant both pointed at `$data-type-allele`, i.e. ΔE **0.0** — the same badge for two categories. Candidates scored by minimum ΔE against every other badge colour:

| Candidate | Min ΔE | Closest to |
|---|---|---|
| light orange `#ffbb78` | 42.6 | disease |
| **teal `#17becf`** | **35.9** | gene |
| light blue `#aec7e8` | 32.3 | dataset |
| red `#d62728` | 29.5 | disease |

Light orange scored highest but was rejected: it reintroduces orange right after we removed it for crowding, and at lightness 73 it is weak on white. Teal's hue sits near gene's, but it is much lighter and more saturated, so it separates cleanly.

### Model

`MODEL_CATEGORY` is `model_search_result` and nothing in the codebase passes a bare `model`, so `$data-type-model` was dead and model badges rendered with no colour at all. Renaming the selector activates the existing olive.

Also dropped `.biological_process` and `.resource` from the "colors from SGD that aren't used yet" comment, since both are now in use; `#ff7f0e` goes back to being genuinely unused.

## Verification

- `npm run build` (`tsc -b && vite build`) passes, confirming `$data-type-variant` resolves through the real sass pipeline.
- prettier clean on both files; `jest src/containers/search src/tests` 7/7.