### PR TITLE
fix: rename public site search category display name from "Literature" to "Reference"

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -83,7 +83,7 @@ export const CATEGORIES = [
   },
   {
     name: LITERATURE_CATEGORY,
-    displayName: 'Literature',
+    displayName: 'Reference',
     displayFields: ['shortCitation', 'authors', 'publicationYear', 'abstractText', 'crossReferences'],
   },
 ];


### PR DESCRIPTION
Renames the `literature_search_result` search category display name from "Literature" to "Reference".

The single `displayName` in `CATEGORIES` drives every user-visible spot for the category, since they all render through `CategoryLabel`:

- search facet list
- search bar category dropdown
- search breadcrumbs
- result rows
- multi-table headings ("N Reference Results" / "Show All Reference Results")

Left unchanged: `LITERATURE_CATEGORY = 'literature_search_result'`, the `.literature_search_result` SCSS class and the `$data-type-literature` color token — internal identifiers tied to the ES `category` value, not display text.

Tests: `npx jest` — 51 suites, 236 tests, all passing.